### PR TITLE
Add mobile authentication web bridge

### DIFF
--- a/SeattleCarsInBikeLanes/wwwroot/index.html
+++ b/SeattleCarsInBikeLanes/wwwroot/index.html
@@ -383,6 +383,7 @@
     <script src="js/bluesky-auth.js"></script>
     <script src="js/bikelanes.js"></script>
     <script src="js/index.js"></script>
+    <script src="js/mobile-auth.js"></script>
     <script type="module" src="js/csvexport.js"></script>
 </body>
 </html>

--- a/SeattleCarsInBikeLanes/wwwroot/js/bluesky-auth.js
+++ b/SeattleCarsInBikeLanes/wwwroot/js/bluesky-auth.js
@@ -106,11 +106,16 @@ function loginWithBluesky() {
     });
 }
 
-function clearBlueskyAuth() {
-    fetch('/api/BlueskyAuth/logout', { method: 'POST' })
+function clearBlueskyAuth(notifyNative = true) {
+    return fetch('/api/BlueskyAuth/logout', { method: 'POST' })
     .catch(() => { /* Signing out locally is what matters. */ })
     .then(() => {
         setBlueskyLoggedOut();
+        if (notifyNative) {
+            window.dispatchEvent(new CustomEvent('carsInBikeLanesAuthChanged', {
+                detail: { provider: 'bluesky', signedIn: false }
+            }));
+        }
     });
 }
 

--- a/SeattleCarsInBikeLanes/wwwroot/js/index.js
+++ b/SeattleCarsInBikeLanes/wwwroot/js/index.js
@@ -98,13 +98,18 @@ function setMastodonButtonAsLoggedOut() {
     mastodonButton.innerText = 'Sign in with Mastodon';
 }
 
-function clearMastodonAuth() {
+function clearMastodonAuth(notifyNative = true) {
     localStorage.removeItem('mastodonEndpoint');
     localStorage.removeItem('mastodonAccessToken');
     loggedInMastodonFullUsername = null;
     loggedInMastodonUsername = null;
     setMastodonButtonAsLoggedOut();
     document.getElementById('mastodonLogoutButton').className = 'dropdown-item disabled';
+    if (notifyNative) {
+        window.dispatchEvent(new CustomEvent('carsInBikeLanesAuthChanged', {
+            detail: { provider: 'mastodon', signedIn: false }
+        }));
+    }
 }
 
 function checkMastodonAuth() {

--- a/SeattleCarsInBikeLanes/wwwroot/js/mobile-auth.js
+++ b/SeattleCarsInBikeLanes/wwwroot/js/mobile-auth.js
@@ -1,0 +1,89 @@
+(function() {
+    let nativeNotificationsEnabled = false;
+    const pendingNativeSignOuts = new Set();
+
+    function getProviderConfig(provider) {
+        if (provider === 'bluesky') {
+            return {
+                modalId: 'blueskyHandleModal',
+                applySignedOut: function() {
+                    setBlueskyLoggedOut();
+                }
+            };
+        }
+
+        if (provider === 'mastodon') {
+            return {
+                modalId: 'mastodonServerModal',
+                applySignedOut: function() {
+                    clearMastodonAuth(false);
+                }
+            };
+        }
+
+        return null;
+    }
+
+    function openSignIn(provider) {
+        const config = getProviderConfig(provider);
+        const modal = config && document.getElementById(config.modalId);
+        if (!modal || !window.bootstrap || !bootstrap.Modal) {
+            return false;
+        }
+
+        bootstrap.Modal.getOrCreateInstance(modal).show();
+        return true;
+    }
+
+    function applySignedOut(provider) {
+        const config = getProviderConfig(provider);
+        if (!config) {
+            return false;
+        }
+
+        try {
+            config.applySignedOut();
+            return true;
+        } catch {
+            return false;
+        }
+    }
+
+    function notifyNativeSignedOut(provider) {
+        if (!nativeNotificationsEnabled) {
+            pendingNativeSignOuts.add(provider);
+            return;
+        }
+
+        window.location.href = `cibl-mobile://auth/signed-out?provider=${provider}`;
+    }
+
+    function enableNativeNotifications() {
+        nativeNotificationsEnabled = true;
+        Array.from(pendingNativeSignOuts).forEach(function(provider, index) {
+            setTimeout(function() {
+                notifyNativeSignedOut(provider);
+            }, index * 50);
+        });
+        pendingNativeSignOuts.clear();
+        return true;
+    }
+
+    window.addEventListener('carsInBikeLanesAuthChanged', function(event) {
+        const detail = event.detail;
+        const provider = detail && detail.provider;
+        if (!detail ||
+            detail.signedIn !== false ||
+            (provider !== 'bluesky' && provider !== 'mastodon')) {
+            return;
+        }
+
+        notifyNativeSignedOut(provider);
+    });
+
+    window.carsInBikeLanesMobileAuth = Object.freeze({
+        openSignIn: openSignIn,
+        applySignedOut: applySignedOut,
+        enableNativeNotifications: enableNativeNotifications
+    });
+})();


### PR DESCRIPTION
## Summary
- expose stable mobile hooks for opening Bluesky and Mastodon sign-in dialogs
- notify the embedded mobile app when a user signs out from the website
- suppress reverse notifications when native Settings initiated the sign-out
- buffer early logout notifications until the mobile WebView enables the bridge

## Validation
- `node --check SeattleCarsInBikeLanes/wwwroot/js/mobile-auth.js`
- `node --check SeattleCarsInBikeLanes/wwwroot/js/bluesky-auth.js`
- `node --check SeattleCarsInBikeLanes/wwwroot/js/index.js`