### PR TITLE
Require login when switching social accounts

### DIFF
--- a/SeattleCarsInBikeLanes/Controllers/BlueskyAuthController.cs
+++ b/SeattleCarsInBikeLanes/Controllers/BlueskyAuthController.cs
@@ -112,6 +112,9 @@ namespace SeattleCarsInBikeLanes.Controllers
                     oAuthClient: oAuthClient,
                     handle: parsedHandle,
                     returnUri: new Uri(options.RedirectUri),
+                    // Prevent the authorization server from silently reusing the account session
+                    // for this handle after the user has signed out of our site.
+                    uriExtraParameters: new[] { KeyValuePair.Create("prompt", "login") },
                     cancellationToken: cancellationToken);
 
                 if (oAuthClient.State is null)

--- a/SeattleCarsInBikeLanes/Controllers/MastodonController.cs
+++ b/SeattleCarsInBikeLanes/Controllers/MastodonController.cs
@@ -3,6 +3,7 @@ using golf1052.Mastodon.Models.Accounts;
 using golf1052.Mastodon.Models.Apps.OAuth;
 using golf1052.Mastodon.Models.OEmbed;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.WebUtilities;
 using SeattleCarsInBikeLanes.Providers;
 
 namespace SeattleCarsInBikeLanes.Controllers
@@ -72,7 +73,10 @@ namespace SeattleCarsInBikeLanes.Controllers
             MastodonClient mastodonClient = await mastodonClientProvider.GetClient(endpointUri);
             return new MastodonOAuthUrlResponse()
             {
-                AuthUrl = mastodonClient.AuthorizeUser(RedirectUrl, Scopes)
+                AuthUrl = QueryHelpers.AddQueryString(
+                    mastodonClient.AuthorizeUser(RedirectUrl, Scopes),
+                    "force_login",
+                    "true")
             };
         }
 


### PR DESCRIPTION
## Summary
- force Mastodon to show its login/account selection screen during OAuth
- force Bluesky to re-authenticate the requested handle instead of silently reusing its existing session

## Testing
- `dotnet test SeattleCarsInBikeLanes.Tests/SeattleCarsInBikeLanes.Tests.csproj`