### PR TITLE
Add Bootstrap 5.3 light/dark theming to website

### DIFF
--- a/SeattleCarsInBikeLanes/wwwroot/css/guess-game.css
+++ b/SeattleCarsInBikeLanes/wwwroot/css/guess-game.css
@@ -13,6 +13,44 @@ html, body {
     flex: 1 1 auto;
 }
 
+.atlas-map .maplibregl-popup-content {
+    background: var(--bs-body-bg);
+    color: var(--bs-body-color);
+}
+
+.atlas-map .popup-container {
+    color: var(--bs-body-bg) !important;
+}
+
+.atlas-map .popup-content-container {
+    background-color: var(--bs-body-bg) !important;
+    color: var(--bs-body-color) !important;
+}
+
+.atlas-map .popup-close {
+    color: var(--bs-body-color);
+}
+
+.atlas-map .maplibregl-popup-anchor-top .maplibregl-popup-tip,
+.atlas-map .maplibregl-popup-anchor-top-left .maplibregl-popup-tip,
+.atlas-map .maplibregl-popup-anchor-top-right .maplibregl-popup-tip {
+    border-bottom-color: var(--bs-body-bg);
+}
+
+.atlas-map .maplibregl-popup-anchor-bottom .maplibregl-popup-tip,
+.atlas-map .maplibregl-popup-anchor-bottom-left .maplibregl-popup-tip,
+.atlas-map .maplibregl-popup-anchor-bottom-right .maplibregl-popup-tip {
+    border-top-color: var(--bs-body-bg);
+}
+
+.atlas-map .maplibregl-popup-anchor-left .maplibregl-popup-tip {
+    border-right-color: var(--bs-body-bg);
+}
+
+.atlas-map .maplibregl-popup-anchor-right .maplibregl-popup-tip {
+    border-left-color: var(--bs-body-bg);
+}
+
 .bottom-right > .atlas-legend-control-container {
     max-width: none !important;
     max-height: none !important;

--- a/SeattleCarsInBikeLanes/wwwroot/css/index.css
+++ b/SeattleCarsInBikeLanes/wwwroot/css/index.css
@@ -17,6 +17,45 @@ html, body {
     padding: 15px;
 }
 
+.atlas-map .maplibregl-popup-content {
+    background: var(--bs-body-bg);
+    color: var(--bs-body-color);
+}
+
+.atlas-map .popup-container {
+    color: var(--bs-body-bg) !important;
+}
+
+.atlas-map .popup-content-container {
+    background-color: var(--bs-body-bg) !important;
+    color: var(--bs-body-color) !important;
+}
+
+.atlas-map .maplibregl-popup-close-button,
+.atlas-map .popup-close {
+    color: var(--bs-body-color);
+}
+
+.atlas-map .maplibregl-popup-anchor-top .maplibregl-popup-tip,
+.atlas-map .maplibregl-popup-anchor-top-left .maplibregl-popup-tip,
+.atlas-map .maplibregl-popup-anchor-top-right .maplibregl-popup-tip {
+    border-bottom-color: var(--bs-body-bg);
+}
+
+.atlas-map .maplibregl-popup-anchor-bottom .maplibregl-popup-tip,
+.atlas-map .maplibregl-popup-anchor-bottom-left .maplibregl-popup-tip,
+.atlas-map .maplibregl-popup-anchor-bottom-right .maplibregl-popup-tip {
+    border-top-color: var(--bs-body-bg);
+}
+
+.atlas-map .maplibregl-popup-anchor-left .maplibregl-popup-tip {
+    border-right-color: var(--bs-body-bg);
+}
+
+.atlas-map .maplibregl-popup-anchor-right .maplibregl-popup-tip {
+    border-left-color: var(--bs-body-bg);
+}
+
 @media (max-height: 1000px) {
     .atlas-layer-legend-card {
         /* This overrides the legend card height so it doesn't take up too much space on small devices. */
@@ -26,16 +65,18 @@ html, body {
 
 .twitter-button {
     background-color: #1DA1F2 !important;
+    color: #000 !important;
     margin-bottom: 4px;
 }
 
 .mastodon-button {
     background-color: #6364FF !important;
+    color: #fff !important;
 }
 
 .bluesky-button {
     background-color: #1185FE !important;
-    color: white;
+    color: #fff !important;
 }
 
 .collapsing {

--- a/SeattleCarsInBikeLanes/wwwroot/game.html
+++ b/SeattleCarsInBikeLanes/wwwroot/game.html
@@ -4,22 +4,24 @@
   <meta charset="UTF-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="color-scheme" content="light dark">
   <title>Seattle Bike Lane Guesser</title>
+  <script src="js/theme.js"></script>
   <link rel="stylesheet" href="https://atlas.microsoft.com/sdk/javascript/mapcontrol/3.0.0-preview.6/atlas.min.css" type="text/css" />
   <script src="https://atlas.microsoft.com/sdk/javascript/mapcontrol/3.0.0-preview.6/atlas.min.js"></script>
   <link rel="stylesheet" href="css/azure-maps-layer-legend.min.css">
   <script src="https://unpkg.com/@popperjs/core@2"></script>
-  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/css/bootstrap.min.css" rel="stylesheet"
-    integrity="sha384-rbsA2VBKQhggwzxH7pPCaAqO46MgnOM80zW1RWuH61DGLwZJEdK2Kadq2F9CUG65" crossorigin="anonymous">
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/bootstrap.bundle.min.js"
-    integrity="sha384-kenU1KFdBIe4zVF0s0G1M5b4hcpxyD9F7jL+jjXkk+Q2h455rYXK/7HAuoJl+0I4"
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/css/bootstrap.min.css" rel="stylesheet"
+    integrity="sha384-sRIl4kxILFvY47J16cr9ZwB07vP4J8+LH7qKQnuqkuIAvNWLzeN8tE5YBujZqJLB" crossorigin="anonymous">
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-FKyoEForCGlyvwx9Hj09JcYn3nv7wiPVlz7YYwJrWVcXK/BmnVDxM+D2scQbITxI"
     crossorigin="anonymous"></script>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.4/font/bootstrap-icons.css">
   <link rel="stylesheet" href="css/guess-game.css">
 </head>
 <body>
   <div id="wrapper" class="wrapper" hidden>
-    <nav class="navbar bg-light navbar-expand sticky-top">
+    <nav class="navbar bg-body-tertiary navbar-expand sticky-top">
       <div class="container-fluid">
         <div class="collapse navbar-collapse" id="navContent">
           <button class="btn btn-success" id="startGameButton" hidden>Start game</button>

--- a/SeattleCarsInBikeLanes/wwwroot/index.html
+++ b/SeattleCarsInBikeLanes/wwwroot/index.html
@@ -7,18 +7,20 @@
     <link rel="icon" href="favicon.png" type="image/png">
     <title>Seattle Cars In Bike Lanes</title>
     <meta name="description" content="Pictures of cars in bike lanes. Accepting submissions through website, Twitter/Mastodon mention, or DM.">
+    <meta name="color-scheme" content="light dark">
     <link rel="alternate" href="rss.xml" type="application/rss+xml" title="RSS">
     <link rel="alternate" href="atom.xml" type="application/atom+xml" title="Atom">
+    <script src="js/theme.js"></script>
     <link rel="stylesheet" href="https://atlas.microsoft.com/sdk/javascript/mapcontrol/3/atlas.min.css" type="text/css">
     <script src="https://atlas.microsoft.com/sdk/javascript/mapcontrol/3/atlas.min.js"></script>
     <link rel="stylesheet" href="css/azure-maps-layer-legend.min.css">
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-rbsA2VBKQhggwzxH7pPCaAqO46MgnOM80zW1RWuH61DGLwZJEdK2Kadq2F9CUG65" crossorigin="anonymous">
-    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-kenU1KFdBIe4zVF0s0G1M5b4hcpxyD9F7jL+jjXkk+Q2h455rYXK/7HAuoJl+0I4" crossorigin="anonymous"></script>
-    <link rel="stylesheet" href="css/index.css"></script>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-sRIl4kxILFvY47J16cr9ZwB07vP4J8+LH7qKQnuqkuIAvNWLzeN8tE5YBujZqJLB" crossorigin="anonymous">
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/js/bootstrap.bundle.min.js" integrity="sha384-FKyoEForCGlyvwx9Hj09JcYn3nv7wiPVlz7YYwJrWVcXK/BmnVDxM+D2scQbITxI" crossorigin="anonymous"></script>
+    <link rel="stylesheet" href="css/index.css">
 </head>
 <body>
     <div class="wrapper">
-      <nav class="navbar bg-light navbar-expand-lg sticky-top">
+      <nav class="navbar bg-body-tertiary navbar-expand-lg sticky-top">
         <div class="container-fluid">
           <span class="navbar-brand">Seattle</span>
           <button id="navbarToggler" class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navContent" aria-controls="navContent" aria-expanded="false" aria-label="Toggle navigation">

--- a/SeattleCarsInBikeLanes/wwwroot/js/guess-game.js
+++ b/SeattleCarsInBikeLanes/wwwroot/js/guess-game.js
@@ -3,12 +3,15 @@ let gameCode = null;
 let userId = '';
 let username = '';
 let map = null;
+let mapReady = false;
+let mapTheme = window.siteTheme.getTheme();
 const seattleBoundingBox = new atlas.data.BoundingBox([-122.436522, 47.495082], [-122.235787, 47.735525]);
-const darkMode = window.matchMedia('(prefers-color-scheme: dark)').matches;
 let guessLocationDataSource = null;
 let realLocationDataSource = null;
 let distancesPointDataSource = null;
 let distancesLineDataSource = null;
+let distancesSymbolLayer = null;
+let distancesLineLayer = null;
 let playersLegendControl = null;
 let helpLegendControl = null;
 let knownPlayers = [];
@@ -26,6 +29,45 @@ const popup = new atlas.Popup({
     content: ''
 });
 let popupTimeout = null;
+
+function getDistanceTextOptions(theme) {
+    return {
+        textField: ['get', 'content'],
+        color: theme === 'dark' ? '#fff' : '#000',
+        haloColor: theme === 'dark' ? '#000' : '#fff',
+        haloWidth: 2
+    };
+}
+
+function applyGameTheme(theme) {
+    if (mapReady && map && mapTheme !== theme) {
+        map.setStyle({
+            style: theme === 'dark' ? 'night' : 'road'
+        });
+        mapTheme = theme;
+    }
+
+    [playersLegendControl, imageLegendControl, helpLegendControl].forEach(legendControl => {
+        if (legendControl) {
+            legendControl.setOptions({
+                style: theme
+            });
+        }
+    });
+
+    if (distancesLineLayer) {
+        distancesLineLayer.setOptions({
+            strokeColor: theme === 'dark' ? '#fff' : '#000'
+        });
+    }
+    if (distancesSymbolLayer) {
+        distancesSymbolLayer.setOptions({
+            textOptions: getDistanceTextOptions(theme)
+        });
+    }
+}
+
+window.siteTheme.subscribe(applyGameTheme);
 
 const connection = new signalR.HubConnectionBuilder()
     .withUrl('/GuessGameHub')
@@ -167,13 +209,11 @@ connection.on('EndRound', function(endRoundInfo) {
         distancesPointDataSource = new atlas.source.DataSource(null, { cluster: false });
         distancesPointDataSource.add(distancesPointFeatureCollection);
         map.sources.add(distancesPointDataSource);
-        const distancesSymbolLayer = new atlas.layer.SymbolLayer(distancesPointDataSource, null, {
+        distancesSymbolLayer = new atlas.layer.SymbolLayer(distancesPointDataSource, null, {
             iconOptions: {
                 image: 'marker-yellow'
             },
-            textOptions: {
-                textField: ['get', 'content']
-            }
+            textOptions: getDistanceTextOptions(window.siteTheme.getTheme())
         });
         map.layers.add(distancesSymbolLayer);
     } else {
@@ -186,8 +226,8 @@ connection.on('EndRound', function(endRoundInfo) {
         distancesLineDataSource = new atlas.source.DataSource(null, { cluster: false });
         distancesLineDataSource.add(distancesLineFeatureCollection);
         map.sources.add(distancesLineDataSource);
-        const distancesLineLayer = new atlas.layer.LineLayer(distancesLineDataSource, null, {
-            strokeColor: 'black',
+        distancesLineLayer = new atlas.layer.LineLayer(distancesLineDataSource, null, {
+            strokeColor: window.siteTheme.isDark() ? '#fff' : '#000',
             strokeDashArray: [4, 4]
         });
         map.layers.add(distancesLineLayer);
@@ -436,11 +476,12 @@ if (urlSearchParams.has('gameCode')) {
 }
 
 function initMap() {
+    mapTheme = window.siteTheme.getTheme();
     map = new atlas.Map('map', {
         center: [-122.333301, 47.606501],
         zoom: 11,
         language: 'en-US',
-        style: darkMode ? 'night' : 'road',
+        style: mapTheme === 'dark' ? 'night' : 'road',
         authOptions: {
             authType: 'anonymous',
             clientId: 'df857d2c-3805-4793-90e4-63e84a499756',
@@ -453,6 +494,8 @@ function initMap() {
     });
 
     map.events.add('ready', function() {
+        mapReady = true;
+        applyGameTheme(window.siteTheme.getTheme());
         if (isAdmin) {
             document.getElementById('startGameButton').removeAttribute('hidden');
             document.getElementById('shareButton').removeAttribute('hidden');
@@ -475,7 +518,7 @@ function initMap() {
         .then((players) => {
             knownPlayers = players;
             playersLegendControl = new atlas.control.LegendControl({
-                style: 'auto',
+                style: window.siteTheme.getTheme(),
                 showToggle: true,
                 visible: true,
                 legends: [{
@@ -493,7 +536,7 @@ function initMap() {
         });
 
         imageLegendControl = new atlas.control.LegendControl({
-            style: 'auto',
+            style: window.siteTheme.getTheme(),
             showToggle: true,
             visible: false,
             legends: [{
@@ -504,7 +547,7 @@ function initMap() {
         map.controls.add(imageLegendControl, { position: 'bottom-right' });
 
         helpLegendControl = new atlas.control.LegendControl({
-            style: 'auto',
+            style: window.siteTheme.getTheme(),
             showToggle: false,
             visible: false,
             legends: [{
@@ -590,7 +633,7 @@ function buildPlayerList(players, addHeader) {
         if (player.lastRoundScore) {
             const lastRoundScoreSpan = document.createElement('span');
             lastRoundScoreSpan.innerText = ` (+${player.lastRoundScore})`;
-            lastRoundScoreSpan.style.color = 'green';
+            lastRoundScoreSpan.className = 'text-success-emphasis';
             playerListItem.append(lastRoundScoreSpan);
         }
         playersHtmlList.append(playerListItem);

--- a/SeattleCarsInBikeLanes/wwwroot/js/index.js
+++ b/SeattleCarsInBikeLanes/wwwroot/js/index.js
@@ -1,4 +1,6 @@
 let map = null;
+let mapReady = false;
+let mapTheme = window.siteTheme.getTheme();
 let reportedItemsPromise = null;
 let dataSource = null;
 let popup = null;
@@ -22,9 +24,58 @@ let blLayer = null;
 let clLayer = null;
 let oLayer = null;
 let trailsLayer = null;
-const darkMode = window.matchMedia('(prefers-color-scheme: dark)').matches;
 let loggedInMastodonFullUsername = null;
 let loggedInMastodonUsername = null;
+
+function getBikeFacilityLegendItems(theme) {
+    return [
+        { label: 'Protected Bike Lane', color: 'rgb(22, 145, 208)', strokeWidth: 4 },
+        { label: 'Buffered Bike Lane', color: 'rgb(28, 179, 255)', strokeWidth: 3 },
+        { label: 'Painted Bike Lane', color: 'rgb(255, 108, 44)', strokeWidth: 3 },
+        { label: 'Climbing Lane', color: 'rgb(0, 168, 93)', strokeWidth: 2 },
+        { label: 'Miscellaneous Off Street Bicycle Facility', color: theme === 'dark' ? '#fff' : '#000', strokeWidth: 2 },
+        { label: 'Multi-Use Trail', color: 'rgb(168, 56, 0)', strokeWidth: 4 }
+    ];
+}
+
+function applyWebTheme(theme) {
+    if (mapReady && map && mapTheme !== theme) {
+        map.setStyle({
+            style: theme === 'dark' ? 'night' : 'road'
+        });
+        mapTheme = theme;
+    }
+
+    [filterLegendControl, uploadLegendControl, filterStatusLegendControl].forEach(legendControl => {
+        if (legendControl) {
+            legendControl.setOptions({
+                style: theme
+            });
+        }
+    });
+
+    const otherBikeLaneColor = theme === 'dark' ? '#fff' : '#000';
+    if (oLayer) {
+        oLayer.setOptions({
+            strokeColor: otherBikeLaneColor
+        });
+    }
+    if (bikeLaneLegendControl) {
+        bikeLaneLegendControl.setOptions({
+            style: theme,
+            legends: [{
+                type: 'category',
+                itemLayout: 'row',
+                shape: 'line',
+                fitItems: true,
+                shapeSize: 20,
+                items: getBikeFacilityLegendItems(theme)
+            }]
+        });
+    }
+}
+
+window.siteTheme.subscribe(applyWebTheme);
 
 function toggleFilterLegendControl() {
     toggleLegendControl(filterLegendControl);
@@ -729,11 +780,12 @@ function initUploadDoneLegendHtml() {
 }
 
 function initMap() {
+    mapTheme = window.siteTheme.getTheme();
     map = new atlas.Map('map', {
         center: [-122.333301, 47.606501],
         zoom: 11,
         language: 'en-US',
-        style: darkMode ? 'night' : 'road',
+        style: mapTheme === 'dark' ? 'night' : 'road',
         authOptions: {
             authType: 'anonymous',
             clientId: 'df857d2c-3805-4793-90e4-63e84a499756',
@@ -746,6 +798,8 @@ function initMap() {
     });
 
     map.events.add('ready', function() {
+        mapReady = true;
+        applyWebTheme(window.siteTheme.getTheme());
         initMapControls();
         popup = new atlas.Popup();
 
@@ -765,7 +819,7 @@ function initMap() {
         .then(reportedItems => {
             filterLegendControl = new atlas.control.LegendControl({
                 title: 'Filters',
-                style: 'auto',
+                style: window.siteTheme.getTheme(),
                 showToggle: false,
                 visible: false,
                 legends: [{
@@ -777,7 +831,7 @@ function initMap() {
 
             uploadLegendControl = new atlas.control.LegendControl({
                 title: 'Upload',
-                style: 'auto',
+                style: window.siteTheme.getTheme(),
                 showToggle: false,
                 visible: false,
                 legends: [{
@@ -790,7 +844,7 @@ function initMap() {
             // Add filter status legend control (top-right)
             filterStatusLegendControl = new atlas.control.LegendControl({
                 title: 'Current Filters',
-                style: 'auto',
+                style: window.siteTheme.getTheme(),
                 showToggle: false,
                 visible: true,
                 legends: [{
@@ -855,7 +909,7 @@ function initMap() {
             .then(lanes => {
                 bikeLaneLegendControl = new atlas.control.LegendControl({
                     title: 'Bike Facilities',
-                    style: 'auto',
+                    style: window.siteTheme.getTheme(),
                     visible: false,
                     legends: [{
                         type: 'category',
@@ -863,14 +917,7 @@ function initMap() {
                         shape: 'line',
                         fitItems: true,
                         shapeSize: 20,
-                        items: [
-                            { label: 'Protected Bike Lane', color: 'rgb(22, 145, 208)', strokeWidth: 4 },
-                            { label: 'Buffered Bike Lane', color: 'rgb(28, 179, 255)', strokeWidth: 3 },
-                            { label: 'Painted Bike Lane', color: 'rgb(255, 108, 44)', strokeWidth: 3 },
-                            { label: 'Climbing Lane', color: 'rgb(0, 168, 93)', strokeWidth: 2 },
-                            { label: 'Miscellaneous Off Street Bicycle Facility', color: darkMode ? '#fff': '#000', strokeWidth: 2 },
-                            { label: 'Multi-Use Trail', color: 'rgb(168, 56, 0)', strokeWidth: 4 }
-                        ]
+                        items: getBikeFacilityLegendItems(window.siteTheme.getTheme())
                     }]
                 });
                 map.controls.add(bikeLaneLegendControl, { position: 'bottom-left' });
@@ -879,7 +926,7 @@ function initMap() {
                 bblLayer = getLineLayer(getBufferedBikeLanesCollection(lanes), 'rgb(28, 179, 255)', 3, map);
                 blLayer = getLineLayer(getPaintedBikeLanesCollection(lanes), 'rgb(255, 108, 44)', 3, map);
                 clLayer = getLineLayer(getClimbingLanesCollection(lanes), 'rgb(0, 168, 93)', 2, map);
-                otherBikeLaneColor = darkMode ? '#fff' : '#000';
+                const otherBikeLaneColor = window.siteTheme.isDark() ? '#fff' : '#000';
                 oLayer = getLineLayer(getOtherLanesCollection(lanes), otherBikeLaneColor, 2, map);
                 map.layers.add(pblLayer);
                 map.layers.add(bblLayer);
@@ -969,16 +1016,6 @@ function initMap() {
     });
 }
 
-function initDarkMode() {
-    if (!darkMode) {
-        return;
-    }
-    const nav = document.querySelector('nav');
-    nav.classList.remove('bg-light');
-    nav.classList.add('navbar-dark', 'bg-dark');
-}
-
-initDarkMode();
 initControls();
 initMap();
 checkMastodonAuth();

--- a/SeattleCarsInBikeLanes/wwwroot/js/theme.js
+++ b/SeattleCarsInBikeLanes/wwwroot/js/theme.js
@@ -1,0 +1,41 @@
+(function () {
+    const colorScheme = window.matchMedia('(prefers-color-scheme: dark)');
+    const listeners = new Set();
+
+    function getTheme() {
+        return colorScheme.matches ? 'dark' : 'light';
+    }
+
+    function applyTheme() {
+        const theme = getTheme();
+        document.documentElement.setAttribute('data-bs-theme', theme);
+        document.documentElement.style.colorScheme = theme;
+        return theme;
+    }
+
+    function onColorSchemeChanged() {
+        const theme = applyTheme();
+        listeners.forEach(listener => listener(theme));
+    }
+
+    if (colorScheme.addEventListener) {
+        colorScheme.addEventListener('change', onColorSchemeChanged);
+    } else {
+        colorScheme.addListener(onColorSchemeChanged);
+    }
+
+    window.siteTheme = {
+        getTheme: getTheme,
+        isDark: function () {
+            return getTheme() === 'dark';
+        },
+        subscribe: function (listener) {
+            listeners.add(listener);
+            return function () {
+                listeners.delete(listener);
+            };
+        }
+    };
+
+    applyTheme();
+})();


### PR DESCRIPTION
## Summary
Adds full Bootstrap 5.3 light/dark theming support to the public website (map page and guess-the-location game), driven by the OS `prefers-color-scheme` setting, including live updates to Azure Maps styling when the OS theme changes.

## Changes
- **`js/theme.js`** (new): detects `prefers-color-scheme`, sets `data-bs-theme` / `color-scheme` on `<html>`, and exposes `window.siteTheme` (`getTheme`, `isDark`, `subscribe`) for other scripts to react to theme changes.
- **`index.html`** / **`game.html`**: wired up for Bootstrap 5.3 theming (`data-bs-theme` attribute, `theme.js` script include).
- **`css/index.css`** / **`css/guess-game.css`**: added dark-mode-aware styles.
- **`js/index.js`** / **`js/guess-game.js`**: apply the correct Azure Maps style on initial load and subscribe to live theme changes to update the map style without a reload.

## Scope
Website-only changes (`SeattleCarsInBikeLanes/wwwroot/**`). No native `SeattleCarsInBikeLanes.Mobile` changes are included.

## Validation
- `node --check` passed on `index.js`, `guess-game.js`, `theme.js`
- `git diff --check` — no whitespace errors
- `dotnet build SeattleCarsInBikeLanes/SeattleCarsInBikeLanes.csproj` — succeeded, 0 errors (pre-existing warnings only)
- Existing test suite (`SeattleCarsInBikeLanes.Tests`) covers controllers/auth only, unaffected by this change

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>