### PR TITLE
Add website privacy policy

### DIFF
--- a/SeattleCarsInBikeLanes.Tests/PrivacyControllerTests.cs
+++ b/SeattleCarsInBikeLanes.Tests/PrivacyControllerTests.cs
@@ -1,0 +1,20 @@
+using Microsoft.AspNetCore.Mvc;
+using SeattleCarsInBikeLanes.Controllers;
+
+namespace SeattleCarsInBikeLanes.Tests
+{
+    public class PrivacyControllerTests
+    {
+        [Fact]
+        public void Get_ReturnsPrivacyPage()
+        {
+            PrivacyController controller = new PrivacyController();
+
+            VirtualFileResult result = Assert.IsType<VirtualFileResult>(controller.Get());
+
+            Assert.Equal("privacy.html", result.FileName);
+            Assert.Equal("text/html", result.ContentType);
+        }
+
+    }
+}

--- a/SeattleCarsInBikeLanes/Controllers/PrivacyController.cs
+++ b/SeattleCarsInBikeLanes/Controllers/PrivacyController.cs
@@ -1,0 +1,14 @@
+using Microsoft.AspNetCore.Mvc;
+
+namespace SeattleCarsInBikeLanes.Controllers
+{
+    [ApiController]
+    public class PrivacyController : ControllerBase
+    {
+        [HttpGet("/privacy")]
+        public IActionResult Get()
+        {
+            return File("privacy.html", "text/html");
+        }
+    }
+}

--- a/SeattleCarsInBikeLanes/wwwroot/index.html
+++ b/SeattleCarsInBikeLanes/wwwroot/index.html
@@ -47,6 +47,7 @@
                 <a class="nav-link dropdown-toggle" role="button" data-bs-toggle="dropdown" aria-expanded="false">Resources</a>
                 <ul class="dropdown-menu">
                   <li><a class="dropdown-item" href="https://www.seattle.gov/transportation/projects-and-programs/programs/bike-program/bike-web-map" target="_blank">Official Seattle Bike Web Map</a></li>
+                  <li><a class="dropdown-item" href="/privacy">Privacy Policy</a></li>
                 </ul>
               </li>
               <li class="nav-item dropdown">

--- a/SeattleCarsInBikeLanes/wwwroot/privacy.html
+++ b/SeattleCarsInBikeLanes/wwwroot/privacy.html
@@ -1,0 +1,230 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="Privacy policy for the Cars in Bike Lanes website and mobile apps.">
+  <link rel="canonical" href="https://carinbikelane.com/privacy">
+  <link rel="icon" href="/favicon.png" type="image/png">
+  <title>Privacy Policy | Cars in Bike Lanes</title>
+  <style>
+    body {
+      font-family: sans-serif;
+    }
+
+    .container {
+      max-width: 52rem;
+      margin: 0 auto;
+      padding: 1rem;
+    }
+  </style>
+</head>
+<body>
+  <main class="container">
+    <p><a href="/">Back to Cars in Bike Lanes</a></p>
+    <h1>Privacy Policy</h1>
+    <p><strong>Last updated:</strong> August 23, 2026</p>
+
+    <p>
+      This Privacy Policy explains how Cars in Bike Lanes ("we," "us," or "our") handles
+      information when you use our websites, including carinbikelane.com and
+      seattle.carinbikelane.com, or our iOS and Android mobile applications (together, the
+      "Services").
+    </p>
+
+    <p>
+      <strong>In brief:</strong> We use information to accept, moderate, publish, and attribute
+      reports of vehicles in bike lanes, keep the Services reliable and secure, and support the
+      features you choose to use. Submitted photos, locations, dates, and attribution may be made
+      public. We do not sell personal information or use it for targeted advertising.
+    </p>
+
+    <h2>Information we handle</h2>
+    <p>Depending on how you use the Services, we may handle the following information:</p>
+    <ul>
+      <li>
+        <strong>Reports and photos.</strong> Photos you choose to submit, the number of vehicles,
+        a date and time, a location or cross street, and related report details. Photos may contain
+        metadata such as capture date, time, device orientation, and precise GPS coordinates.
+      </li>
+      <li>
+        <strong>Social account information.</strong> If you sign in and request attribution through
+        a supported social service, we may handle your handle, username, decentralized identifier,
+        server address, session information, and access token. We use this information to verify
+        your identity, attribute a report, or publish as requested. We do not ask for or receive
+        your social account password. Cars in Bike Lanes does not create a user account for you;
+        Bluesky and Mastodon sign-in are optional and are used only to attribute reports you choose
+        to submit.
+      </li>
+      <li>
+        <strong>Website and service activity.</strong> Our servers and reliability tools may
+        receive an IP address, browser or app type, operating system, request URL, response status,
+        timestamps, referring page, cookie or session identifiers, and similar request and
+        diagnostic information.
+      </li>
+      <li>
+        <strong>Mobile app information.</strong> The apps create a random installation identifier
+        for abuse prevention and duplicate-upload protection. Depending on the device, this
+        identifier may survive an app reinstall. Sentry automatically receives mobile reliability
+        data that may include app version, device and operating-system information, errors, crash
+        details, performance measurements, and feature outcomes such as whether a permission request
+        was accepted or denied.
+      </li>
+      <li>
+        <strong>Game information.</strong> If you use the website's game, we process the display
+        name you enter, game state, answers, and scores while providing the game.
+      </li>
+    </ul>
+
+    <h2>Mobile permissions and information stored on your device</h2>
+    <p>The mobile apps may request access to the following device features:</p>
+    <ul>
+      <li><strong>Camera</strong> to take a photo for a report.</li>
+      <li>
+        <strong>Photos</strong> to save captured photos or let you choose existing photos. On
+        Android, individual imports use the system photo picker rather than broad library access.
+      </li>
+      <li>
+        <strong>Location while using the app</strong> to record where a photo was taken or help you
+        choose the report location. The apps do not request background location access.
+      </li>
+    </ul>
+    <p>
+      Granting a permission does not by itself submit a photo or report. Captured and imported
+      photos may remain in your photo library or private app storage. Drafts and queued uploads are
+      stored on the device so a report can finish after a temporary connection failure. Social
+      credentials and the random installation identifier are stored using operating-system secure
+      storage when available. You can revoke camera, photo-library, or location access in your
+      device settings. Revoking a permission stops the app's future access to that device resource
+      but does not delete information you already submitted.
+    </p>
+
+    <h2>How we use information</h2>
+    <p>We use information to:</p>
+    <ul>
+      <li>receive, validate, queue, moderate, and publish reports;</li>
+      <li>read photo metadata and determine or confirm a report's date and location;</li>
+      <li>analyze images for relevant objects and unsafe content;</li>
+      <li>display reports on maps and publish or embed posts on supported social services;</li>
+      <li>authenticate users and provide optional public attribution;</li>
+      <li>operate the website game and other requested features;</li>
+      <li>diagnose errors, measure performance, prevent duplicate reports, and improve reliability;</li>
+      <li>detect, investigate, and prevent abuse, fraud, or security incidents; and</li>
+      <li>respond to requests and comply with legal obligations.</li>
+    </ul>
+
+    <h2>Public reports and sharing</h2>
+    <p>
+      Reports accepted for publication may publicly display the submitted photo, location or cross
+      street, date and time, number of vehicles, and social attribution you selected. We may also
+      publish reports through social networks, feeds, or image-hosting services. Public information
+      can be copied, indexed, reposted, or retained by other people and services outside our
+      control. Removing a report from our Services may not remove copies held elsewhere.
+    </p>
+
+    <p>We may otherwise disclose information:</p>
+    <ul>
+      <li>
+        <strong>To service providers.</strong> We use providers to host and operate the Services,
+        store data, provide maps and geocoding, analyze and moderate images, monitor reliability,
+        send internal report notifications, and publish content. We use providers whose applicable
+        agreements, terms, and privacy commitments require them to protect user data consistently
+        with this policy, applicable platform rules, and law.
+      </li>
+      <li>
+        <strong>When you connect another service.</strong> Bluesky, Mastodon, and other social or
+        mapping services receive information necessary for the sign-in, attribution, map, embed, or
+        publishing feature you request. Their own privacy policies govern their handling.
+      </li>
+    </ul>
+
+    <h2>Service providers and integrations</h2>
+    <p>
+      Sentry is the only third-party SDK embedded in the mobile app specifically to collect
+      automatic crash, performance, and diagnostic telemetry. Other providers receive or process
+      information only for narrower service functions or user-directed transfers. These providers
+      include Microsoft Azure for hosting, storage, databases, maps, image analysis, content safety,
+      and Application Insights diagnostics; Google Maps on Android and Apple mapping services on
+      Apple devices; Bluesky and Mastodon for optional sign-in and attribution; and social
+      publishing, embedding, notification, content-delivery, or image-hosting services such as
+      Threads, Slack, jsDelivr, and Imgur. Which providers receive information depends on the
+      features you use and how a report is published.
+    </p>
+
+    <h2>Cookies and local storage</h2>
+    <p>
+      The website uses cookies required for sign-in and security. It also uses browser local storage
+      to keep certain social sign-in details, such as a Mastodon server address and access token, on
+      your device. The mobile apps use cookies, app storage, and secure storage for the same
+      functional purposes. These technologies are not used by us for targeted advertising. You can
+      sign out to remove the social access tokens and attribution details held in the native app's
+      secure storage, clear its supported sign-in sessions, and stop future report attribution.
+      Signing out does not remove attribution from reports that were already published. Browser or
+      device controls may let you clear other stored data. Blocking necessary storage may prevent
+      sign-in or queued uploads from working.
+    </p>
+
+    <h2>Retention</h2>
+    <p>
+      We retain completed photo submissions and their associated report metadata indefinitely unless
+      the app owner deletes them. Incomplete uploads are removed when they are no longer needed for
+      submission processing, and queued content remains on a device while needed to send a report.
+      We do not retain any information after deleting a report.
+    </p>
+
+    <h2>Your choices and privacy rights</h2>
+    <ul>
+      <li>You may submit a report anonymously or choose supported social attribution.</li>
+      <li>You may decline or later change camera, photo, and location permissions.</li>
+      <li>
+        You may sign out to remove the native app's stored social credentials and stop future
+        attribution, and you may clear other browser or app data using available device controls.
+      </li>
+      <li>
+        You may ask to access, correct, or delete personal information, or object to or restrict
+        certain processing, where applicable law provides those rights.
+      </li>
+    </ul>
+    <p>
+      You may request deletion of a photo published with your social attribution by emailing
+      <a href="mailto:seattlecarsinbikelanes@outlook.com">seattlecarsinbikelanes@outlook.com</a>.
+      Include enough information to identify the report. We will ask you to verify control of the
+      social identity shown in the attribution. Once accepted, we will remove the photo
+      and associated report metadata from storage and public social media we control and remove it
+      from publishing destinations we control. We cannot verify
+      ownership of an anonymous submission (it's anonymous!). Copies independently indexed, cached,
+      saved, or reposted by other people or services may remain outside our control.
+    </p>
+    <p>
+      You may also use the same email address to ask to access or correct personal information, or
+      to object to or restrict certain processing, where applicable law provides those rights. Some
+      information may be retained or requests may be limited where permitted by law, including for
+      security, legal compliance, or information that is not reasonably identifiable as yours. You
+      may also have the right to appeal our response or contact your local privacy regulator.
+    </p>
+
+    <h2>Security and international processing</h2>
+    <p>
+      We use administrative and technical safeguards intended to protect information, including
+      encrypted connections and operating-system secure storage where available. No storage or
+      transmission method is completely secure. Our providers and connected services may process
+      information in the United States and other countries where privacy laws may differ from those
+      where you live.
+    </p>
+
+    <h2>Changes to this policy</h2>
+    <p>
+      We may update this policy as the Services or our practices change. We will post the updated
+      policy at this URL and change the "Last updated" date. If a change is material, we may provide
+      additional notice through the Services when appropriate.
+    </p>
+
+    <h2>Contact us</h2>
+    <p>
+      Cars in Bike Lanes<br>
+      Email:
+      <a href="mailto:seattlecarsinbikelanes@outlook.com">seattlecarsinbikelanes@outlook.com</a>
+    </p>
+  </main>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- publish a privacy policy at `/privacy`
- link it from the website Resources menu
- add a focused route test

## Validation
- `dotnet test SeattleCarsInBikeLanes.Tests/SeattleCarsInBikeLanes.Tests.csproj --filter FullyQualifiedName~PrivacyControllerTests --verbosity minimal`