### PR TITLE
Unify report uploads and moderation under the existing API

### DIFF
--- a/.github/workflows/main_seattle-carsinbikelanes.yml
+++ b/.github/workflows/main_seattle-carsinbikelanes.yml
@@ -4,6 +4,13 @@
 name: Build and deploy ASP.Net Core app to Azure Web App - seattle-carsinbikelanes
 
 on:
+  pull_request:
+    paths:
+      - ".github/workflows/main_seattle-carsinbikelanes.yml"
+      - "SeattleCarsInBikeLanes/**"
+      - "SeattleCarsInBikeLanes.Tests/**"
+      - "SeattleCarsInBikeLanes.Core/**"
+      - "SeattleCarsInBikeLanes.Core.Tests/**"
   push:
     branches:
       - main
@@ -23,12 +30,15 @@ jobs:
 
       - name: Build with dotnet
         run: dotnet build SeattleCarsInBikeLanes/SeattleCarsInBikeLanes.csproj --configuration Release
-      
+
       - name: Build tests
         run: dotnet build SeattleCarsInBikeLanes.Tests/SeattleCarsInBikeLanes.Tests.csproj --configuration Release
 
       - name: Run tests
         run: dotnet test SeattleCarsInBikeLanes.Tests/SeattleCarsInBikeLanes.Tests.csproj --configuration Release
+
+      - name: Run shared contract tests
+        run: dotnet test SeattleCarsInBikeLanes.Core.Tests/SeattleCarsInBikeLanes.Core.Tests.csproj --configuration Release
 
       - name: dotnet publish
         run: dotnet publish SeattleCarsInBikeLanes/SeattleCarsInBikeLanes.csproj -c Release -r win-x64 --self-contained true -o "${{env.DOTNET_ROOT}}/myapp"
@@ -40,6 +50,7 @@ jobs:
           path: ${{env.DOTNET_ROOT}}/myapp
 
   deploy:
+    if: github.event_name != 'pull_request'
     runs-on: windows-latest
     needs: build
     environment:

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 *.user
 *.userosscache
 *.sln.docstates
+SeattleCarsInBikeLanes.Mobile/SeattleCarsInBikeLanes.Mobile.local.props
 
 # User-specific files (MonoDevelop/Xamarin Studio)
 *.userprefs

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,7 +10,7 @@
             "request": "launch",
             "preLaunchTask": "build",
             // If you have changed target frameworks, make sure to update the program path.
-            "program": "${workspaceFolder}/SeattleCarsInBikeLanes/bin/Debug/net8.0/SeattleCarsInBikeLanes.dll",
+            "program": "${workspaceFolder}/SeattleCarsInBikeLanes/bin/Debug/net10.0/SeattleCarsInBikeLanes.dll",
             "args": [],
             "cwd": "${workspaceFolder}/SeattleCarsInBikeLanes",
             "stopAtEntry": false,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -115,3 +115,236 @@ let privateKey = sessionRequest.result.value.dpopKey.keyPair.privateKey;
 1. `dotnet build -c Release`
 2. `dotnet pack -c Release`
 3. `dotnet nuget push <path to .nupkg> -k <NuGet API key>`
+
+## Shared report uploads
+
+The website and mobile app use the same two-stage API and report store. Photos
+remain ordinary JPEG blobs; the server does not embed image bytes in report JSON.
+There is no `FinalizeMobile` endpoint.
+
+| Request | Purpose |
+| --- | --- |
+| `POST /api/Upload/Initial` | Analyze multipart `files` and return ordered prepared-photo metadata and preview URLs. |
+| `POST /api/Upload/Finalize` | Accept a complete report and return its durable receipt. |
+| `GET /api/Upload/Reports/{reportId}` | Reconcile an uncertain submission using its original receipt. |
+| `GET /api/Upload/Limits` | Return shared location, photo-count, and processed-photo size limits. |
+
+Create a random 32-character lowercase hexadecimal report ID before the first
+upload, and send it as `X-Report-Id` on both POSTs. Keep it for every retry of that
+logical report, even when the photos must be prepared again. Native callers also
+send `X-Device-Id`; website callers do not need a device identity or social login.
+Neither an installation ID nor a client-supplied attribution identity proves who
+a person is.
+
+Initial upload returns an array of `InitialPhotoUpload` objects. Their
+`submissionId` identifies a preparation set, not the final accepted report. The
+server reads EXIF capture metadata and falls back to bounded, entity-disabled
+XMP parsing for missing date/GPS fields. Capture dates retain their camera
+wall-clock time rather than being converted to the web server's time zone. The
+shared finalization body is an envelope:
+
+```json
+{
+  "photos": [
+    {
+      "photoId": "returned-prepared-photo-id",
+      "submissionId": "returned-preparation-id",
+      "photoNumber": 0,
+      "photoDateTime": "2026-09-07T12:00:00",
+      "photoLatitude": "47.60621",
+      "photoLongitude": "-122.33207",
+      "photoCrossStreet": "Pike St",
+      "numberOfCars": 1
+    }
+  ],
+  "attribution": {}
+}
+```
+
+An empty attribution object explicitly requests anonymity, even if the request
+also contains signed-in cookies. Attributed requests include `blueskyDid` and/or
+`mastodonServer` plus `mastodonAccountId`. The server verifies the actual cookie,
+bearer, or Mastodon credential against that selection. An explicitly supplied
+native bearer cannot fall back to a different cookie identity. Credential
+rejection and temporary provider unavailability are different failures.
+Mastodon identity verification is limited to 64 KiB and a 15-second deadline
+covering both response headers and body reads. A stalled provider is a retryable
+outage, not a reason to drop attribution.
+
+Success returns a `SubmissionReceipt` containing `reportId`, `submissionId`,
+`submittedAt`, and the accepted `attribution`. The same logical report always
+returns its original receipt once accepted, including after moderation/deletion.
+A receipt is acceptance into moderation, not confirmation that social posts exist.
+Do not infer acceptance from the completion of `Initial` or individual blob writes.
+
+The website retains its files, report ID, and submitted values in the open page
+while an outcome is uncertain. It checks the receipt before resending, and does
+not adopt edits or a different account during that recovery. A definitively
+rejected request can be corrected. Confirmed expired credentials let the website
+user sign in again or explicitly turn attribution off; the mobile queue retains
+its separately approved automatic anonymous-fallback behavior.
+
+### Storage and recovery
+
+Temporary analyzed images stay under `initialupload/`. All permanent report data
+stays under the existing `finalizedupload/` prefix. New report records use
+`finalizedupload/reports/<report-id>.json`, with separate immutable JPEGs under
+`finalizedupload/photos/<report-id>/<attempt-id>/`. A conditional transition of
+the report record is the acceptance boundary: moderation never discovers new
+reports by listing individual JPEGs.
+
+Preparing work, retry takeover, acceptance, and abandonment are fenced through
+the same versioned report record. An old worker cannot commit after its attempt
+is superseded. Prepared source versions and completed destination lengths/versions
+are checked before acceptance. Credentials and administrator tokens must never
+appear in durable report or recovery metadata.
+
+The initial-upload pruner must not scan permanent photo storage. The report
+cleanup service separately fences expired preparations before deleting their
+files, collects superseded attempts, and retries cleanup after retirement.
+Accepted and unresolved moderation records retain their photos. Retired records
+retain their original receipt permanently, so late client retries cannot recreate
+moderated reports. Do not manually age-delete report receipts.
+Corrupt report records are logged and skipped during cleanup, together with any
+photos they might reference; they are not treated as missing reports. Repair the
+record before expecting its cleanup or moderation to proceed.
+
+### Existing moderation data
+
+Existing `finalizedupload/<photo-id>.jpeg/.json` submissions remain available
+without a destructive bulk migration. The Admin Panel groups their stored
+metadata by original submission ID. Before the first moderation action, it
+conditionally adopts the complete server-loaded group into the shared report
+model, retaining the existing JPEGs and original submission identity.
+The per-photo reader only examines flat JSON files directly under
+`finalizedupload/`; nested report records are read by the shared report store.
+
+Shared records, including retired tombstones, suppress legacy entries in the
+pending list. Legacy files are removed only through retirement cleanup; a cleanup
+failure must not make a previously moderated submission appear again. Missing or
+unreadable legacy files require operator attention rather than silent omission.
+This stored-data adapter is not compatibility support for old API request bodies.
+
+### Blocking device submissions
+
+On `/AdminPage`, choose **Block device** next to a pending report's device ID.
+The confirmation modal requires a reason (1-1,000 characters after trimming).
+Confirming saves the device and reason in Cosmos DB. The **Blocked devices**
+section lists those reasons and provides a confirmed **Unblock** action, even
+after the source report has been published or deleted. Unblocking removes the
+active record and its reason; this is not a historical audit log.
+
+The reason is administrator-only plain text. It is never sent to the mobile app,
+included in receipts, or published with reports. Device IDs are case-sensitive
+installation identifiers supplied by clients, not verified identities. Reports
+without a device ID have no block action.
+
+Blocking stops new preparations and new report finalizations with the existing
+HTTP 403 response. It does not remove accepted reports, prevent publishing or
+deletion, or stop a device from recovering an already accepted receipt. Requests
+that already passed their device check are not canceled by a subsequent block.
+
+Submission checks use an uncached point read against the exact device ID and
+partition key. A normal new mobile report makes up to two logical reads, plus any
+retries; website requests without a device ID make none. Caching could reduce
+request units for repeated IDs, but is deliberately omitted for simplicity and to
+avoid a cache delay after administrative changes. Actual cost depends on request
+volume and the Cosmos account's capacity model, not how often devices are blocked.
+Visibility still follows the account's consistency configuration.
+
+Blocklist read failures are logged and **fail open only for submission checks**.
+The admin list and mutations do not fail open: they show errors instead of claiming
+that the list is empty or that an unconfirmed change succeeded. Refresh blocked
+devices after an uncertain response to reconcile the saved state. Blocking and
+unblocking do not discard edits to pending reports.
+
+#### Cosmos setup before deployment
+
+1. In the existing `seattle-carsinbikelanes-db` Cosmos account, create an empty
+   `blocked-devices` container under the `seattle` database, with partition-key
+   path `/id` and TTL disabled. This is a new container, not a database or account.
+2. Use the account's appropriate existing capacity model. Check whether database
+   throughput is shared before selecting container throughput; do not assume shared
+   throughput or allocate a new fixed RU/s budget by default.
+3. Grant the deployed managed identity and authorized local developers Cosmos
+   data-plane access to read/query/upsert/delete items in this container (for
+   example, Cosmos DB Built-in Data Contributor scoped to the container).
+   Existing `items`-scoped permissions do not automatically cover it. Reuse
+   `DefaultAzureCredential`; no new keys or secrets are needed.
+4. Confirm that the admin list and a temporary block/unblock work against the
+   intended nonproduction container before rollout. Successful uploads alone
+   cannot confirm configuration because submission checks fail open. Verify the
+   deployed application's list and mutation access before relying on blocking.
+
+The application obtains the container with `GetContainer`; it does not create
+Azure resources at startup. Items have this shape, with the ID also serving as the
+partition-key value:
+
+```json
+{
+  "id": "example-installation-id",
+  "reason": "Repeated unrelated photo submissions."
+}
+```
+
+There are no existing blocked devices to import. `blockeddevices.json` is no longer
+read, and there is no blob fallback or dual-write mode. Photos and report receipts
+still use their existing blob storage. A rollback to the blob-based implementation
+would not enforce blocks added in Cosmos; preserve those records and account for
+them explicitly before rolling back. This storage change does not require mobile
+API changes; retain the Cosmos implementation when integrating the mobile branch.
+
+### Retrying failed publication
+
+Imgur uploads finish first. Mastodon, Bluesky, and Threads then publish
+concurrently; Mastodon and Bluesky receive independent read-only streams over
+the same JPEG buffers. All three tasks finish before any database/feed writes
+or failed-attempt release, so a failed provider cannot leave another provider
+still posting after the report becomes available for retry.
+
+Publication and deletion acquire conditional ownership of the whole report.
+Stale edits or an overlapping request must reload the current state. Metadata edits
+are a separate moderation snapshot and do not rewrite the submission receipt.
+
+When a publishing request fails, it releases ownership and keeps the report and
+its photos pending. We check Bluesky, Mastodon and Threads, delete any posts that
+succeeded, check the logs and fix the cause, then click Upload again. The panel
+keeps our edited form and receives the current report version for the retry.
+Social publishing is never retried automatically.
+
+Publication writes use the stable report ID for the database item and each feed
+entry. A retry replaces earlier database/feed results rather than conflicting
+with an existing database row or duplicating RSS after an Atom write failure.
+Photo retirement happens only after publication, database, and feed work
+complete. If storage is unavailable, the panel cannot safely confirm the report
+state and requires a refresh after that storage error is fixed.
+
+Submission deduplication is separate from social posting: we check and remove
+any posts that succeeded before retrying publication.
+
+### Validation and deployment order
+
+Use the existing server and shared Core test projects directly; building the
+website does not require mobile workloads. `SeattleCarsInBikeLanes.Tests/TestFiles/UploadFlow.html`
+also exercises the production browser upload helpers against an in-memory fake
+server. Serve it and its relative JavaScript dependencies from the repository
+root on a local HTTP server; it never submits real reports.
+`SeattleCarsInBikeLanes.Tests/TestFiles/AdminDeviceBlocks.html` similarly exercises
+the production admin page, confirmation modals, and block/unblock recovery against
+an in-memory fake API. It does not use Azure or submit real moderation actions.
+
+The standalone server PR updates the website and API contract together. There is
+no old array-body adapter, `FinalizeMobile` alias, or browser offline queue.
+Pause moderation during deployment so old server instances cannot publish legacy
+reports outside the new ownership protocol. Refresh website/admin pages after
+the deployment has completed on all instances.
+PR workflow runs build and test but do not deploy. Merge/deploy the shared backend
+before updating the mobile branch to use it; a green PR workflow with a skipped
+deploy job is not evidence that the server is live.
+
+After deployment, merge main into the existing mobile branch and update its
+upload URLs, preparation report-ID propagation, shared request/error types, and
+tests. Remove the abandoned mobile-only server/bundle code during that merge
+without discarding queued reports, retained credentials, receipt-first local
+acknowledgement, or either platform's photo recovery. Exercise the combined flow
+against a matching test backend before using it for real reports.

--- a/SeattleCarsInBikeLanes.Core.Tests/SeattleCarsInBikeLanes.Core.Tests.csproj
+++ b/SeattleCarsInBikeLanes.Core.Tests/SeattleCarsInBikeLanes.Core.Tests.csproj
@@ -1,0 +1,28 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\SeattleCarsInBikeLanes.Core\SeattleCarsInBikeLanes.Core.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+</Project>

--- a/SeattleCarsInBikeLanes.Core.Tests/UploadContractSerializationTests.cs
+++ b/SeattleCarsInBikeLanes.Core.Tests/UploadContractSerializationTests.cs
@@ -1,0 +1,112 @@
+using System.Text.Json;
+using SeattleCarsInBikeLanes.Core.Contracts;
+
+namespace SeattleCarsInBikeLanes.Core.Tests
+{
+    public class UploadContractSerializationTests
+    {
+        private static readonly JsonSerializerOptions JsonOptions =
+            new JsonSerializerOptions(JsonSerializerDefaults.Web);
+
+        [Fact]
+        public void InitialUploadUsesTheEstablishedWireNames()
+        {
+            InitialPhotoUpload upload = new InitialPhotoUpload()
+            {
+                Uri = "https://example.test/photo",
+                PhotoId = "photo-1",
+                SubmissionId = "submission-1",
+                PhotoNumber = 0,
+                PhotoDateTime = new DateTime(2026, 8, 18, 12, 30, 0),
+                PhotoLatitude = "47.60621",
+                PhotoLongitude = "-122.33207",
+                PhotoCrossStreet = "Pike St",
+                Tags = new List<ImageTag>()
+                {
+                    new ImageTag() { Name = "car", Confidence = 0.95f }
+                }
+            };
+
+            using JsonDocument document = JsonDocument.Parse(JsonSerializer.Serialize(upload, JsonOptions));
+            JsonElement root = document.RootElement;
+
+            Assert.Equal("https://example.test/photo", root.GetProperty("uri").GetString());
+            Assert.Equal("photo-1", root.GetProperty("photoId").GetString());
+            Assert.Equal("submission-1", root.GetProperty("submissionId").GetString());
+            Assert.Equal("47.60621", root.GetProperty("photoLatitude").GetString());
+            Assert.Equal("car", root.GetProperty("tags")[0].GetProperty("name").GetString());
+        }
+
+        [Fact]
+        public void FinalizeRequestPreservesAllClientWritableAttributionFields()
+        {
+            const string json = """
+            {
+              "photoId": "photo-1",
+              "submissionId": "submission-1",
+              "photoNumber": 0,
+              "numberOfCars": 2,
+              "twitterUsername": "rider",
+              "twitterAccessToken": "twitter-token",
+              "mastodonEndpoint": "https://example.social",
+              "mastodonUsername": "rider",
+              "mastodonFullUsername": "@rider@example.social",
+              "mastodonAccessToken": "mastodon-token",
+              "threadsUsername": "rider",
+              "threadsAccessToken": "threads-token",
+              "deviceId": "must-not-bind"
+            }
+            """;
+
+            FinalizedPhotoUpload? upload =
+                JsonSerializer.Deserialize<FinalizedPhotoUpload>(json, JsonOptions);
+
+            Assert.NotNull(upload);
+            Assert.Equal("rider", upload.TwitterUsername);
+            Assert.Equal("twitter-token", upload.TwitterAccessToken);
+            Assert.Equal("@rider@example.social", upload.MastodonFullUsername);
+            Assert.Equal("mastodon-token", upload.MastodonAccessToken);
+            Assert.Equal("rider", upload.ThreadsUsername);
+            Assert.Equal("threads-token", upload.ThreadsAccessToken);
+            Assert.Null(typeof(FinalizedPhotoUpload).GetProperty("DeviceId"));
+        }
+
+        [Fact]
+        public void DefaultLimitsMatchTheOfflineMobileFallbackWithoutAddingANullVersion()
+        {
+            string json = JsonSerializer.Serialize(new UploadLimits(), JsonOptions);
+            using JsonDocument document = JsonDocument.Parse(json);
+            JsonElement root = document.RootElement;
+
+            Assert.Equal(4, root.GetProperty("maxPhotosPerReport").GetInt32());
+            Assert.Equal(8 * 1024 * 1024, root.GetProperty("maxPhotoBytes").GetInt32());
+            Assert.Equal(32 * 1024 * 1024, root.GetProperty("maxReportBytes").GetInt32());
+            Assert.Equal(47.495082, root.GetProperty("southLatitude").GetDouble());
+            Assert.Equal(-122.436522, root.GetProperty("westLongitude").GetDouble());
+            Assert.Equal(47.735525, root.GetProperty("northLatitude").GetDouble());
+            Assert.Equal(-122.235787, root.GetProperty("eastLongitude").GetDouble());
+            Assert.False(root.TryGetProperty("minimumSupportedAppVersion", out _));
+        }
+
+        [Fact]
+        public void BothClientsUseOneExplicitAttributionEnvelopeAndReceipt()
+        {
+            const string id = "0123456789abcdef0123456789abcdef";
+            FinalizeReportRequest request = new FinalizeReportRequest([new FinalizedPhotoUpload()            {
+                PhotoId = "prepared-photo",
+                SubmissionId = "preparation",
+                PhotoNumber = 0,
+                NumberOfCars = 2
+            }], new ReportAttribution(BlueskyDid: "did:plc:reporter"));
+            string json = JsonSerializer.Serialize(request, JsonOptions);
+            using JsonDocument document = JsonDocument.Parse(json);
+            Assert.Equal("prepared-photo", document.RootElement.GetProperty("photos")[0].GetProperty("photoId").GetString());
+            Assert.Equal("did:plc:reporter", document.RootElement.GetProperty("attribution").GetProperty("blueskyDid").GetString());
+
+            SubmissionReceipt receipt = new SubmissionReceipt(id, id, DateTimeOffset.UtcNow, request.Attribution);
+            Assert.Equal(receipt, JsonSerializer.Deserialize<SubmissionReceipt>(JsonSerializer.Serialize(receipt, JsonOptions), JsonOptions));
+            Assert.True(new ReportAttribution().IsAnonymous);
+            Assert.False(request.Attribution.IsAnonymous);
+        }
+    }
+}

--- a/SeattleCarsInBikeLanes.Core.Tests/Usings.cs
+++ b/SeattleCarsInBikeLanes.Core.Tests/Usings.cs
@@ -1,0 +1,1 @@
+global using Xunit;

--- a/SeattleCarsInBikeLanes.Core/Contracts/ReportContracts.cs
+++ b/SeattleCarsInBikeLanes.Core/Contracts/ReportContracts.cs
@@ -1,0 +1,34 @@
+namespace SeattleCarsInBikeLanes.Core.Contracts
+{
+    /// <summary>Non-secret constraints, never evidence of an authenticated identity.</summary>
+    public sealed record ReportAttribution(
+        string? BlueskyDid = null,
+        string? MastodonServer = null,
+        string? MastodonAccountId = null)
+    {
+        public bool IsAnonymous => BlueskyDid is null && MastodonAccountId is null && MastodonServer is null;
+    }
+
+    public sealed record SubmissionReceipt(
+        string ReportId,
+        string SubmissionId,
+        DateTimeOffset SubmittedAt,
+        ReportAttribution Attribution);
+
+    public sealed record FinalizeReportRequest(
+        List<FinalizedPhotoUpload> Photos,
+        ReportAttribution Attribution);
+
+    public sealed record CredentialIdentity(string AccountId, string DisplayName, DateTimeOffset? ExpiresAt = null);
+
+    public static class UploadErrors
+    {
+        public const string CredentialRejected = "credential_rejected";
+        public const string IdentityMismatch = "identity_mismatch";
+        public const string ProviderUnavailable = "provider_unavailable";
+        public const string ReportInProgress = "report_in_progress";
+        public const string PreparationExpired = "preparation_expired";
+    }
+
+    public sealed record UploadError(string Code, string Message);
+}

--- a/SeattleCarsInBikeLanes.Core/Contracts/UploadContracts.cs
+++ b/SeattleCarsInBikeLanes.Core/Contracts/UploadContracts.cs
@@ -1,0 +1,157 @@
+using System.Text.Json.Serialization;
+
+namespace SeattleCarsInBikeLanes.Core.Contracts
+{
+    /// <summary>
+    /// What <c>POST /api/Upload/Initial</c> returns for each photo.
+    /// </summary>
+    public sealed class InitialPhotoUpload
+    {
+        [JsonPropertyName("uri")]
+        public string Uri { get; set; } = string.Empty;
+
+        [JsonPropertyName("photoId")]
+        public string PhotoId { get; set; } = string.Empty;
+
+        [JsonPropertyName("submissionId")]
+        public string SubmissionId { get; set; } = string.Empty;
+
+        [JsonPropertyName("photoNumber")]
+        public int PhotoNumber { get; set; }
+
+        [JsonPropertyName("photoDateTime")]
+        public DateTime? PhotoDateTime { get; set; }
+
+        [JsonPropertyName("photoLatitude")]
+        public string? PhotoLatitude { get; set; }
+
+        [JsonPropertyName("photoLongitude")]
+        public string? PhotoLongitude { get; set; }
+
+        [JsonPropertyName("photoCrossStreet")]
+        public string? PhotoCrossStreet { get; set; }
+
+        [JsonPropertyName("tags")]
+        public List<ImageTag> Tags { get; set; } = new List<ImageTag>();
+    }
+
+    public sealed class ImageTag
+    {
+        [JsonPropertyName("name")]
+        public string Name { get; set; } = string.Empty;
+
+        [JsonPropertyName("confidence")]
+        public float Confidence { get; set; }
+    }
+
+    /// <summary>
+    /// A prepared photo in the body of <c>POST /api/Upload/Finalize</c>.
+    /// </summary>
+    /// <remarks>
+    /// Contains only fields a client can legitimately set. Device, report, and authenticated Bluesky
+    /// identity fields are derived by the server and are deliberately absent.
+    /// </remarks>
+    public sealed class FinalizedPhotoUpload
+    {
+        [JsonPropertyName("photoId")]
+        public string PhotoId { get; set; } = string.Empty;
+
+        [JsonPropertyName("submissionId")]
+        public string SubmissionId { get; set; } = string.Empty;
+
+        [JsonPropertyName("photoNumber")]
+        public int PhotoNumber { get; set; }
+
+        [JsonPropertyName("photoDateTime")]
+        public DateTime? PhotoDateTime { get; set; }
+
+        [JsonPropertyName("photoLatitude")]
+        public string? PhotoLatitude { get; set; }
+
+        [JsonPropertyName("photoLongitude")]
+        public string? PhotoLongitude { get; set; }
+
+        [JsonPropertyName("photoCrossStreet")]
+        public string? PhotoCrossStreet { get; set; }
+
+        [JsonPropertyName("tags")]
+        public List<ImageTag> Tags { get; set; } = new List<ImageTag>();
+
+        [JsonPropertyName("numberOfCars")]
+        public int? NumberOfCars { get; set; }
+
+        [JsonPropertyName("userSpecifiedDateTime")]
+        public bool UserSpecifiedDateTime { get; set; }
+
+        [JsonPropertyName("userSpecifiedLocation")]
+        public bool UserSpecifiedLocation { get; set; }
+
+        [JsonPropertyName("attribute")]
+        public bool? Attribute { get; set; }
+
+        [JsonPropertyName("twitterSubmittedBy")]
+        public string? TwitterSubmittedBy { get; set; }
+
+        [JsonPropertyName("mastodonSubmittedBy")]
+        public string? MastodonSubmittedBy { get; set; }
+
+        [JsonPropertyName("blueskySubmittedBy")]
+        public string? BlueskySubmittedBy { get; set; }
+
+        [JsonPropertyName("threadsSubmittedBy")]
+        public string? ThreadsSubmittedBy { get; set; }
+
+        [JsonPropertyName("twitterUsername")]
+        public string? TwitterUsername { get; set; }
+
+        [JsonPropertyName("twitterAccessToken")]
+        public string? TwitterAccessToken { get; set; }
+
+        [JsonPropertyName("mastodonEndpoint")]
+        public string? MastodonEndpoint { get; set; }
+
+        [JsonPropertyName("mastodonUsername")]
+        public string? MastodonUsername { get; set; }
+
+        [JsonPropertyName("mastodonFullUsername")]
+        public string? MastodonFullUsername { get; set; }
+
+        [JsonPropertyName("mastodonAccessToken")]
+        public string? MastodonAccessToken { get; set; }
+
+        [JsonPropertyName("threadsUsername")]
+        public string? ThreadsUsername { get; set; }
+
+        [JsonPropertyName("threadsAccessToken")]
+        public string? ThreadsAccessToken { get; set; }
+    }
+
+    /// <summary>
+    /// The limits returned by <c>GET /api/Upload/Limits</c>.
+    /// </summary>
+    public sealed class UploadLimits
+    {
+        [JsonPropertyName("maxPhotosPerReport")]
+        public int MaxPhotosPerReport { get; set; } = 4;
+
+        public int MaxPhotoBytes { get; set; } = 8 * 1024 * 1024;
+
+        public int MaxReportBytes { get; set; } = 32 * 1024 * 1024;
+
+        [JsonPropertyName("southLatitude")]
+        public double SouthLatitude { get; set; } = 47.495082;
+
+        [JsonPropertyName("westLongitude")]
+        public double WestLongitude { get; set; } = -122.436522;
+
+        [JsonPropertyName("northLatitude")]
+        public double NorthLatitude { get; set; } = 47.735525;
+
+        [JsonPropertyName("eastLongitude")]
+        public double EastLongitude { get; set; } = -122.235787;
+
+        [JsonPropertyName("minimumSupportedAppVersion")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string? MinimumSupportedAppVersion { get; set; }
+    }
+}

--- a/SeattleCarsInBikeLanes.Core/SeattleCarsInBikeLanes.Core.csproj
+++ b/SeattleCarsInBikeLanes.Core/SeattleCarsInBikeLanes.Core.csproj
@@ -1,0 +1,11 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <RootNamespace>SeattleCarsInBikeLanes.Core</RootNamespace>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+</Project>

--- a/SeattleCarsInBikeLanes.Tests/AdminDeviceBlocksControllerTests.cs
+++ b/SeattleCarsInBikeLanes.Tests/AdminDeviceBlocksControllerTests.cs
@@ -1,0 +1,592 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Security.Claims;
+using System.Text;
+using System.Text.Encodings.Web;
+using System.Text.Json;
+using idunno.Authentication.Basic;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Azure.Cosmos;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using SeattleCarsInBikeLanes.Controllers;
+using SeattleCarsInBikeLanes.Database;
+using SeattleCarsInBikeLanes.Database.Models;
+using SeattleCarsInBikeLanes.Models;
+
+namespace SeattleCarsInBikeLanes.Tests
+{
+    public class AdminDeviceBlocksControllerTests
+    {
+        private const string Route = "/api/AdminPage/BlockedDevices";
+        private const string DeviceId = "Case-Preserved_123";
+        private const string Reason = "<b>Administrator-only plain text</b>";
+        private const string SocialScheme = "TestSocial";
+
+        [Fact]
+        public async Task GetReturnsOnlyAdminDtosAndForwardsCancellation()
+        {
+            using CancellationTokenSource cancellation = new CancellationTokenSource();
+            Mock<BlockedDevicesDatabase> database = CreateDatabase();
+            database.Setup(d => d.ListAsync(cancellation.Token)).ReturnsAsync(new[]
+            {
+                new BlockedDevice { DeviceId = DeviceId, Reason = Reason },
+                new BlockedDevice { DeviceId = "other", Reason = "Another reason" }
+            });
+            AdminDeviceBlocksController controller = CreateController(database);
+
+            OkObjectResult result = Assert.IsType<OkObjectResult>(await controller.Get(cancellation.Token));
+
+            var devices = Assert.IsType<AdminBlockedDeviceResponse[]>(result.Value);
+            Assert.Equal(new[] { new AdminBlockedDeviceResponse(DeviceId, Reason), new AdminBlockedDeviceResponse("other", "Another reason") }, devices);
+            database.VerifyAll();
+            database.VerifyNoOtherCalls();
+        }
+
+        [Theory]
+        [InlineData(1, 1)]
+        [InlineData(128, 1000)]
+        public async Task MutationsNormalizeWithoutChangingCaseAndAcceptExactBoundaries(int idLength, int reasonLength)
+        {
+            string id = new string('A', idLength);
+            string reason = new string('r', reasonLength);
+            using CancellationTokenSource cancellation = new CancellationTokenSource();
+            Mock<BlockedDevicesDatabase> database = CreateDatabase();
+            database.Setup(d => d.BlockAsync(id, reason, cancellation.Token)).Returns(Task.CompletedTask);
+            database.Setup(d => d.UnblockAsync(id, cancellation.Token)).Returns(Task.CompletedTask);
+            AdminDeviceBlocksController controller = CreateController(database);
+
+            Assert.IsType<NoContentResult>(await controller.Block(
+                new BlockDeviceRequest { DeviceId = $" \t{id}\n ", Reason = $" \n{reason}\t " }, cancellation.Token));
+            Assert.IsType<NoContentResult>(await controller.Unblock(
+                new UnblockDeviceRequest { DeviceId = $" \t{id}\n " }, cancellation.Token));
+
+            database.VerifyAll();
+            database.VerifyNoOtherCalls();
+        }
+
+        [Theory]
+        [MemberData(nameof(BlockedDevicesDatabaseTests.InvalidDeviceIds), MemberType = typeof(BlockedDevicesDatabaseTests))]
+        public async Task InvalidIdsReturn400WithoutStorageAccess(string? deviceId)
+        {
+            Mock<BlockedDevicesDatabase> database = CreateDatabase();
+            AdminDeviceBlocksController controller = CreateController(database);
+
+            Assert.IsType<BadRequestObjectResult>(await controller.Block(new BlockDeviceRequest { DeviceId = deviceId, Reason = Reason }));
+            Assert.IsType<BadRequestObjectResult>(await controller.Unblock(new UnblockDeviceRequest { DeviceId = deviceId }));
+
+            database.VerifyNoOtherCalls();
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData(" \r\n\t")]
+        public async Task MissingReasonReturns400WithoutStorageAccess(string? reason)
+        {
+            Mock<BlockedDevicesDatabase> database = CreateDatabase();
+
+            Assert.IsType<BadRequestObjectResult>(await CreateController(database)
+                .Block(new BlockDeviceRequest { DeviceId = DeviceId, Reason = reason }));
+
+            database.VerifyNoOtherCalls();
+        }
+
+        [Fact]
+        public async Task OverlongTrimmedReasonReturns400WithoutStorageAccess()
+        {
+            Mock<BlockedDevicesDatabase> database = CreateDatabase();
+
+            Assert.IsType<BadRequestObjectResult>(await CreateController(database)
+                .Block(new BlockDeviceRequest { DeviceId = DeviceId, Reason = " " + new string('x', 1001) + " " }));
+
+            database.VerifyNoOtherCalls();
+        }
+
+        [Theory]
+        [InlineData("get")]
+        [InlineData("block")]
+        [InlineData("unblock")]
+        public async Task ExpectedStorageFailuresAreLoggedAndReturnHonest503WithoutExceptionDetails(string operation)
+        {
+            foreach (Exception failure in new Exception[]
+            {
+                new CosmosException(Reason, HttpStatusCode.NotFound, 0, "test", 0),
+                new CosmosException(Reason, HttpStatusCode.Unauthorized, 0, "test", 0),
+                new CosmosException(Reason, HttpStatusCode.Forbidden, 0, "test", 0),
+                new CosmosException(Reason, HttpStatusCode.TooManyRequests, 0, "test", 0),
+                new CosmosException(Reason, HttpStatusCode.ServiceUnavailable, 0, "test", 0),
+                new HttpRequestException(Reason), new TimeoutException(Reason),
+                new Azure.Identity.AuthenticationFailedException(Reason), new Newtonsoft.Json.JsonException(Reason),
+                new OperationCanceledException(Reason)
+            })
+            {
+                Mock<BlockedDevicesDatabase> database = CreateDatabase();
+                SetupFailure(database, operation, failure, CancellationToken.None);
+                Mock<ILogger<AdminDeviceBlocksController>> logger = new Mock<ILogger<AdminDeviceBlocksController>>();
+                AdminDeviceBlocksController controller = CreateController(database, logger.Object);
+
+                ObjectResult result = Assert.IsType<ObjectResult>(await Invoke(controller, operation));
+
+                Assert.Equal(StatusCodes.Status503ServiceUnavailable, result.StatusCode);
+                string message = Assert.IsType<string>(result.Value);
+                Assert.Contains("Refresh", message);
+                Assert.DoesNotContain(Reason, message);
+                Assert.DoesNotContain(DeviceId, message);
+                VerifyLoggedFailure(logger, failure);
+                database.VerifyAll();
+            }
+        }
+
+        [Theory]
+        [InlineData("get")]
+        [InlineData("block")]
+        [InlineData("unblock")]
+        public async Task UnexpectedErrorsPropagateWithoutBeingReportedAsStorageOutage(string operation)
+        {
+            Mock<BlockedDevicesDatabase> database = CreateDatabase();
+            InvalidOperationException failure = new InvalidOperationException("Programming failure");
+            SetupFailure(database, operation, failure, CancellationToken.None);
+            Mock<ILogger<AdminDeviceBlocksController>> logger = new Mock<ILogger<AdminDeviceBlocksController>>();
+
+            Assert.Same(failure, await Assert.ThrowsAsync<InvalidOperationException>(() =>
+                Invoke(CreateController(database, logger.Object), operation)));
+
+            logger.VerifyNoOtherCalls();
+        }
+
+        [Theory]
+        [InlineData("get")]
+        [InlineData("block")]
+        [InlineData("unblock")]
+        public async Task CallerCancellationBeforeAndDuringStoragePropagatesWithoutLoggingAnOutage(string operation)
+        {
+            using CancellationTokenSource cancellation = new CancellationTokenSource();
+            Mock<BlockedDevicesDatabase> database = CreateDatabase();
+            Mock<ILogger<AdminDeviceBlocksController>> logger = new Mock<ILogger<AdminDeviceBlocksController>>();
+            AdminDeviceBlocksController controller = CreateController(database, logger.Object);
+            OperationCanceledException failure = new OperationCanceledException(cancellation.Token);
+            SetupFailure(database, operation, failure, cancellation.Token, cancellation.Cancel);
+
+            Assert.Same(failure, await Assert.ThrowsAsync<OperationCanceledException>(() =>
+                Invoke(controller, operation, cancellation.Token)));
+
+            database.VerifyAll();
+            database.Invocations.Clear();
+            var preCanceled = await Assert.ThrowsAsync<OperationCanceledException>(() =>
+                Invoke(controller, operation, cancellation.Token));
+            Assert.Equal(cancellation.Token, preCanceled.CancellationToken);
+            database.VerifyNoOtherCalls();
+            logger.VerifyNoOtherCalls();
+        }
+
+        [Theory]
+        [InlineData("get")]
+        [InlineData("block")]
+        [InlineData("unblock")]
+        public async Task CallerCancellationTakesPriorityOverConcurrentStorageFailures(string operation)
+        {
+            foreach (Exception failure in new Exception[]
+            {
+                new CosmosException("Unavailable", HttpStatusCode.ServiceUnavailable, 0, "test", 0),
+                new HttpRequestException("Offline"), new TimeoutException("Timeout"),
+                new Azure.Identity.AuthenticationFailedException("Unavailable credentials"),
+                new Newtonsoft.Json.JsonException("Invalid stored document")
+            })
+            {
+                using CancellationTokenSource cancellation = new CancellationTokenSource();
+                Mock<BlockedDevicesDatabase> database = CreateDatabase();
+                Mock<ILogger<AdminDeviceBlocksController>> logger = new Mock<ILogger<AdminDeviceBlocksController>>();
+                SetupFailure(database, operation, failure, cancellation.Token, cancellation.Cancel);
+
+                var error = await Assert.ThrowsAsync<OperationCanceledException>(() =>
+                    Invoke(CreateController(database, logger.Object), operation, cancellation.Token));
+
+                Assert.Equal(cancellation.Token, error.CancellationToken);
+                logger.VerifyNoOtherCalls();
+                database.VerifyAll();
+            }
+        }
+
+        [Fact]
+        public async Task HttpRoutesRequireActualBasicAuthenticationNotDefaultSocialOrMobileCredentials()
+        {
+            Mock<BlockedDevicesDatabase> database = CreateDatabase();
+            await using ApiHost host = await ApiHost.Start(database);
+            foreach (string credential in new[] { "none", "wrong-basic", "bearer", "cookie", "wrong-basic-with-cookie" })
+            {
+                if (credential is "bearer" or "cookie")
+                {
+                    using HttpRequestMessage socialRequest = new HttpRequestMessage(HttpMethod.Get, "/test/social-identity");
+                    SetNonAdminCredential(socialRequest, credential);
+                    using HttpResponseMessage socialResponse = await host.Client.SendAsync(socialRequest);
+                    Assert.Equal(HttpStatusCode.OK, socialResponse.StatusCode);
+                    Assert.Equal("true", await socialResponse.Content.ReadAsStringAsync());
+                }
+
+                foreach (HttpMethod method in new[] { HttpMethod.Get, HttpMethod.Post, HttpMethod.Delete })
+                {
+                    using HttpRequestMessage request = Request(method, """{"deviceId":"Case-Preserved_123","reason":"private"}""", authenticated: false);
+                    SetNonAdminCredential(request, credential);
+                    using HttpResponseMessage response = await host.Client.SendAsync(request);
+
+                    Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+                    Assert.Contains(response.Headers.WwwAuthenticate, challenge => challenge.Scheme == "Basic");
+                    Assert.DoesNotContain(Reason, await response.Content.ReadAsStringAsync());
+                }
+            }
+
+            database.VerifyNoOtherCalls();
+        }
+
+        [Fact]
+        public async Task HttpRoutesUseJsonAdminDtoNoStoreAndIdempotentMutations()
+        {
+            Dictionary<string, string> items = new Dictionary<string, string>(StringComparer.Ordinal);
+            Mock<BlockedDevicesDatabase> database = CreateDatabase();
+            database.Setup(d => d.BlockAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .Callback<string, string, CancellationToken>((id, reason, token) =>
+                {
+                    Assert.True(token.CanBeCanceled);
+                    items[id] = reason;
+                })
+                .Returns(Task.CompletedTask);
+            database.Setup(d => d.UnblockAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .Callback<string, CancellationToken>((id, token) =>
+                {
+                    Assert.True(token.CanBeCanceled);
+                    items.Remove(id);
+                })
+                .Returns(Task.CompletedTask);
+            database.Setup(d => d.ListAsync(It.IsAny<CancellationToken>()))
+                .Returns((CancellationToken token) =>
+                {
+                    Assert.True(token.CanBeCanceled);
+                    return Task.FromResult<IReadOnlyList<BlockedDevice>>(items.Select(item =>
+                        new BlockedDevice { DeviceId = item.Key, Reason = item.Value }).ToArray());
+                });
+            await using ApiHost host = await ApiHost.Start(database);
+            string body = JsonSerializer.Serialize(new { deviceId = $" \t{DeviceId}\n ", reason = $" \n{Reason}\t " });
+            for (int retry = 0; retry < 2; retry++)
+            {
+                using HttpRequestMessage blockRequest = Request(HttpMethod.Post, body);
+                using HttpResponseMessage blockResponse = await host.Client.SendAsync(blockRequest);
+                Assert.Equal(HttpStatusCode.NoContent, blockResponse.StatusCode);
+                Assert.Equal("", await blockResponse.Content.ReadAsStringAsync());
+            }
+
+            using (HttpRequestMessage listRequest = Request(HttpMethod.Get))
+            using (HttpResponseMessage listResponse = await host.Client.SendAsync(listRequest))
+            {
+                Assert.Equal(HttpStatusCode.OK, listResponse.StatusCode);
+                Assert.True(listResponse.Headers.CacheControl?.NoStore);
+                using JsonDocument json = JsonDocument.Parse(await listResponse.Content.ReadAsStringAsync());
+                JsonElement item = Assert.Single(json.RootElement.EnumerateArray());
+                Assert.Equal(new[] { "deviceId", "reason" }, item.EnumerateObject().Select(property => property.Name));
+                Assert.Equal(DeviceId, item.GetProperty("deviceId").GetString());
+                Assert.Equal(Reason, item.GetProperty("reason").GetString());
+            }
+
+            for (int retry = 0; retry < 2; retry++)
+            {
+                using HttpRequestMessage unblockRequest = Request(HttpMethod.Delete, JsonSerializer.Serialize(new { deviceId = $" {DeviceId} " }));
+                using HttpResponseMessage unblockResponse = await host.Client.SendAsync(unblockRequest);
+                Assert.Equal(HttpStatusCode.NoContent, unblockResponse.StatusCode);
+            }
+            using HttpRequestMessage emptyListRequest = Request(HttpMethod.Get);
+            using HttpResponseMessage emptyListResponse = await host.Client.SendAsync(emptyListRequest);
+            Assert.Equal(HttpStatusCode.OK, emptyListResponse.StatusCode);
+            Assert.Equal("[]", await emptyListResponse.Content.ReadAsStringAsync());
+            database.Verify(d => d.BlockAsync(DeviceId, Reason, It.IsAny<CancellationToken>()), Times.Exactly(2));
+            database.Verify(d => d.UnblockAsync(DeviceId, It.IsAny<CancellationToken>()), Times.Exactly(2));
+            database.Verify(d => d.ListAsync(It.IsAny<CancellationToken>()), Times.Exactly(2));
+            database.VerifyNoOtherCalls();
+        }
+
+        [Fact]
+        public async Task HttpMutationBindingRejectsInvalidJsonIdsAndReasonsBeforeStorage()
+        {
+            Mock<BlockedDevicesDatabase> database = CreateDatabase();
+            await using ApiHost host = await ApiHost.Start(database);
+            List<string> commonInvalidBodies = new List<string>
+            {
+                "", "null", "[]", "{", "{}", """{"deviceId":null}""", """{"deviceId":42}""",
+                """{"deviceId":""}""", """{"deviceId":" \t"}""", """{"deviceId":"a/b"}""",
+                """{"deviceId":"a b"}""", """{"deviceId":"é"}""",
+                JsonSerializer.Serialize(new { deviceId = new string('a', 129), reason = Reason })
+            };
+            foreach (HttpMethod method in new[] { HttpMethod.Post, HttpMethod.Delete })
+            {
+                foreach (string body in commonInvalidBodies)
+                {
+                    using HttpRequestMessage request = Request(method, body);
+                    using HttpResponseMessage response = await host.Client.SendAsync(request);
+                    Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+                }
+            }
+            foreach (string body in new[]
+            {
+                """{"deviceId":"valid"}""", """{"deviceId":"valid","reason":null}""",
+                """{"deviceId":"valid","reason":""}""", """{"deviceId":"valid","reason":" \t\n"}""",
+                """{"deviceId":"valid","reason":42}""",
+                JsonSerializer.Serialize(new { deviceId = "valid", reason = " " + new string('r', 1001) + " " })
+            })
+            {
+                using HttpRequestMessage request = Request(HttpMethod.Post, body);
+                using HttpResponseMessage response = await host.Client.SendAsync(request);
+                Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+            }
+
+            database.VerifyNoOtherCalls();
+        }
+
+        [Fact]
+        public async Task HttpMutationsRejectNonJsonAndDoNotHaveGetOrLegacyAliases()
+        {
+            Mock<BlockedDevicesDatabase> database = CreateDatabase();
+            await using ApiHost host = await ApiHost.Start(database);
+            foreach (HttpMethod method in new[] { HttpMethod.Post, HttpMethod.Delete })
+            {
+                foreach (string contentType in new[] { "text/plain", "application/x-www-form-urlencoded", "text/json" })
+                {
+                    using HttpRequestMessage request = Request(method, """{"deviceId":"valid","reason":"reason"}""");
+                    request.Content!.Headers.ContentType = new MediaTypeHeaderValue(contentType);
+                    using HttpResponseMessage response = await host.Client.SendAsync(request);
+                    Assert.Equal(HttpStatusCode.UnsupportedMediaType, response.StatusCode);
+                }
+            }
+            using (HttpRequestMessage put = Request(HttpMethod.Put, """{"deviceId":"valid","reason":"reason"}"""))
+            using (HttpResponseMessage response = await host.Client.SendAsync(put))
+            {
+                Assert.Equal(HttpStatusCode.MethodNotAllowed, response.StatusCode);
+            }
+            foreach (string path in new[] { Route + "/Block", Route + "/Unblock", "/api/AdminDeviceBlocks" })
+            {
+                using HttpRequestMessage request = Request(HttpMethod.Get);
+                request.RequestUri = new Uri(path, UriKind.Relative);
+                using HttpResponseMessage response = await host.Client.SendAsync(request);
+                Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+            }
+
+            database.VerifyNoOtherCalls();
+        }
+
+        [Fact]
+        public async Task HttpFailuresReturn503RatherThanSuccessOrAnEmptyList()
+        {
+            Mock<BlockedDevicesDatabase> database = CreateDatabase();
+            CosmosException failure = new CosmosException(Reason, HttpStatusCode.Forbidden, 0, "test", 0);
+            database.Setup(d => d.ListAsync(It.IsAny<CancellationToken>())).ThrowsAsync(failure);
+            database.Setup(d => d.BlockAsync(DeviceId, Reason, It.IsAny<CancellationToken>())).ThrowsAsync(failure);
+            database.Setup(d => d.UnblockAsync(DeviceId, It.IsAny<CancellationToken>())).ThrowsAsync(failure);
+            await using ApiHost host = await ApiHost.Start(database);
+            foreach (HttpMethod method in new[] { HttpMethod.Get, HttpMethod.Post, HttpMethod.Delete })
+            {
+                using HttpRequestMessage request = Request(method, JsonSerializer.Serialize(new { deviceId = DeviceId, reason = Reason }));
+                using HttpResponseMessage response = await host.Client.SendAsync(request);
+
+                Assert.Equal(HttpStatusCode.ServiceUnavailable, response.StatusCode);
+                string message = await response.Content.ReadAsStringAsync();
+                Assert.Contains("Refresh", message);
+                Assert.DoesNotContain(Reason, message);
+                Assert.NotEqual("[]", message);
+                if (method == HttpMethod.Get)
+                {
+                    Assert.True(response.Headers.CacheControl?.NoStore);
+                }
+            }
+            database.VerifyAll();
+        }
+
+        [Fact]
+        public async Task HttpRequestCancellationReachesTheDatabase()
+        {
+            TaskCompletionSource started = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            TaskCompletionSource<bool> canceled = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            Mock<BlockedDevicesDatabase> database = CreateDatabase();
+            database.Setup(d => d.ListAsync(It.IsAny<CancellationToken>()))
+                .Returns(async (CancellationToken token) =>
+                {
+                    started.TrySetResult();
+                    try
+                    {
+                        await Task.Delay(Timeout.InfiniteTimeSpan, token);
+                        return (IReadOnlyList<BlockedDevice>)Array.Empty<BlockedDevice>();
+                    }
+                    finally
+                    {
+                        canceled.TrySetResult(token.IsCancellationRequested);
+                    }
+                });
+            await using ApiHost host = await ApiHost.Start(database);
+            using CancellationTokenSource cancellation = new CancellationTokenSource();
+            using HttpRequestMessage request = Request(HttpMethod.Get);
+            Task<HttpResponseMessage> response = host.Client.SendAsync(request, cancellation.Token);
+            await started.Task.WaitAsync(TimeSpan.FromSeconds(10));
+
+            cancellation.Cancel();
+
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => response);
+            Assert.True(await canceled.Task.WaitAsync(TimeSpan.FromSeconds(10)));
+            database.Verify(d => d.ListAsync(It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        private static Mock<BlockedDevicesDatabase> CreateDatabase() =>
+            new Mock<BlockedDevicesDatabase>(MockBehavior.Strict, NullLogger<BlockedDevicesDatabase>.Instance, Mock.Of<Container>());
+
+        private static AdminDeviceBlocksController CreateController(Mock<BlockedDevicesDatabase> database,
+            ILogger<AdminDeviceBlocksController>? logger = null) =>
+            new AdminDeviceBlocksController(logger ?? NullLogger<AdminDeviceBlocksController>.Instance, database.Object);
+
+        private static Task<IActionResult> Invoke(AdminDeviceBlocksController controller, string operation, CancellationToken token = default) =>
+            operation switch
+            {
+                "get" => controller.Get(token),
+                "block" => controller.Block(new BlockDeviceRequest { DeviceId = DeviceId, Reason = Reason }, token),
+                "unblock" => controller.Unblock(new UnblockDeviceRequest { DeviceId = DeviceId }, token),
+                _ => throw new ArgumentOutOfRangeException(nameof(operation))
+            };
+
+        private static void SetupFailure(Mock<BlockedDevicesDatabase> database, string operation, Exception failure,
+            CancellationToken token, Action? beforeFailure = null)
+        {
+            Action callback = beforeFailure ?? (() => { });
+            switch (operation)
+            {
+                case "get":
+                    database.Setup(d => d.ListAsync(token)).Callback(callback).ThrowsAsync(failure);
+                    break;
+                case "block":
+                    database.Setup(d => d.BlockAsync(DeviceId, Reason, token)).Callback(callback).ThrowsAsync(failure);
+                    break;
+                case "unblock":
+                    database.Setup(d => d.UnblockAsync(DeviceId, token)).Callback(callback).ThrowsAsync(failure);
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(operation));
+            }
+        }
+
+        private static void VerifyLoggedFailure(Mock<ILogger<AdminDeviceBlocksController>> logger, Exception failure)
+        {
+            logger.Verify(l => l.Log(LogLevel.Error, It.IsAny<EventId>(), It.IsAny<It.IsAnyType>(), failure,
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()), Times.Once);
+        }
+
+        private static HttpRequestMessage Request(HttpMethod method, string? body = null, bool authenticated = true)
+        {
+            HttpRequestMessage request = new HttpRequestMessage(method, Route);
+            if (body is not null && method != HttpMethod.Get)
+            {
+                request.Content = new StringContent(body, Encoding.UTF8, "application/json");
+            }
+            if (authenticated)
+            {
+                request.Headers.Authorization = new AuthenticationHeaderValue("Basic",
+                    Convert.ToBase64String(Encoding.UTF8.GetBytes("test-admin:test-password")));
+            }
+            return request;
+        }
+
+        private static void SetNonAdminCredential(HttpRequestMessage request, string credential)
+        {
+            if (credential is "wrong-basic" or "wrong-basic-with-cookie")
+            {
+                request.Headers.Authorization = new AuthenticationHeaderValue("Basic",
+                    Convert.ToBase64String(Encoding.UTF8.GetBytes("test-admin:incorrect")));
+            }
+            if (credential == "bearer")
+            {
+                request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", "social-token");
+            }
+            if (credential is "cookie" or "wrong-basic-with-cookie")
+            {
+                request.Headers.Add("Cookie", "test-social=session");
+            }
+        }
+
+        private sealed class ApiHost : IAsyncDisposable
+        {
+            private readonly WebApplication app;
+            public HttpClient Client { get; }
+
+            private ApiHost(WebApplication app)
+            {
+                this.app = app;
+                Client = new HttpClient { BaseAddress = new Uri(app.Urls.Single()) };
+            }
+
+            public static async Task<ApiHost> Start(Mock<BlockedDevicesDatabase> database)
+            {
+                WebApplicationBuilder builder = WebApplication.CreateBuilder();
+                builder.Logging.ClearProviders();
+                builder.WebHost.ConfigureKestrel(options => options.Listen(IPAddress.Loopback, 0));
+                builder.Services.AddControllers().AddApplicationPart(typeof(AdminDeviceBlocksController).Assembly);
+                builder.Services.AddSingleton(database.Object);
+                // Deliberately use a non-admin default to prove the controller requires Basic explicitly.
+                builder.Services.AddAuthentication(SocialScheme)
+                    .AddScheme<AuthenticationSchemeOptions, SocialAuthenticationHandler>(SocialScheme, _ => { })
+                    .AddBasic(options =>
+                    {
+                        options.Realm = "Admin page";
+                        options.AllowInsecureProtocol = true;
+                        options.Events = new BasicAuthenticationEvents
+                        {
+                            OnValidateCredentials = context =>
+                            {
+                                if (context.Username == "test-admin" && context.Password == "test-password")
+                                {
+                                    context.Principal = new ClaimsPrincipal(new ClaimsIdentity(
+                                        new[] { new Claim(ClaimTypes.NameIdentifier, context.Username) },
+                                        BasicAuthenticationDefaults.AuthenticationScheme));
+                                    context.Success();
+                                }
+                                return Task.CompletedTask;
+                            }
+                        };
+                    });
+                builder.Services.AddAuthorization();
+                WebApplication app = builder.Build();
+                app.UseAuthentication();
+                app.UseAuthorization();
+                app.MapControllers();
+                app.MapGet("/test/social-identity", (HttpContext context) => Results.Ok(context.User.Identity!.IsAuthenticated))
+                    .RequireAuthorization();
+                await app.StartAsync();
+                return new ApiHost(app);
+            }
+
+            public async ValueTask DisposeAsync()
+            {
+                Client.Dispose();
+                await app.DisposeAsync();
+            }
+        }
+
+        public sealed class SocialAuthenticationHandler : AuthenticationHandler<AuthenticationSchemeOptions>
+        {
+            public SocialAuthenticationHandler(IOptionsMonitor<AuthenticationSchemeOptions> options, ILoggerFactory logger, UrlEncoder encoder)
+                : base(options, logger, encoder)
+            {
+            }
+
+            protected override Task<AuthenticateResult> HandleAuthenticateAsync()
+            {
+                if (Request.Headers.Authorization == "Bearer social-token" || Request.Cookies["test-social"] == "session")
+                {
+                    ClaimsPrincipal principal = new ClaimsPrincipal(new ClaimsIdentity(
+                        new[] { new Claim(ClaimTypes.NameIdentifier, "social-user") }, SocialScheme));
+                    return Task.FromResult(AuthenticateResult.Success(new AuthenticationTicket(principal, SocialScheme)));
+                }
+                return Task.FromResult(AuthenticateResult.NoResult());
+            }
+        }
+    }
+}

--- a/SeattleCarsInBikeLanes.Tests/AdminModerationTests.cs
+++ b/SeattleCarsInBikeLanes.Tests/AdminModerationTests.cs
@@ -1,0 +1,985 @@
+using Azure;
+using Azure.Storage.Blobs;
+using Azure.Storage.Blobs.Models;
+using Azure.Storage.Sas;
+using golf1052.atproto.net.Models.AtProto.Repo;
+using golf1052.atproto.net.Models.Bsky.Feed;
+using golf1052.atproto.net.Models.Bsky.Richtext;
+using golf1052.Mastodon.Models.Statuses;
+using golf1052.Mastodon.Models.Statuses.Media;
+using golf1052.ThreadsAPI.Models;
+using Imgur.API.Models;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using Newtonsoft.Json;
+using SeattleCarsInBikeLanes.Core.Contracts;
+using SeattleCarsInBikeLanes.Database.Models;
+using SeattleCarsInBikeLanes.Providers;
+using SeattleCarsInBikeLanes.Storage.Models;
+using static SeattleCarsInBikeLanes.Controllers.AdminPageController;
+
+namespace SeattleCarsInBikeLanes.Tests
+{
+    public partial class AdminPageControllerTests
+    {
+        private const string ReportId = "0123456789abcdef0123456789abcdef";
+
+        private static SubmissionReport SavedReport(int count = 2)
+        {
+            var photos = Enumerable.Range(0, count).Select(index =>
+                                    {
+                                        FinalizedPhotoUploadMetadata metadata = new FinalizedPhotoUploadMetadata()
+                                        {
+                                            ReportId = ReportId,
+                                            SubmissionId = "original-submission",
+                                            PhotoId = $"photo-{index}",
+                                            PhotoNumber = index,
+                                            NumberOfCars = 1,
+                                            PhotoDateTime = new DateTime(2026, 9, 1, 12, 30, 0),
+                                            PhotoLatitude = "47.62",
+                                            PhotoLongitude = "-122.33",
+                                            PhotoCrossStreet = "Original street",
+                                            Tags = [new ImageTag() { Name = "bicycle", Confidence = .9f }],
+                                            BlueskyUserDid = "did:plc:original",
+                                            BlueskyHandle = "original.example",
+                                            TwitterSubmittedBy = "Submission",
+                                            MastodonSubmittedBy = "Submission",
+                                            BlueskySubmittedBy = "Submission",
+                                            ThreadsSubmittedBy = "Submission"
+                                        };
+                                        return new SubmissionPhoto(metadata, $"{ReportStore.PhotoPrefix}{ReportId}/attempt/{index}.jpeg", "\"photo-version\"", 3);
+                                    }).ToList();
+            return new SubmissionReport(new SubmissionReceipt(ReportId, "original-submission", DateTimeOffset.UtcNow,
+                new ReportAttribution(BlueskyDid: "did:plc:original")), "installation", photos)
+            {
+                Version = "\"report-version\""
+            };
+        }
+
+        private static ModerateReportRequest RequestFor(SubmissionReport report)
+        {
+            return new ModerateReportRequest()
+            {
+                ReportId = report.Receipt.ReportId,
+                ReportVersion = report.Version!,
+                PhotoIds = report.Photos.Select(p => p.Metadata.PhotoId).ToList(),
+                Edits = new AdminPublicationEdits()
+                {
+                    NumberOfCars = 3,
+                    PhotoDateTime = new DateTime(2026, 9, 2, 13, 45, 0),
+                    PhotoLatitude = "47.61",
+                    PhotoLongitude = "-122.32",
+                    PhotoCrossStreet = "Corrected street",
+                    TwitterSubmittedBy = "Corrected Twitter text",
+                    MastodonSubmittedBy = "Corrected Mastodon text",
+                    BlueskySubmittedBy = "Corrected Bluesky text",
+                    ThreadsSubmittedBy = "Corrected Threads text",
+                    TwitterLink = "https://x.com/example/status/1"
+                }
+            };
+        }
+
+        private void SetupReport(SubmissionReport report, Action<IReadOnlyList<FinalizedPhotoUploadMetadata>?>? inspect = null)
+        {
+            mockReportStore.Setup(s => s.GetForModerationAsync(report.Receipt.ReportId, It.IsAny<CancellationToken>()))
+                                        .ReturnsAsync(report);
+            mockReportStore.Setup(s => s.BeginModerationAsync(report.Receipt.ReportId, It.IsAny<string>(),
+                    It.IsAny<IReadOnlyList<FinalizedPhotoUploadMetadata>?>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync((string id, string kind, IReadOnlyList<FinalizedPhotoUploadMetadata>? edits, string? version, CancellationToken ct) =>
+                {
+                    Assert.Equal(report.Version, version);
+                    inspect?.Invoke(edits);
+                    return report with
+                    {
+                        Photos = report.Photos.Select((p, i) => p with { Metadata = edits?[i] ?? p.Metadata }).ToList(),
+                        Moderation = new ModerationOperation("operation", kind, DateTimeOffset.UtcNow),
+                        Version = "\"owned\""
+                    };
+                });
+        }
+
+        private Mock<BlobClient> SetupJpeg(SubmissionPhoto photo)
+        {
+            Mock<BlobClient> blob = new Mock<BlobClient>();
+            mockBlobContainerClient!.Setup(c => c.GetBlobClient(photo.BlobName)).Returns(blob.Object);
+            blob.Setup(b => b.GetPropertiesAsync(It.IsAny<BlobRequestConditions>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(Response.FromValue(BlobsModelFactory.BlobProperties(contentLength: photo.Length,
+                    eTag: new ETag(photo.ETag)), Mock.Of<Response>()));
+            blob.Setup(b => b.DownloadContentAsync(It.IsAny<BlobDownloadOptions>(), It.IsAny<CancellationToken>()))
+                .Callback<BlobDownloadOptions, CancellationToken>((options, _) => Assert.Equal(photo.ETag, options.Conditions.IfMatch.ToString()))
+                .ReturnsAsync(Response.FromValue(BlobsModelFactory.BlobDownloadResult(
+                    BinaryData.FromBytes(new byte[] { 1, 2, 3 })), Mock.Of<Response>()));
+            blob.SetupGet(b => b.CanGenerateSasUri).Returns(true);
+            blob.Setup(b => b.GenerateSasUri(BlobSasPermissions.Read, It.IsAny<DateTimeOffset>()))
+                .Returns(new Uri($"https://storage.example/{photo.BlobName}?sig=test"));
+            return blob;
+        }
+
+        private void SetupPending(params SubmissionReport[] reports)
+        {
+            mockReportStore.Setup(s => s.GetPendingAsync(It.IsAny<CancellationToken>())).Returns(Enumerate(reports));
+            SetupLegacyListing([]);
+        }
+
+        private static async IAsyncEnumerable<SubmissionReport> Enumerate(IEnumerable<SubmissionReport> reports)
+        {
+            await Task.CompletedTask;
+            foreach (var report in reports)
+            {
+                yield return report;
+            }
+        }
+
+        private void SetupLegacyListing(IReadOnlyList<(string Name, string Json)> sidecars)
+        {
+            var blobs = sidecars.Select(pair => BlobsModelFactory.BlobItem(name: pair.Name)).ToList();
+            mockBlobContainerClient!.Setup(c => c.GetBlobsAsync(BlobTraits.None, BlobStates.None, "finalizedupload/", It.IsAny<CancellationToken>()))
+                .Returns(AsyncPageable<BlobItem>.FromPages([Page<BlobItem>.FromValues(blobs, null, Mock.Of<Response>())]));
+            foreach (var pair in sidecars)
+            {
+                Mock<BlobClient> blob = new Mock<BlobClient>();
+                blob.Setup(b => b.DownloadContentAsync(It.IsAny<CancellationToken>()))
+                    .ReturnsAsync(Response.FromValue(BlobsModelFactory.BlobDownloadResult(BinaryData.FromString(pair.Json),
+                        BlobsModelFactory.BlobDownloadDetails(eTag: new ETag("\"sidecar-version\""))), Mock.Of<Response>()));
+                mockBlobContainerClient.Setup(c => c.GetBlobClient(pair.Name)).Returns(blob.Object);
+            }
+        }
+
+        private SubmissionReport SetupLegacy(int count = 2)
+        {
+            var original = SavedReport(count);
+            string id = ReportStore.LegacyReportId(original.Receipt.SubmissionId);
+            var report = original with
+            {
+                Receipt = original.Receipt with
+                {
+                    ReportId = id
+                },
+                DeviceId = null,
+                Photos = original.Photos.Select(p => p with { BlobName = $"finalizedupload/{p.Metadata.PhotoId}.jpeg" }).ToList()
+            };
+            SetupPending();
+            SetupLegacyListing(report.Photos.Select(p => ($"finalizedupload/{p.Metadata.PhotoId}.json", JsonConvert.SerializeObject(p.Metadata))).ToList());
+            foreach (var photo in report.Photos)
+            {
+                SetupJpeg(photo);
+            }
+
+            return report;
+        }
+
+        [Fact]
+        public async Task Pending_UsesJpegReferencesAndShowsOwnerWithoutSecrets()
+        {
+            var report = SavedReport() with
+            {
+                Moderation = new ModerationOperation("owner", "publishing", DateTimeOffset.UtcNow)
+            };
+            report.Photos[0].Metadata.BlueskyAccessJwt = "secret";
+            SetupPending(report);
+            var jpegs = report.Photos.Select(SetupJpeg).ToList();
+            var pending = await controller!.GetPendingPhotos();
+            var photos = pending[ReportId];
+            Assert.Equal(2, photos.Count);
+            Assert.All(photos, photo =>
+            {
+                Assert.Equal(report.Version, photo.ReportVersion);
+                Assert.Equal("installation", photo.DeviceId);
+                Assert.Equal("publishing", photo.ModerationStatus);
+                Assert.Equal("owner", photo.ModerationOperationId);
+                Assert.False(photo.CanModerate);
+                Assert.StartsWith("https://storage.example/", photo.Uri);
+                Assert.Contains("in progress", photo.Warning);
+            });
+            string json = JsonConvert.SerializeObject(pending);
+            Assert.DoesNotContain("secret", json);
+            Assert.DoesNotContain("base64", json);
+            foreach (var jpeg in jpegs)
+            {
+                jpeg.Verify(b => b.DownloadContentAsync(It.IsAny<BlobDownloadOptions>(), It.IsAny<CancellationToken>()), Times.Never);
+            }
+
+            mockReportStore.Verify(s => s.AdoptLegacyAsync(It.IsAny<string>(), It.IsAny<IReadOnlyList<SubmissionPhoto>>(), It.IsAny<CancellationToken>()), Times.Never);
+        }
+
+        [Fact]
+        public async Task LegacyListing_IsReadOnlyAndPreservesOriginalGrouping()
+        {
+            var report = SetupLegacy();
+            var pending = await controller!.GetPendingPhotos();
+            var photos = Assert.Single(pending).Value;
+            Assert.Equal(2, photos.Count);
+            Assert.Equal([0, 1], photos.Select(p => p.PhotoNumber));
+            Assert.All(photos, photo =>
+            {
+                Assert.Equal(report.Receipt.SubmissionId, photo.SubmissionId);
+                Assert.Equal(report.Receipt.ReportId, photo.ReportId);
+                Assert.StartsWith("legacy:", photo.ReportVersion);
+                Assert.True(photo.CanModerate);
+            });
+            mockReportStore.Verify(s => s.AdoptLegacyAsync(It.IsAny<string>(), It.IsAny<IReadOnlyList<SubmissionPhoto>>(), It.IsAny<CancellationToken>()), Times.Never);
+        }
+
+        [Fact]
+        public async Task Pending_SharedFinalizedRootDoesNotInterpretNestedRecordsAsPhotoSidecars()
+        {
+            var existing = SetupLegacy(1);
+            var current = SavedReport(1);
+            foreach (var photo in current.Photos)
+            {
+                SetupJpeg(photo);
+            }
+
+            mockReportStore.Setup(s => s.GetPendingAsync(It.IsAny<CancellationToken>())).Returns(Enumerate([current]));
+            string record = $"{ReportStore.BlobPrefix}{ReportId}.json";
+            string nested = $"{ReportStore.PhotoPrefix}{ReportId}/attempt/unrelated.json";
+            SetupLegacyListing([
+                ($"finalizedupload/{existing.Photos[0].Metadata.PhotoId}.json",
+                    JsonConvert.SerializeObject(existing.Photos[0].Metadata)),
+                (record, "{not a per-photo sidecar"),
+                (nested, "{not a per-photo sidecar")
+            ]);
+
+            var pending = await controller!.GetPendingPhotos();
+
+            Assert.Equal(2, pending.Count);
+            Assert.True(Assert.Single(pending[existing.Receipt.ReportId]).CanModerate);
+            Assert.True(Assert.Single(pending[ReportId]).CanModerate);
+            mockBlobContainerClient!.Verify(c => c.GetBlobClient(record), Times.Never);
+            mockBlobContainerClient.Verify(c => c.GetBlobClient(nested), Times.Never);
+        }
+
+        [Fact]
+        public async Task LegacyDelete_AdoptsFullServerReadSetBeforeOwnershipAndRetirement()
+        {
+            var report = SetupLegacy();
+            SetupReport(report);
+            var pending = (await controller!.GetPendingPhotos())[report.Receipt.ReportId];
+            var request = RequestFor(report);
+            request.ReportVersion = pending[0].ReportVersion!;
+            request.LegacySubmissionId = report.Receipt.SubmissionId;
+            bool adopted = false, owned = false, retired = false;
+            mockReportStore.Setup(s => s.AdoptLegacyAsync(report.Receipt.SubmissionId, It.IsAny<IReadOnlyList<SubmissionPhoto>>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync((string _, IReadOnlyList<SubmissionPhoto> photos, CancellationToken _) =>
+                {
+                    Assert.Equal(report.Photos.Select(p => p.BlobName), photos.Select(p => p.BlobName));
+                    Assert.All(photos, p =>
+                    {
+                        Assert.Equal(3, p.Length);
+                        Assert.Equal("\"photo-version\"", p.ETag);
+                    });
+                    adopted = true;
+                    return report;
+                });
+            mockReportStore.Setup(s => s.BeginModerationAsync(report.Receipt.ReportId, "deleting", null, report.Version, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(() =>
+                {
+                    Assert.True(adopted);
+                    owned = true;
+                    return report with
+                    {
+                        Moderation = new ModerationOperation("operation", "deleting", DateTimeOffset.UtcNow)
+                    };
+                });
+            mockReportStore.Setup(s => s.RetireAsync(report.Receipt.ReportId, "operation", It.IsAny<CancellationToken>()))
+                .Callback(() =>
+                {
+                    Assert.True(owned);
+                    retired = true;
+                }).Returns(Task.CompletedTask);
+            mockReportStore.Setup(s => s.CleanupAsync(It.IsAny<CancellationToken>()))
+                .Callback(() => Assert.True(retired)).Returns(Task.CompletedTask);
+            Assert.IsType<NoContentResult>(await controller.DeletePendingPhoto(request));
+            Assert.True(retired);
+        }
+
+        [Fact]
+        public async Task LegacyPublish_UsesTheSameJpegPublicationPipelineAfterAdoption()
+        {
+            var report = SetupLegacy(1);
+            SetupPublication(report);
+            var photos = (await controller!.GetPendingPhotos())[report.Receipt.ReportId];
+            mockReportStore.Setup(s => s.AdoptLegacyAsync(report.Receipt.SubmissionId,
+                It.IsAny<IReadOnlyList<SubmissionPhoto>>(), It.IsAny<CancellationToken>())).ReturnsAsync(report);
+            var request = RequestFor(report);
+            request.ReportVersion = photos[0].ReportVersion!;
+            request.LegacySubmissionId = report.Receipt.SubmissionId;
+            Assert.IsType<NoContentResult>(await controller.UploadTweet(request));
+            mockReportStore.Verify(s => s.AdoptLegacyAsync(report.Receipt.SubmissionId,
+                It.IsAny<IReadOnlyList<SubmissionPhoto>>(), It.IsAny<CancellationToken>()), Times.Once);
+            mockReportedItemsDatabase!.Verify(d => d.SavePublishedReportAsync(It.Is<ReportedItem>(item =>
+                item.TweetId == report.Receipt.ReportId + ".0" && item.NumberOfCars == 3),
+                It.IsAny<CancellationToken>()), Times.Once);
+            mockReportStore.Verify(s => s.RetireAsync(report.Receipt.ReportId, "operation", It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task LegacyTombstone_SuppressesSidecarsRemainingAfterCleanup()
+        {
+            var report = SetupLegacy();
+            mockReportStore.Setup(s => s.ExistsAsync(report.Receipt.ReportId, It.IsAny<CancellationToken>())).ReturnsAsync(true);
+            Assert.Empty(await controller!.GetPendingPhotos());
+        }
+
+        [Fact]
+        public async Task LegacyMissingJpeg_IsVisibleAndCannotBeAdopted()
+        {
+            var report = SetupLegacy();
+            var missing = SetupJpeg(report.Photos[1]);
+            missing.Setup(b => b.GetPropertiesAsync(It.IsAny<BlobRequestConditions>(), It.IsAny<CancellationToken>()))
+                .ThrowsAsync(new RequestFailedException(404, "missing"));
+            var photos = (await controller!.GetPendingPhotos())[report.Receipt.ReportId];
+            Assert.Equal(2, photos.Count);
+            Assert.All(photos, p => Assert.False(p.CanModerate));
+            Assert.Contains("missing", photos[0].Warning);
+            var request = RequestFor(report);
+            request.ReportVersion = photos[0].ReportVersion!;
+            request.LegacySubmissionId = report.Receipt.SubmissionId;
+            Assert.IsType<BadRequestObjectResult>(await controller.DeletePendingPhoto(request));
+            mockReportStore.Verify(s => s.AdoptLegacyAsync(It.IsAny<string>(), It.IsAny<IReadOnlyList<SubmissionPhoto>>(), It.IsAny<CancellationToken>()), Times.Never);
+        }
+
+        [Fact]
+        public async Task LegacyCorruptJson_IsVisibleRatherThanSilentlyDropped()
+        {
+            SetupPending();
+            SetupLegacyListing([("finalizedupload/broken.json", "{invalid")]);
+            var photo = Assert.Single(Assert.Single(await controller!.GetPendingPhotos()).Value);
+            Assert.False(photo.CanModerate);
+            Assert.Contains("corrupt", photo.Warning);
+        }
+
+        [Fact]
+        public async Task LegacyAdoptedSinceListing_RequiresRefreshRatherThanOverwritingTheSharedReport()
+        {
+            var report = SetupLegacy();
+            var photos = (await controller!.GetPendingPhotos())[report.Receipt.ReportId];
+            mockReportStore.Setup(s => s.ExistsAsync(report.Receipt.ReportId, It.IsAny<CancellationToken>())).ReturnsAsync(true);
+            var request = RequestFor(report);
+            request.ReportVersion = photos[0].ReportVersion!;
+            request.LegacySubmissionId = report.Receipt.SubmissionId;
+            Assert.IsType<ConflictObjectResult>(await controller.DeletePendingPhoto(request));
+            mockReportStore.Verify(s => s.AdoptLegacyAsync(It.IsAny<string>(), It.IsAny<IReadOnlyList<SubmissionPhoto>>(), It.IsAny<CancellationToken>()), Times.Never);
+        }
+
+        [Fact]
+        public async Task Pending_ChangedJpegIsVisibleAndDisablesTheWholeReport()
+        {
+            var report = SavedReport();
+            SetupPending(report);
+            foreach (var photo in report.Photos)
+            {
+                SetupJpeg(photo);
+            }
+
+            SetupJpeg(report.Photos[0]).Setup(b => b.GetPropertiesAsync(It.IsAny<BlobRequestConditions>(), It.IsAny<CancellationToken>()))
+                .ThrowsAsync(new RequestFailedException(412, "changed"));
+            var photos = (await controller!.GetPendingPhotos())[ReportId];
+            Assert.All(photos, p => Assert.False(p.CanModerate));
+            Assert.Contains("missing, changed or invalid", photos[0].Warning);
+        }
+
+        [Fact]
+        public async Task Pending_PinsPreviewToBlobVersionWhenStorageVersioningIsAvailable()
+        {
+            var report = SavedReport(1);
+            SetupPending(report);
+            var photo = report.Photos[0];
+            Mock<BlobClient> blob = new Mock<BlobClient>(new Uri("https://storage.example/container/photo.jpeg"),
+                new Azure.Storage.StorageSharedKeyCredential("storage", Convert.ToBase64String(new byte[32])),
+                new BlobClientOptions())
+            {
+                CallBase = true
+            };
+            mockBlobContainerClient!.Setup(c => c.GetBlobClient(photo.BlobName)).Returns(blob.Object);
+            blob.Setup(b => b.GetPropertiesAsync(It.IsAny<BlobRequestConditions>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(Response.FromValue(BlobsModelFactory.BlobProperties(contentLength: 3,
+                    eTag: new ETag(photo.ETag), versionId: "version-1"), Mock.Of<Response>()));
+            string uri = (await controller!.GetPendingPhotos())[ReportId][0].Uri!;
+            Assert.Contains("versionid=version-1", uri);
+            Assert.Contains("sr=bv", uri);
+            Assert.Contains("sp=r", uri);
+        }
+
+        [Fact]
+        public async Task Delete_RejectsPartialOrForgedPhotoSet()
+        {
+            var report = SavedReport();
+            SetupReport(report);
+            var request = RequestFor(report);
+            request.PhotoIds = ["../../other-report"];
+            Assert.IsType<BadRequestObjectResult>(await controller!.DeletePendingPhoto(request));
+            mockReportStore.Verify(s => s.BeginModerationAsync(It.IsAny<string>(), It.IsAny<string>(),
+                It.IsAny<IReadOnlyList<FinalizedPhotoUploadMetadata>?>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()), Times.Never);
+            mockReportStore.Verify(s => s.RetireAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+        }
+
+        [Theory]
+        [InlineData("publishing")]
+        [InlineData("deleting")]
+        public async Task Moderation_ConflictsDoNotStartExternalWorkOrRetire(string kind)
+        {
+            var report = SavedReport();
+            SetupReport(report);
+            mockReportStore.Setup(s => s.BeginModerationAsync(ReportId, kind, It.IsAny<IReadOnlyList<FinalizedPhotoUploadMetadata>?>(),
+                It.IsAny<string?>(), It.IsAny<CancellationToken>())).ThrowsAsync(new ReportConflictException("stale or owned"));
+            var result = kind == "publishing" ? await controller!.UploadTweet(RequestFor(report)) : await controller!.DeletePendingPhoto(RequestFor(report));
+            Assert.IsType<ConflictObjectResult>(result);
+            mockMastodonClientProvider!.Verify(p => p.GetServerClient(), Times.Never);
+            mockReportStore.Verify(s => s.RetireAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+        }
+
+        [Fact]
+        public async Task Publish_SnapshotAllowsCorrectionsButPreservesIdentityReceiptAndStripsSecrets()
+        {
+            var report = SavedReport();
+            foreach (var photo in report.Photos)
+            {
+                photo.Metadata.TwitterAccessToken = "twitter-secret";
+                photo.Metadata.MastodonAccessToken = "mastodon-secret";
+                photo.Metadata.ThreadsAccessToken = "threads-secret";
+                photo.Metadata.BlueskyAccessJwt = "bluesky-secret";
+                photo.Metadata.BlueskyAdminDid = "admin-secret";
+            }
+            bool inspected = false;
+            SetupReport(report, edits =>
+            {
+                inspected = true;
+                Assert.Equal(2, edits!.Count);
+                Assert.All(edits, edit =>
+                {
+                    Assert.Equal("did:plc:original", edit.BlueskyUserDid);
+                    Assert.Equal("Corrected street", edit.PhotoCrossStreet);
+                    Assert.Equal(3, edit.NumberOfCars);
+                    Assert.Equal("Corrected Bluesky text", edit.BlueskySubmittedBy);
+                    Assert.Equal("https://x.com/example/status/1", edit.TwitterLink);
+                    Assert.Single(edit.Tags);
+                    Assert.DoesNotContain("secret", JsonConvert.SerializeObject(edit));
+                });
+                Assert.Equal(report.Photos.Select(p => p.Metadata.PhotoId), edits.Select(p => p.PhotoId));
+            });
+            var request = RequestFor(report);
+            request.BlueskyAdminDid = "request-only-did";
+            request.BlueskyAccessJwt = "request-only-jwt";
+            var browserJson = Newtonsoft.Json.Linq.JObject.FromObject(request);
+            browserJson["Edits"]!["PhotoId"] = "../../forged";
+            browserJson["Edits"]!["BlueskyUserDid"] = "did:plc:forged";
+            browserJson["Edits"]!["DeviceId"] = "forged-device";
+            browserJson["Edits"]!["TwitterAccessToken"] = "forged-secret";
+            browserJson["Edits"]!["Tags"] = new Newtonsoft.Json.Linq.JArray();
+            request = browserJson.ToObject<ModerateReportRequest>()!;
+            mockMastodonClientProvider!.Setup(p => p.GetServerClient()).Throws(new InvalidOperationException("preflight"));
+            var result = Assert.IsType<ObjectResult>(await controller!.UploadTweet(request));
+            Assert.Equal(503, result.StatusCode);
+            Assert.True(inspected);
+            Assert.Equal("did:plc:original", report.Receipt.Attribution.BlueskyDid);
+            Assert.All(report.Photos, p => Assert.Equal("Original street", p.Metadata.PhotoCrossStreet));
+            mockReportStore.Verify(s => s.ReleaseModerationAsync(ReportId, "operation", It.IsAny<CancellationToken>()), Times.Once);
+            mockReportStore.Verify(s => s.RetireAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+        }
+
+        [Fact]
+        public async Task Publish_InvalidGpsFailsBeforeClaim()
+        {
+            var report = SavedReport();
+            var request = RequestFor(report);
+            request.Edits!.PhotoLatitude = "NaN";
+            Assert.IsType<BadRequestObjectResult>(await controller!.UploadTweet(request));
+            mockReportStore.Verify(s => s.BeginModerationAsync(It.IsAny<string>(), It.IsAny<string>(),
+                It.IsAny<IReadOnlyList<FinalizedPhotoUploadMetadata>?>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()), Times.Never);
+        }
+
+        private void SetupPublication(SubmissionReport report)
+        {
+            SetupReport(report);
+            foreach (var photo in report.Photos)
+            {
+                SetupJpeg(photo);
+            }
+
+            mockMastodonClientProvider!.Setup(p => p.GetServerClient()).Returns(mockMastodonClient!.Object);
+            mockBlueskyClientProvider!.Setup(p => p.GetClient()).ReturnsAsync(mockBlueskyClient!.Object);
+            mockImageEndpoint!.Setup(p => p.UploadImageAsync(It.IsAny<Stream>(), It.IsAny<string>(), It.IsAny<string>(),
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<IProgress<int>>(), It.IsAny<int?>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new Image() { Link = "https://imgur.example/photo.jpeg" });
+            MastodonAttachment attachment = new MastodonAttachment() { Id = "attachment" };
+            mockMastodonClient.Setup(p => p.UploadMedia(It.IsAny<Stream>())).ReturnsAsync(attachment);
+            mockMastodonClient.Setup(p => p.GetAttachment(It.IsAny<string>())).ReturnsAsync(attachment);
+            mockMastodonClient.Setup(p => p.PublishStatus(It.IsAny<string>(), It.IsAny<IEnumerable<string>>(), It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync(new MastodonStatus() { Url = "https://mastodon.example/post" });
+            mockBlueskyClient.Setup(p => p.UploadBlob(It.IsAny<UploadBlobRequest>())).ReturnsAsync(new UploadBlobResponse()
+            {
+                Blob = new AtProtoBlob() { Type = "blob", Ref = new AtProtoBlobRef() { Link = "blob" }, MimeType = "image/jpeg", Size = 3 }
+            });
+            mockBlueskyClient.Setup(p => p.CreateRecord(It.IsAny<CreateRecordRequest<BskyPost>>()))
+                .ReturnsAsync(new CreateRecordResponse() { Cid = "cid", Uri = "at://did:plc:original/app.bsky.feed.post/post" });
+            mockHelperMethods!.Setup(h => h.GetBlueskyPostUrl(It.IsAny<string>())).Returns("https://bsky.app/profile/example/post/post");
+            mockReportedItemsDatabase!.Setup(d => d.SavePublishedReportAsync(It.IsAny<ReportedItem>(),
+                It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
+        }
+
+        [Fact]
+        public async Task Publish_SocialProvidersOverlapWithIndependentReadOnlyPhotoStreams()
+        {
+            var report = SavedReport(2);
+            SetupPublication(report);
+            byte[][] images = [[1, 2, 3], [4, 5, 6]];
+            for (int index = 0; index < images.Length; index++)
+            {
+                byte[] bytes = images[index];
+                SetupJpeg(report.Photos[index])
+                    .Setup(b => b.DownloadContentAsync(It.IsAny<BlobDownloadOptions>(), It.IsAny<CancellationToken>()))
+                    .ReturnsAsync(Response.FromValue(BlobsModelFactory.BlobDownloadResult(BinaryData.FromBytes(bytes)),
+                        Mock.Of<Response>()));
+            }
+            static TaskCompletionSource Signal()
+            {
+                return new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            }
+            var imgurStarted = Signal();
+            var mastodonStarted = Signal();
+            var blueskyStarted = Signal();
+            var threadsStarted = Signal();
+            var blueskyFinished = Signal();
+            var releaseImgur = Signal();
+            var releaseMastodon = Signal();
+            var releaseBluesky = Signal();
+            var releaseThreads = Signal();
+            int imgurUploads = 0;
+            bool mastodonPosted = false, threadsPosted = false;
+            List<Stream> mastodonStreams = new List<Stream>();
+            List<Stream> blueskyStreams = new List<Stream>();
+            mockImageEndpoint!.Setup(p => p.UploadImageAsync(It.IsAny<Stream>(), It.IsAny<string>(), It.IsAny<string>(),
+                    It.IsAny<string>(), It.IsAny<string>(), It.IsAny<IProgress<int>>(), It.IsAny<int?>(), It.IsAny<CancellationToken>()))
+                .Returns(async () =>
+                {
+                    imgurStarted.TrySetResult();
+                    await releaseImgur.Task;
+                    imgurUploads++;
+                    return new Image() { Link = "https://imgur.example/photo.jpeg" };
+                });
+            mockMastodonClient!.Setup(p => p.UploadMedia(It.IsAny<Stream>())).Returns(async (Stream stream) =>
+            {
+                Assert.Equal(2, imgurUploads);
+                Assert.False(stream.CanWrite);
+                int index = mastodonStreams.Count;
+                mastodonStreams.Add(stream);
+                Assert.Equal(images[index][0], stream.ReadByte());
+                mastodonStarted.TrySetResult();
+                await releaseMastodon.Task;
+                using MemoryStream remainder = new MemoryStream();
+                await stream.CopyToAsync(remainder);
+                Assert.Equal(images[index][1..], remainder.ToArray());
+                stream.Dispose();
+                return new MastodonAttachment() { Id = "attachment" };
+            });
+            mockBlueskyClient!.Setup(p => p.UploadBlob(It.IsAny<UploadBlobRequest>()))
+                .Returns(async (UploadBlobRequest request) =>
+                {
+                    Assert.Equal(2, imgurUploads);
+                    Stream stream = request.Content;
+                    Assert.False(stream.CanWrite);
+                    int index = blueskyStreams.Count;
+                    blueskyStreams.Add(stream);
+                    blueskyStarted.TrySetResult();
+                    await releaseBluesky.Task;
+                    using MemoryStream bytes = new MemoryStream();
+                    await stream.CopyToAsync(bytes);
+                    Assert.Equal(images[index], bytes.ToArray());
+                    stream.Dispose();
+                    return new UploadBlobResponse()
+                    {
+                        Blob = new AtProtoBlob() { Type = "blob", Ref = new AtProtoBlobRef() { Link = "blob" }, MimeType = "image/jpeg", Size = 3 }
+                    };
+                });
+            mockThreadsClient!.Setup(p => p.CreateThreadsMediaContainer(It.IsAny<string>(), It.IsAny<string>(),
+                    It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool?>(), It.IsAny<List<string>>()))
+                .Returns(async () =>
+                {
+                    Assert.Equal(2, imgurUploads);
+                    threadsStarted.TrySetResult();
+                    await releaseThreads.Task;
+                    return "001";
+                });
+            mockMastodonClient.Setup(p => p.PublishStatus(It.IsAny<string>(), It.IsAny<IEnumerable<string>>(),
+                    It.IsAny<string>(), It.IsAny<string>()))
+                .Callback(() => mastodonPosted = true)
+                .ReturnsAsync(new MastodonStatus() { Url = "https://mastodon.example/post" });
+            mockBlueskyClient.Setup(p => p.CreateRecord(It.IsAny<CreateRecordRequest<BskyPost>>()))
+                .Callback(() => blueskyFinished.TrySetResult())
+                .ReturnsAsync(new CreateRecordResponse() { Cid = "cid", Uri = "at://did:plc:original/app.bsky.feed.post/post" });
+            mockThreadsClient.Setup(p => p.GetThreadsMediaObject(It.IsAny<string>(), It.IsAny<string>()))
+                .Callback(() => threadsPosted = true)
+                .ReturnsAsync(new ThreadsMediaObject() { Id = "002", Permalink = "https://threads.net/002" });
+            mockReportedItemsDatabase!.Setup(d => d.SavePublishedReportAsync(It.IsAny<ReportedItem>(), It.IsAny<CancellationToken>()))
+                .Callback(() => Assert.True(mastodonPosted && blueskyFinished.Task.IsCompleted && threadsPosted))
+                .Returns(Task.CompletedTask);
+
+            Task<IActionResult> publishing = controller!.UploadTweet(RequestFor(report));
+            try
+            {
+                await imgurStarted.Task.WaitAsync(TimeSpan.FromSeconds(10));
+                Assert.False(mastodonStarted.Task.IsCompleted);
+                Assert.False(blueskyStarted.Task.IsCompleted);
+                Assert.False(threadsStarted.Task.IsCompleted);
+                releaseImgur.TrySetResult();
+                await Task.WhenAll(mastodonStarted.Task, blueskyStarted.Task, threadsStarted.Task)
+                    .WaitAsync(TimeSpan.FromSeconds(10));
+                Assert.NotSame(mastodonStreams[0], blueskyStreams[0]);
+                Assert.Equal(1, mastodonStreams[0].Position);
+                Assert.Equal(0, blueskyStreams[0].Position);
+
+                releaseBluesky.TrySetResult();
+                await blueskyFinished.Task.WaitAsync(TimeSpan.FromSeconds(10));
+                Assert.True(mastodonStreams[0].CanRead);
+                Assert.Equal(1, mastodonStreams[0].Position);
+                mockReportedItemsDatabase.Verify(d => d.SavePublishedReportAsync(It.IsAny<ReportedItem>(),
+                    It.IsAny<CancellationToken>()), Times.Never);
+                releaseMastodon.TrySetResult();
+                releaseThreads.TrySetResult();
+                Assert.IsType<NoContentResult>(await publishing.WaitAsync(TimeSpan.FromSeconds(10)));
+                Assert.Equal(2, mastodonStreams.Count);
+                Assert.Equal(2, blueskyStreams.Count);
+                Assert.All(mastodonStreams.Concat(blueskyStreams), stream => Assert.False(stream.CanRead));
+            }
+            finally
+            {
+                releaseImgur.TrySetResult();
+                releaseMastodon.TrySetResult();
+                releaseBluesky.TrySetResult();
+                releaseThreads.TrySetResult();
+                await publishing.WaitAsync(TimeSpan.FromSeconds(10));
+            }
+        }
+
+        [Theory]
+        [InlineData("mastodon")]
+        [InlineData("bluesky")]
+        [InlineData("threads")]
+        public async Task Publish_WaitsForEveryProviderBeforeReleasingAFailedAttempt(string failingProvider)
+        {
+            var report = SavedReport(1);
+            SetupPublication(report);
+            string[] providers = ["mastodon", "bluesky", "threads"];
+            var started = providers.ToDictionary(name => name,
+                _ => new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously));
+            var release = providers.ToDictionary(name => name,
+                _ => new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously));
+            Stream? mastodonStream = null, blueskyStream = null;
+            Task WaitForProvider(string name)
+            {
+                started[name].TrySetResult();
+                return name == failingProvider
+                    ? Task.FromException(new HttpRequestException($"{name} failed"))
+                    : release[name].Task;
+            }
+            mockMastodonClient!.Setup(p => p.UploadMedia(It.IsAny<Stream>())).Returns(async (Stream stream) =>
+            {
+                mastodonStream = stream;
+                await WaitForProvider("mastodon");
+                Assert.True(stream.CanRead);
+                return new MastodonAttachment() { Id = "attachment" };
+            });
+            mockBlueskyClient!.Setup(p => p.UploadBlob(It.IsAny<UploadBlobRequest>()))
+                .Returns(async (UploadBlobRequest request) =>
+                {
+                    blueskyStream = request.Content;
+                    await WaitForProvider("bluesky");
+                    Assert.True(blueskyStream.CanRead);
+                    return new UploadBlobResponse()
+                    {
+                        Blob = new AtProtoBlob() { Type = "blob", Ref = new AtProtoBlobRef() { Link = "blob" }, MimeType = "image/jpeg", Size = 3 }
+                    };
+                });
+            mockThreadsClient!.Setup(p => p.CreateThreadsMediaContainer(It.IsAny<string>(), It.IsAny<string>(),
+                    It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool?>(), It.IsAny<List<string>>()))
+                .Returns(async () =>
+                {
+                    await WaitForProvider("threads");
+                    return "001";
+                });
+
+            Task<IActionResult> publishing = controller!.UploadTweet(RequestFor(report));
+            try
+            {
+                await Task.WhenAll(started.Values.Select(signal => signal.Task)).WaitAsync(TimeSpan.FromSeconds(10));
+                Assert.False(publishing.IsCompleted);
+                Assert.True(mastodonStream!.CanRead);
+                Assert.True(blueskyStream!.CanRead);
+                mockReportStore.Verify(s => s.ReleaseModerationAsync(It.IsAny<string>(), It.IsAny<string>(),
+                    It.IsAny<CancellationToken>()), Times.Never);
+                foreach (var signal in release.Values)
+                {
+                    signal.TrySetResult();
+                }
+
+                Assert.Equal(502, Assert.IsType<ObjectResult>(await publishing.WaitAsync(TimeSpan.FromSeconds(10))).StatusCode);
+                mockReportStore.Verify(s => s.ReleaseModerationAsync(ReportId, "operation", It.IsAny<CancellationToken>()), Times.Once);
+                mockReportedItemsDatabase!.Verify(d => d.SavePublishedReportAsync(It.IsAny<ReportedItem>(),
+                    It.IsAny<CancellationToken>()), Times.Never);
+                mockFeedProvider!.Verify(p => p.AddReportedItemToFeed(It.IsAny<ReportedItem>()), Times.Never);
+                mockReportStore.Verify(s => s.RetireAsync(It.IsAny<string>(), It.IsAny<string>(),
+                    It.IsAny<CancellationToken>()), Times.Never);
+                Assert.False(mastodonStream.CanRead);
+                Assert.False(blueskyStream.CanRead);
+            }
+            finally
+            {
+                foreach (var signal in release.Values)
+                {
+                    signal.TrySetResult();
+                }
+
+                await publishing.WaitAsync(TimeSpan.FromSeconds(10));
+            }
+        }
+
+        [Fact]
+        public async Task Publish_ImgurTimeoutReleasesOwnershipAndKeepsPhotosForManualRetry()
+        {
+            var report = SavedReport(1);
+            SetupPublication(report);
+            mockImageEndpoint!.Setup(p => p.UploadImageAsync(It.IsAny<Stream>(), It.IsAny<string>(), It.IsAny<string>(),
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<IProgress<int>>(), It.IsAny<int?>(), It.IsAny<CancellationToken>()))
+                .ThrowsAsync(new HttpRequestException("response lost"));
+            var result = Assert.IsType<ObjectResult>(await controller!.UploadTweet(RequestFor(report)));
+            Assert.Equal(502, result.StatusCode);
+            var failure = Newtonsoft.Json.Linq.JObject.FromObject(result.Value!);
+            Assert.True((bool)failure["retryAllowed"]!);
+            Assert.Equal(report.Version, (string?)failure["reportVersion"]);
+            Assert.Contains("delete any successful posts", (string?)failure["message"]);
+            mockReportStore.Verify(s => s.ReleaseModerationAsync(ReportId, "operation", It.IsAny<CancellationToken>()), Times.Once);
+            mockReportStore.Verify(s => s.RetireAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+        }
+
+        [Fact]
+        public async Task Publish_ChangedPhotoReleasesOwnershipBeforeAnyExternalPost()
+        {
+            var report = SavedReport(1);
+            SetupPublication(report);
+            SetupJpeg(report.Photos[0]).Setup(b => b.DownloadContentAsync(It.IsAny<BlobDownloadOptions>(), It.IsAny<CancellationToken>()))
+                .ThrowsAsync(new RequestFailedException(412, "changed"));
+            Assert.IsType<ConflictObjectResult>(await controller!.UploadTweet(RequestFor(report)));
+            mockReportStore.Verify(s => s.ReleaseModerationAsync(ReportId, "operation", It.IsAny<CancellationToken>()), Times.Once);
+            mockImageEndpoint!.Verify(p => p.UploadImageAsync(It.IsAny<Stream>(), It.IsAny<string>(), It.IsAny<string>(),
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<IProgress<int>>(), It.IsAny<int?>(), It.IsAny<CancellationToken>()), Times.Never);
+        }
+
+        [Fact]
+        public async Task Delete_UnconfirmedRetirementReturnsFailureAndDoesNotReleaseOrCleanPhotos()
+        {
+            var report = SavedReport();
+            SetupReport(report);
+            mockReportStore.Setup(s => s.RetireAsync(ReportId, "operation", It.IsAny<CancellationToken>()))
+                .ThrowsAsync(new IOException("response lost"));
+            Assert.Equal(503, Assert.IsType<ObjectResult>(await controller!.DeletePendingPhoto(RequestFor(report))).StatusCode);
+            mockReportStore.Verify(s => s.ReleaseModerationAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+            mockReportStore.Verify(s => s.CleanupAsync(It.IsAny<CancellationToken>()), Times.Never);
+        }
+
+        [Theory]
+        [InlineData("mastodon")]
+        [InlineData("bluesky")]
+        [InlineData("threads")]
+        [InlineData("database")]
+        [InlineData("feed")]
+        public async Task Publish_DownstreamFailuresDoNotRetire(string failure)
+        {
+            var report = SavedReport(1);
+            SetupPublication(report);
+            if (failure == "mastodon")
+            {
+                mockMastodonClient!.Setup(p => p.PublishStatus(It.IsAny<string>(), It.IsAny<IEnumerable<string>>(), It.IsAny<string>(), It.IsAny<string>()))
+                                                    .ThrowsAsync(new HttpRequestException("unavailable"));
+            }
+
+            if (failure == "bluesky")
+            {
+                mockBlueskyClient!.Setup(p => p.CreateRecord(It.IsAny<CreateRecordRequest<BskyPost>>()))
+                                                    .ThrowsAsync(new HttpRequestException("unavailable"));
+            }
+
+            if (failure == "threads")
+            {
+                mockThreadsClient!.Setup(p => p.PublishThreadsMediaContainer(It.IsAny<string>()))
+                                                    .ThrowsAsync(new HttpRequestException("expired token"));
+            }
+
+            if (failure == "database")
+            {
+                mockReportedItemsDatabase!.Setup(d => d.SavePublishedReportAsync(It.IsAny<ReportedItem>(),
+                                                    It.IsAny<CancellationToken>())).ThrowsAsync(new IOException("unavailable"));
+            }
+
+            if (failure == "feed")
+            {
+                mockFeedProvider!.Setup(f => f.AddReportedItemToFeed(It.IsAny<ReportedItem>())).ThrowsAsync(new IOException("unavailable"));
+            }
+
+            Assert.Equal(502, Assert.IsType<ObjectResult>(await controller!.UploadTweet(RequestFor(report))).StatusCode);
+            mockReportStore.Verify(s => s.RetireAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+            mockReportStore.Verify(s => s.ReleaseModerationAsync(ReportId, "operation", It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task Publish_RetiresOnlyAfterDatabaseAndFeedAndToleratesCleanupFailure()
+        {
+            var report = SavedReport(1);
+            SetupPublication(report);
+            bool databaseSaved = false, feedSaved = false;
+            mockReportedItemsDatabase!.Setup(d => d.SavePublishedReportAsync(It.IsAny<ReportedItem>(), It.IsAny<CancellationToken>()))
+                .Callback(() => databaseSaved = true).Returns(Task.CompletedTask);
+            mockFeedProvider!.Setup(f => f.AddReportedItemToFeed(It.IsAny<ReportedItem>()))
+                .Callback(() =>
+                {
+                    Assert.True(databaseSaved);
+                    feedSaved = true;
+                }).Returns(Task.CompletedTask);
+            mockReportStore.Setup(s => s.RetireAsync(ReportId, "operation", It.IsAny<CancellationToken>()))
+                .Callback(() => Assert.True(feedSaved)).Returns(Task.CompletedTask);
+            mockReportStore.Setup(s => s.CleanupAsync(It.IsAny<CancellationToken>())).ThrowsAsync(new IOException("retry cleanup"));
+            Assert.IsType<NoContentResult>(await controller!.UploadTweet(RequestFor(report)));
+            mockReportStore.Verify(s => s.RetireAsync(ReportId, "operation", It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task Publish_CanRetryTheSameItemAfterThreadsFailureIsFixed()
+        {
+            var report = SavedReport(1);
+            SetupPublication(report);
+            bool owned = false;
+            int attempts = 0;
+            mockReportStore.Setup(s => s.BeginModerationAsync(ReportId, "publishing",
+                    It.IsAny<IReadOnlyList<FinalizedPhotoUploadMetadata>?>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync((string _, string _, IReadOnlyList<FinalizedPhotoUploadMetadata>? edits, string? _, CancellationToken _) =>
+                {
+                    Assert.False(owned);
+                    owned = true;
+                    attempts++;
+                    return report with
+                    {
+                        Photos = [report.Photos[0] with { Metadata = edits![0] }],
+                        Moderation = new ModerationOperation("operation", "publishing", DateTimeOffset.UtcNow)
+                    };
+                });
+            mockReportStore.Setup(s => s.ReleaseModerationAsync(ReportId, "operation", It.IsAny<CancellationToken>()))
+                .Callback(() => owned = false).Returns(Task.CompletedTask);
+            mockThreadsClient!.SetupSequence(p => p.PublishThreadsMediaContainer(It.IsAny<string>()))
+                .ThrowsAsync(new HttpRequestException("Threads token expired"))
+                .ReturnsAsync("002");
+
+            var request = RequestFor(report);
+            var failure = Assert.IsType<ObjectResult>(await controller!.UploadTweet(request));
+            Assert.Equal(502, failure.StatusCode);
+            Assert.False(owned);
+            Assert.Equal(1, attempts);
+            mockReportStore.Verify(s => s.RetireAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+            request.ReportVersion = (string)Newtonsoft.Json.Linq.JObject.FromObject(failure.Value!)["reportVersion"]!;
+
+            // We remove successful posts and fix the token before clicking Upload again.
+            Assert.IsType<NoContentResult>(await controller.UploadTweet(request));
+
+            Assert.Equal(2, attempts);
+            mockReportStore.Verify(s => s.RetireAsync(ReportId, "operation", It.IsAny<CancellationToken>()), Times.Once);
+            mockReportedItemsDatabase!.Verify(d => d.SavePublishedReportAsync(It.Is<ReportedItem>(item =>
+                item.TweetId == ReportId + ".0"), It.IsAny<CancellationToken>()), Times.Once);
+            mockBlueskyClient!.Verify(p => p.CreateRecord(It.IsAny<CreateRecordRequest<BskyPost>>()), Times.Exactly(2));
+        }
+
+        [Fact]
+        public async Task Publish_LostRetirementResponseDoesNotUnlockAnAlreadyCompletedReport()
+        {
+            var report = SavedReport(1);
+            SetupPublication(report);
+            mockReportStore.Setup(s => s.RetireAsync(ReportId, "operation", It.IsAny<CancellationToken>()))
+                .ThrowsAsync(new IOException("lost response"));
+            mockReportStore.Setup(s => s.GetAsync(ReportId, report.DeviceId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(report with
+                {
+                    Retired = true,
+                    Moderation = new ModerationOperation("operation", "publishing", DateTimeOffset.UtcNow)
+                });
+
+            Assert.IsType<NoContentResult>(await controller!.UploadTweet(RequestFor(report)));
+
+            mockReportStore.Verify(s => s.ReleaseModerationAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+        }
+
+        [Fact]
+        public async Task Publish_FailureDoesNotOfferRetryIfAnotherRequestAlreadyStarted()
+        {
+            var report = SavedReport(1);
+            SetupReport(report);
+            mockReportStore.SetupSequence(s => s.GetForModerationAsync(ReportId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(report)
+                .ReturnsAsync(report with
+                {
+                    Moderation = new ModerationOperation("next-operation", "publishing", DateTimeOffset.UtcNow),
+                    Version = "\"next-version\""
+                });
+            mockMastodonClientProvider!.Setup(p => p.GetServerClient()).Throws(new InvalidOperationException("preflight"));
+
+            var result = Assert.IsType<ObjectResult>(await controller!.UploadTweet(RequestFor(report)));
+
+            Assert.False((bool)Newtonsoft.Json.Linq.JObject.FromObject(result.Value!)["retryAllowed"]!);
+            mockReportStore.Verify(s => s.ReleaseModerationAsync(ReportId, "operation", It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task Publish_RequestOnlyAdminAuthAndUnicodeLocationPreserveAttribution()
+        {
+            var report = SavedReport(1);
+            SetupPublication(report);
+            var request = RequestFor(report);
+            request.BlueskyAdminDid = "did:plc:admin";
+            request.BlueskyAccessJwt = "request-token";
+            request.Edits!.PhotoCrossStreet = "Café & Pine 🚲";
+            request.Edits.BlueskySubmittedBy = "Submitted by @original.example";
+            mockBlueskyClientProvider!.Setup(p => p.GetClient("did:plc:admin", "request-token")).Returns(mockBlueskyClient!.Object);
+            mockBlueskyClient.Setup(p => p.CreateRecord(It.IsAny<CreateRecordRequest<BskyPost>>()))
+                .Callback<CreateRecordRequest<BskyPost>>(post =>
+                {
+                    var facet = Assert.Single(post.Record.Facets!);
+                    byte[] bytes = System.Text.Encoding.UTF8.GetBytes(post.Record.Text);
+                    Assert.Equal("@original.example", System.Text.Encoding.UTF8.GetString(bytes[(int)facet.Index.ByteStart..(int)facet.Index.ByteEnd]));
+                })
+                .ReturnsAsync(new CreateRecordResponse() { Cid = "cid", Uri = "at://did:plc:original/app.bsky.feed.post/post" });
+            Assert.IsType<NoContentResult>(await controller!.UploadTweet(request));
+            mockBlueskyClientProvider.Verify(p => p.GetClient("did:plc:admin", "request-token"), Times.Once);
+        }
+
+        [Theory]
+        [InlineData(true, true)]
+        [InlineData(true, false)]
+        [InlineData(false, true)]
+        [InlineData(false, false)]
+        public async Task Publish_UnchangedGeneratedCreditMentionsOriginalDidWithCurrentHandle(bool canonical, bool handleChanged)
+        {
+            var report = SavedReport(1);
+            var submitted = report.Photos[0].Metadata;
+            submitted.BlueskySubmittedBy = $"Submitted by {(canonical ? "@" : "")}{submitted.BlueskyHandle}";
+            SetupPublication(report);
+            string expectedHandle = handleChanged ? "renamed.example" : submitted.BlueskyHandle!;
+            mockBlueskyOAuthProvider!.Setup(p => p.ResolveHandleFromDid(submitted.BlueskyUserDid!, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(expectedHandle);
+            var request = RequestFor(report);
+            request.Edits!.BlueskySubmittedBy = submitted.BlueskySubmittedBy;
+            mockBlueskyClient!.Setup(p => p.CreateRecord(It.IsAny<CreateRecordRequest<BskyPost>>()))
+                .Callback<CreateRecordRequest<BskyPost>>(post =>
+                {
+                    Assert.Contains($"Submitted by @{expectedHandle}", post.Record.Text);
+                    var facet = Assert.Single(post.Record.Facets!);
+                    var mention = Assert.IsType<BskyMention>(Assert.Single(facet.Features));
+                    Assert.Equal("did:plc:original", mention.Did);
+                    if (handleChanged)
+                    {
+                        Assert.DoesNotContain("@original.example", post.Record.Text);
+                    }
+                })
+                .ReturnsAsync(new CreateRecordResponse() { Cid = "cid", Uri = "at://did:plc:original/app.bsky.feed.post/post" });
+
+            Assert.IsType<NoContentResult>(await controller!.UploadTweet(request));
+            Assert.Equal("did:plc:original", report.Receipt.Attribution.BlueskyDid);
+        }
+    }
+}

--- a/SeattleCarsInBikeLanes.Tests/AdminPageControllerTests.cs
+++ b/SeattleCarsInBikeLanes.Tests/AdminPageControllerTests.cs
@@ -31,7 +31,7 @@ using static SeattleCarsInBikeLanes.Controllers.AdminPageController;
 
 namespace SeattleCarsInBikeLanes.Tests
 {
-    public class AdminPageControllerTests
+    public partial class AdminPageControllerTests
     {
         private AdminPageController? controller;
         private ILogger<AdminPageController>? logger;
@@ -55,6 +55,7 @@ namespace SeattleCarsInBikeLanes.Tests
         private Mock<MastodonClient>? mockMastodonClient;
         private Mock<AtProtoClient>? mockBlueskyClient;
         private Mock<ThreadsClient>? mockThreadsClient;
+        private Mock<ReportStore> mockReportStore;
 
         public AdminPageControllerTests()
         {
@@ -62,6 +63,7 @@ namespace SeattleCarsInBikeLanes.Tests
             mockHttpMessageHandler = new Mock<HttpMessageHandler>(MockBehavior.Strict);
             mockHelperMethods = new Mock<HelperMethods>();
             mockBlobContainerClient = new Mock<BlobContainerClient>();
+            mockReportStore = new Mock<ReportStore>(mockBlobContainerClient.Object, NullLogger<ReportStore>.Instance, null!);
             mockSecretClient = new Mock<SecretClient>();
             mockImgurApiClient = new Mock<IApiClient>();
             mockImgurApiClient.Setup(m => m.ClientId).Returns("1234");
@@ -151,7 +153,8 @@ namespace SeattleCarsInBikeLanes.Tests
                 mockFeedProvider.Object,
                 mockBlueskyClientProvider.Object,
                 mockBlueskyOAuthProvider.Object,
-                mockThreadsClient.Object);
+                mockThreadsClient.Object,
+                mockReportStore.Object);
         }
 
         [Fact]
@@ -215,7 +218,8 @@ namespace SeattleCarsInBikeLanes.Tests
                     }
                 });
             mockBlueskyClient.Setup(m => m.CreateRecord(It.IsAny<CreateRecordRequest<BskyPost>>()).Result)
-                .Returns((CreateRecordRequest<BskyPost> request) => {
+                .Returns((CreateRecordRequest<BskyPost> request) =>
+                {
                     Assert.NotNull(request.Record.Facets);
                     Assert.Single(request.Record.Facets);
                     return new CreateRecordResponse()
@@ -294,7 +298,8 @@ namespace SeattleCarsInBikeLanes.Tests
                     }
                 });
             mockBlueskyClient.Setup(m => m.CreateRecord(It.IsAny<CreateRecordRequest<BskyPost>>()).Result)
-                .Returns((CreateRecordRequest<BskyPost> request) => {
+                .Returns((CreateRecordRequest<BskyPost> request) =>
+                {
                     Assert.NotNull(request.Record.Facets);
                     Assert.Single(request.Record.Facets);
                     return new CreateRecordResponse()
@@ -373,7 +378,8 @@ namespace SeattleCarsInBikeLanes.Tests
                     }
                 });
             mockBlueskyClient.Setup(m => m.CreateRecord(It.IsAny<CreateRecordRequest<BskyPost>>()).Result)
-                .Returns((CreateRecordRequest<BskyPost> request) => {
+                .Returns((CreateRecordRequest<BskyPost> request) =>
+                {
                     Assert.NotNull(request.Record.Facets);
                     Assert.Single(request.Record.Facets);
                     Assert.Single(request.Record.Facets[0].Features);

--- a/SeattleCarsInBikeLanes.Tests/BlockedDevicesDatabaseTests.cs
+++ b/SeattleCarsInBikeLanes.Tests/BlockedDevicesDatabaseTests.cs
@@ -1,0 +1,427 @@
+using System.Net;
+using Microsoft.Azure.Cosmos;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Moq.Protected;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using SeattleCarsInBikeLanes.Database;
+using SeattleCarsInBikeLanes.Database.Models;
+using SeattleCarsInBikeLanes.Models;
+
+namespace SeattleCarsInBikeLanes.Tests
+{
+    public class BlockedDevicesDatabaseTests
+    {
+        private const string DeviceId = "Case-Preserved_123";
+
+        [Fact]
+        public void BlockedDeviceUsesCosmosIdAndReasonNamesAndRoundTripsPlainText()
+        {
+            BlockedDevice item = new BlockedDevice { DeviceId = DeviceId, Reason = "<script>plain text</script>\n\"reason\"" };
+
+            string json = JsonConvert.SerializeObject(item);
+            JObject document = JObject.Parse(json);
+            Assert.Equal(new[] { "id", "reason" }, document.Properties().Select(property => property.Name));
+            Assert.Equal(DeviceId, document.Value<string>("id"));
+            Assert.Equal(item.Reason, document.Value<string>("reason"));
+            BlockedDevice restored = JsonConvert.DeserializeObject<BlockedDevice>(json)!;
+            Assert.Equal(item.DeviceId, restored.DeviceId);
+            Assert.Equal(item.Reason, restored.Reason);
+        }
+
+        [Theory]
+        [InlineData(null, null)]
+        [InlineData("", null)]
+        [InlineData(" \r\n\t", null)]
+        [InlineData(" \t Case-Preserved_123 \n", DeviceId)]
+        [InlineData("a b", "a b")]
+        public void NormalizeOnlyTrimsAndPreservesCase(string? input, string? expected)
+        {
+            Assert.Equal(expected, DeviceIdRules.Normalize(input));
+        }
+
+        [Fact]
+        public void ValidationAllowsOnlyAsciiLettersDigitsHyphenAndUnderscoreWithinLengthBoundaries()
+        {
+            for (int value = 0; value <= char.MaxValue; value++)
+            {
+                char character = (char)value;
+                bool expected = character is >= 'A' and <= 'Z' or >= 'a' and <= 'z' or
+                    >= '0' and <= '9' or '-' or '_';
+                Assert.Equal(expected, DeviceIdRules.IsValid(character.ToString()));
+            }
+
+            Assert.True(DeviceIdRules.IsValid(new string('a', 128)));
+            Assert.False(DeviceIdRules.IsValid(new string('a', 129)));
+            Assert.False(DeviceIdRules.IsValid(null));
+            Assert.False(DeviceIdRules.IsValid(""));
+            Assert.False(DeviceIdRules.IsValid(" a "));
+        }
+
+        public static IEnumerable<object?[]> InvalidDeviceIds()
+        {
+            foreach (string? id in new[] { null, "", " \t", "a/b", "a\\b", "a.b", "a?b", "a#b", "a b", "a\nb", "é", "Ａ", "😀", new string('a', 129) })
+            {
+                yield return new object?[] { id };
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(InvalidDeviceIds))]
+        public async Task InvalidIdsAreRejectedBeforeAnyStorageAccess(string? deviceId)
+        {
+            Mock<Container> container = new Mock<Container>(MockBehavior.Strict);
+            BlockedDevicesDatabase database = CreateDatabase(container.Object);
+
+            await Assert.ThrowsAsync<ArgumentException>(() => database.IsBlockedAsync(deviceId!));
+            await Assert.ThrowsAsync<ArgumentException>(() => database.BlockAsync(deviceId!, "reason"));
+            await Assert.ThrowsAsync<ArgumentException>(() => database.UnblockAsync(deviceId!));
+
+            container.VerifyNoOtherCalls();
+        }
+
+        [Fact]
+        public async Task PointReadsUseExactIdPartitionAndCancellationWithoutCaching()
+        {
+            using CancellationTokenSource cancellation = new CancellationTokenSource();
+            Mock<Container> container = new Mock<Container>(MockBehavior.Strict);
+            container.Setup(c => c.ReadItemAsync<BlockedDevice>(DeviceId, new PartitionKey(DeviceId), null, cancellation.Token))
+                .ReturnsAsync(Mock.Of<ItemResponse<BlockedDevice>>());
+            string otherCase = DeviceId.ToLowerInvariant();
+            container.Setup(c => c.ReadItemAsync<BlockedDevice>(otherCase, new PartitionKey(otherCase), null, cancellation.Token))
+                .ThrowsAsync(StorageFailure(HttpStatusCode.NotFound));
+            BlockedDevicesDatabase database = CreateDatabase(container.Object);
+
+            Assert.True(await database.IsBlockedAsync($" \t{DeviceId}\n ", cancellation.Token));
+            Assert.False(await database.IsBlockedAsync(otherCase, cancellation.Token));
+            Assert.True(await database.IsBlockedAsync(DeviceId, cancellation.Token));
+            Assert.False(await database.IsBlockedAsync(otherCase, cancellation.Token));
+
+            container.Verify(c => c.ReadItemAsync<BlockedDevice>(DeviceId, new PartitionKey(DeviceId), null, cancellation.Token), Times.Exactly(2));
+            container.Verify(c => c.ReadItemAsync<BlockedDevice>(otherCase, new PartitionKey(otherCase), null, cancellation.Token), Times.Exactly(2));
+            container.VerifyNoOtherCalls();
+        }
+
+        [Fact]
+        public async Task BlockAndUnblockAreAtomicIdempotentAndImmediatelyReflectedByFreshReads()
+        {
+            using CancellationTokenSource cancellation = new CancellationTokenSource();
+            Dictionary<(string, PartitionKey), BlockedDevice> items = new Dictionary<(string, PartitionKey), BlockedDevice>();
+            Mock<Container> container = new Mock<Container>(MockBehavior.Strict);
+            container.Setup(c => c.UpsertItemAsync(It.IsAny<BlockedDevice>(), It.IsAny<PartitionKey?>(), null, cancellation.Token))
+                .Callback<BlockedDevice, PartitionKey?, ItemRequestOptions?, CancellationToken>((item, partition, _, _) =>
+                {
+                    Assert.Equal(new PartitionKey(item.DeviceId), partition);
+                    Assert.Equal(item.DeviceId, JObject.FromObject(item).Value<string>("id"));
+                    Assert.False(string.IsNullOrWhiteSpace(item.Reason));
+                    items[(item.DeviceId, partition!.Value)] = item;
+                })
+                .ReturnsAsync(Mock.Of<ItemResponse<BlockedDevice>>());
+            container.Setup(c => c.ReadItemAsync<BlockedDevice>(It.IsAny<string>(), It.IsAny<PartitionKey>(), null, cancellation.Token))
+                .Returns((string id, PartitionKey partition, ItemRequestOptions? _, CancellationToken _) =>
+                    items.ContainsKey((id, partition))
+                        ? Task.FromResult(Mock.Of<ItemResponse<BlockedDevice>>())
+                        : Task.FromException<ItemResponse<BlockedDevice>>(StorageFailure(HttpStatusCode.NotFound)));
+            container.Setup(c => c.DeleteItemAsync<BlockedDevice>(DeviceId, new PartitionKey(DeviceId), null, cancellation.Token))
+                .Returns(() => items.Remove((DeviceId, new PartitionKey(DeviceId)))
+                    ? Task.FromResult(Mock.Of<ItemResponse<BlockedDevice>>())
+                    : Task.FromException<ItemResponse<BlockedDevice>>(StorageFailure(HttpStatusCode.NotFound)));
+            container.Setup(c => c.ReadContainerAsync(null, cancellation.Token))
+                .ReturnsAsync(Mock.Of<ContainerResponse>());
+            BlockedDevicesDatabase database = CreateDatabase(container.Object);
+
+            Assert.False(await database.IsBlockedAsync(DeviceId, cancellation.Token));
+            await database.BlockAsync(DeviceId.ToLowerInvariant(), "Other installation", cancellation.Token);
+            await database.BlockAsync($" {DeviceId} ", " \nRepeated unrelated photos.\t ", cancellation.Token);
+            await database.BlockAsync(DeviceId, "Repeated unrelated photos.", cancellation.Token);
+            Assert.Equal(2, items.Count);
+            Assert.Equal("Repeated unrelated photos.", items[(DeviceId, new PartitionKey(DeviceId))].Reason);
+            Assert.True(await database.IsBlockedAsync(DeviceId, cancellation.Token));
+
+            await database.UnblockAsync($" {DeviceId} ", cancellation.Token);
+            Assert.False(await database.IsBlockedAsync(DeviceId, cancellation.Token));
+            await database.UnblockAsync(DeviceId, cancellation.Token);
+            Assert.False(await database.IsBlockedAsync(DeviceId, cancellation.Token));
+            Assert.True(await database.IsBlockedAsync(DeviceId.ToLowerInvariant(), cancellation.Token));
+            Assert.Single(items);
+            container.Verify(c => c.ReadContainerAsync(null, cancellation.Token), Times.Once);
+            container.Verify(c => c.UpsertItemAsync(It.Is<BlockedDevice>(item =>
+                item.DeviceId == DeviceId && item.Reason == "Repeated unrelated photos."),
+                new PartitionKey(DeviceId), null, cancellation.Token), Times.Exactly(2));
+        }
+
+        [Theory]
+        [InlineData(1, 1)]
+        [InlineData(128, 1000)]
+        public async Task BlockAcceptsTrimmedIdAndReasonBoundaries(int idLength, int reasonLength)
+        {
+            string id = new string('A', idLength);
+            string reason = new string('r', reasonLength);
+            Mock<Container> container = new Mock<Container>(MockBehavior.Strict);
+            container.Setup(c => c.UpsertItemAsync(It.Is<BlockedDevice>(item => item.DeviceId == id && item.Reason == reason),
+                    new PartitionKey(id), null, CancellationToken.None))
+                .ReturnsAsync(Mock.Of<ItemResponse<BlockedDevice>>());
+
+            await CreateDatabase(container.Object).BlockAsync($" \t{id}\n", $" \r\n{reason}\t ");
+
+            container.VerifyAll();
+            container.VerifyNoOtherCalls();
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData(" \t\n")]
+        public async Task BlockRejectsMissingReasonBeforeStorageAccess(string? reason)
+        {
+            Mock<Container> container = new Mock<Container>(MockBehavior.Strict);
+
+            await Assert.ThrowsAsync<ArgumentException>(() => CreateDatabase(container.Object).BlockAsync(DeviceId, reason!));
+
+            container.VerifyNoOtherCalls();
+        }
+
+        [Fact]
+        public async Task BlockRejectsOverlongTrimmedReasonBeforeStorageAccess()
+        {
+            Mock<Container> container = new Mock<Container>(MockBehavior.Strict);
+
+            await Assert.ThrowsAsync<ArgumentException>(() => CreateDatabase(container.Object)
+                .BlockAsync(DeviceId, " " + new string('r', 1001) + " "));
+
+            container.VerifyNoOtherCalls();
+        }
+
+        [Theory]
+        [InlineData(HttpStatusCode.Forbidden)]
+        [InlineData(HttpStatusCode.Unauthorized)]
+        [InlineData(HttpStatusCode.TooManyRequests)]
+        [InlineData(HttpStatusCode.ServiceUnavailable)]
+        public async Task ReadAndMutationsPropagateCosmosFailures(HttpStatusCode statusCode)
+        {
+            foreach (string operation in new[] { "read", "block", "unblock" })
+            {
+                Mock<Container> container = new Mock<Container>(MockBehavior.Strict);
+                CosmosException failure = StorageFailure(statusCode);
+                SetupFailure(container, operation, failure, CancellationToken.None);
+
+                Assert.Same(failure, await Assert.ThrowsAsync<CosmosException>(() =>
+                    Invoke(CreateDatabase(container.Object), operation)));
+                container.VerifyAll();
+            }
+        }
+
+        [Theory]
+        [InlineData(HttpStatusCode.NotFound)]
+        [InlineData(HttpStatusCode.Forbidden)]
+        [InlineData(HttpStatusCode.TooManyRequests)]
+        [InlineData(HttpStatusCode.ServiceUnavailable)]
+        public async Task Delete404DoesNotAcknowledgeAbsenceWhenContainerCannotBeRead(HttpStatusCode statusCode)
+        {
+            using CancellationTokenSource cancellation = new CancellationTokenSource();
+            CosmosException failure = StorageFailure(statusCode);
+            Mock<Container> container = new Mock<Container>(MockBehavior.Strict);
+            container.Setup(c => c.DeleteItemAsync<BlockedDevice>(DeviceId, new PartitionKey(DeviceId), null, cancellation.Token))
+                .ThrowsAsync(StorageFailure(HttpStatusCode.NotFound));
+            container.Setup(c => c.ReadContainerAsync(null, cancellation.Token)).ThrowsAsync(failure);
+
+            Assert.Same(failure, await Assert.ThrowsAsync<CosmosException>(() =>
+                CreateDatabase(container.Object).UnblockAsync(DeviceId, cancellation.Token)));
+            container.VerifyAll();
+            container.VerifyNoOtherCalls();
+        }
+
+        [Fact]
+        public async Task ListDrainsEveryPageIncludingEmptyPagesAndReturnsStoredReasons()
+        {
+            using CancellationTokenSource cancellation = new CancellationTokenSource();
+            BlockedDevice first = new BlockedDevice { DeviceId = DeviceId, Reason = "<b>Not markup</b>" };
+            BlockedDevice last = new BlockedDevice { DeviceId = "other", Reason = "Still available without a source report" };
+            Queue<BlockedDevice[]> pages = new Queue<BlockedDevice[]>(new[] { new[] { first }, Array.Empty<BlockedDevice>(), new[] { last } });
+            Mock<FeedIterator<BlockedDevice>> iterator = new Mock<FeedIterator<BlockedDevice>>();
+            iterator.SetupGet(i => i.HasMoreResults).Returns(() => pages.Count > 0);
+            iterator.Setup(i => i.ReadNextAsync(cancellation.Token)).ReturnsAsync(() => Page(pages.Dequeue()));
+            Mock<Container> container = QueryContainer(iterator);
+
+            IReadOnlyList<BlockedDevice> results = await CreateDatabase(container.Object).ListAsync(cancellation.Token);
+
+            Assert.Equal(new[] { first, last }, results);
+            Assert.Equal(first.Reason, results[0].Reason);
+            Assert.Equal(last.Reason, results[1].Reason);
+            iterator.Verify(i => i.ReadNextAsync(cancellation.Token), Times.Exactly(3));
+            iterator.Protected().Verify("Dispose", Times.Once(), new object[] { true });
+            container.VerifyAll();
+            container.VerifyNoOtherCalls();
+        }
+
+        [Fact]
+        public async Task ListReturnsEmptyOnlyWhenTheQuerySucceeds()
+        {
+            Mock<FeedIterator<BlockedDevice>> iterator = new Mock<FeedIterator<BlockedDevice>>();
+            iterator.SetupSequence(i => i.HasMoreResults).Returns(true).Returns(false);
+            iterator.Setup(i => i.ReadNextAsync(CancellationToken.None)).ReturnsAsync(Page());
+
+            Assert.Empty(await CreateDatabase(QueryContainer(iterator).Object).ListAsync());
+            iterator.Verify(i => i.ReadNextAsync(CancellationToken.None), Times.Once);
+        }
+
+        [Theory]
+        [InlineData(false, HttpStatusCode.NotFound)]
+        [InlineData(false, HttpStatusCode.Forbidden)]
+        [InlineData(true, HttpStatusCode.ServiceUnavailable)]
+        [InlineData(true, HttpStatusCode.TooManyRequests)]
+        public async Task ListPropagatesFailuresWithoutReturningEmptyOrPartialResults(bool afterFirstPage, HttpStatusCode statusCode)
+        {
+            CosmosException failure = StorageFailure(statusCode);
+            Mock<FeedIterator<BlockedDevice>> iterator = new Mock<FeedIterator<BlockedDevice>>();
+            iterator.SetupGet(i => i.HasMoreResults).Returns(true);
+            var sequence = iterator.SetupSequence(i => i.ReadNextAsync(CancellationToken.None));
+            if (afterFirstPage)
+            {
+                sequence.ReturnsAsync(Page(new BlockedDevice { DeviceId = DeviceId, Reason = "Not a partial result" }));
+            }
+            sequence.ThrowsAsync(failure);
+
+            Assert.Same(failure, await Assert.ThrowsAsync<CosmosException>(() =>
+                CreateDatabase(QueryContainer(iterator).Object).ListAsync()));
+            iterator.Verify(i => i.ReadNextAsync(CancellationToken.None), Times.Exactly(afterFirstPage ? 2 : 1));
+        }
+
+        [Theory]
+        [InlineData("read")]
+        [InlineData("block")]
+        [InlineData("unblock")]
+        [InlineData("list")]
+        public async Task PreCanceledOperationsDoNotAccessStorage(string operation)
+        {
+            using CancellationTokenSource cancellation = new CancellationTokenSource();
+            cancellation.Cancel();
+            Mock<Container> container = new Mock<Container>(MockBehavior.Strict);
+
+            var error = await Assert.ThrowsAsync<OperationCanceledException>(() =>
+                Invoke(CreateDatabase(container.Object), operation, cancellation.Token));
+
+            Assert.Equal(cancellation.Token, error.CancellationToken);
+            container.VerifyNoOtherCalls();
+        }
+
+        [Theory]
+        [InlineData("read")]
+        [InlineData("block")]
+        [InlineData("unblock")]
+        [InlineData("list")]
+        public async Task InFlightCancellationAndUnexpectedFailuresAreNotSwallowed(string operation)
+        {
+            using CancellationTokenSource cancellation = new CancellationTokenSource();
+            foreach (Exception failure in new Exception[]
+            {
+                new OperationCanceledException(cancellation.Token), new HttpRequestException("offline"),
+                new TimeoutException("timeout"), new InvalidOperationException("programming failure")
+            })
+            {
+                Mock<Container> container = new Mock<Container>(MockBehavior.Strict);
+                SetupFailure(container, operation, failure, cancellation.Token);
+
+                Exception? actual = await Record.ExceptionAsync(() =>
+                    Invoke(CreateDatabase(container.Object), operation, cancellation.Token));
+
+                Assert.Same(failure, actual);
+                container.VerifyAll();
+            }
+        }
+
+        [Fact]
+        public async Task ListCancellationBetweenPagesDoesNotReturnPartialResults()
+        {
+            using CancellationTokenSource cancellation = new CancellationTokenSource();
+            Mock<FeedIterator<BlockedDevice>> iterator = new Mock<FeedIterator<BlockedDevice>>();
+            iterator.SetupGet(i => i.HasMoreResults).Returns(true);
+            iterator.Setup(i => i.ReadNextAsync(cancellation.Token)).ReturnsAsync(() =>
+            {
+                cancellation.Cancel();
+                return Page(new BlockedDevice { DeviceId = DeviceId, Reason = "Partial" });
+            });
+
+            await Assert.ThrowsAsync<OperationCanceledException>(() =>
+                CreateDatabase(QueryContainer(iterator).Object).ListAsync(cancellation.Token));
+
+            iterator.Verify(i => i.ReadNextAsync(cancellation.Token), Times.Once);
+        }
+
+        [Fact]
+        public async Task Delete404ContainerVerificationPropagatesCancellation()
+        {
+            using CancellationTokenSource cancellation = new CancellationTokenSource();
+            OperationCanceledException failure = new OperationCanceledException(cancellation.Token);
+            Mock<Container> container = new Mock<Container>(MockBehavior.Strict);
+            container.Setup(c => c.DeleteItemAsync<BlockedDevice>(DeviceId, new PartitionKey(DeviceId), null, cancellation.Token))
+                .ThrowsAsync(StorageFailure(HttpStatusCode.NotFound));
+            container.Setup(c => c.ReadContainerAsync(null, cancellation.Token)).ThrowsAsync(failure);
+
+            Assert.Same(failure, await Assert.ThrowsAsync<OperationCanceledException>(() =>
+                CreateDatabase(container.Object).UnblockAsync(DeviceId, cancellation.Token)));
+            container.VerifyAll();
+        }
+
+        private static BlockedDevicesDatabase CreateDatabase(Container container) =>
+            new BlockedDevicesDatabase(NullLogger<BlockedDevicesDatabase>.Instance, container);
+
+        private static CosmosException StorageFailure(HttpStatusCode statusCode) =>
+            new CosmosException("Storage failure", statusCode, 0, "test", 0);
+
+        private static FeedResponse<BlockedDevice> Page(params BlockedDevice[] items)
+        {
+            Mock<FeedResponse<BlockedDevice>> page = new Mock<FeedResponse<BlockedDevice>>();
+            page.Setup(p => p.GetEnumerator()).Returns(() => ((IEnumerable<BlockedDevice>)items).GetEnumerator());
+            return page.Object;
+        }
+
+        private static Mock<Container> QueryContainer(Mock<FeedIterator<BlockedDevice>> iterator)
+        {
+            Mock<Container> container = new Mock<Container>(MockBehavior.Strict);
+            container.Setup(c => c.GetItemQueryIterator<BlockedDevice>(
+                    It.Is<QueryDefinition>(query => query.QueryText == "SELECT c.id, c.reason FROM c"), null, null))
+                .Returns(iterator.Object);
+            return container;
+        }
+
+        private static Task Invoke(BlockedDevicesDatabase database, string operation, CancellationToken cancellationToken = default) =>
+            operation switch
+            {
+                "read" => database.IsBlockedAsync(DeviceId, cancellationToken),
+                "block" => database.BlockAsync(DeviceId, "reason", cancellationToken),
+                "unblock" => database.UnblockAsync(DeviceId, cancellationToken),
+                "list" => database.ListAsync(cancellationToken),
+                _ => throw new ArgumentOutOfRangeException(nameof(operation))
+            };
+
+        private static void SetupFailure(Mock<Container> container, string operation, Exception failure, CancellationToken cancellationToken)
+        {
+            switch (operation)
+            {
+                case "read":
+                    container.Setup(c => c.ReadItemAsync<BlockedDevice>(DeviceId, new PartitionKey(DeviceId), null, cancellationToken))
+                        .ThrowsAsync(failure);
+                    break;
+                case "block":
+                    container.Setup(c => c.UpsertItemAsync(It.IsAny<BlockedDevice>(), new PartitionKey(DeviceId), null, cancellationToken))
+                        .ThrowsAsync(failure);
+                    break;
+                case "unblock":
+                    container.Setup(c => c.DeleteItemAsync<BlockedDevice>(DeviceId, new PartitionKey(DeviceId), null, cancellationToken))
+                        .ThrowsAsync(failure);
+                    break;
+                case "list":
+                    Mock<FeedIterator<BlockedDevice>> iterator = new Mock<FeedIterator<BlockedDevice>>();
+                    iterator.SetupGet(i => i.HasMoreResults).Returns(true);
+                    iterator.Setup(i => i.ReadNextAsync(cancellationToken)).ThrowsAsync(failure);
+                    container.Setup(c => c.GetItemQueryIterator<BlockedDevice>(It.IsAny<QueryDefinition>(), null, null))
+                        .Returns(iterator.Object);
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(operation));
+            }
+        }
+    }
+}

--- a/SeattleCarsInBikeLanes.Tests/DeviceBlocklistProviderTests.cs
+++ b/SeattleCarsInBikeLanes.Tests/DeviceBlocklistProviderTests.cs
@@ -1,0 +1,208 @@
+using System.Net;
+using Azure.Identity;
+using Microsoft.Azure.Cosmos;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Newtonsoft.Json;
+using SeattleCarsInBikeLanes.Database;
+using SeattleCarsInBikeLanes.Database.Models;
+using SeattleCarsInBikeLanes.Providers;
+
+namespace SeattleCarsInBikeLanes.Tests
+{
+    public class DeviceBlocklistProviderTests
+    {
+        private sealed class Fixture
+        {
+            public Mock<Container> Container { get; } = new Mock<Container>(MockBehavior.Strict);
+            public Mock<ILogger<DeviceBlocklistProvider>> Log { get; } = new Mock<ILogger<DeviceBlocklistProvider>>();
+            public HashSet<string> Blocked { get; } = new HashSet<string>(StringComparer.Ordinal);
+            public DeviceBlocklistProvider Provider { get; }
+
+            public Fixture()
+            {
+                Container.Setup(c => c.ReadItemAsync<BlockedDevice>(It.IsAny<string>(), It.IsAny<PartitionKey>(),
+                        null, It.IsAny<CancellationToken>()))
+                    .ReturnsAsync((string id, PartitionKey partition, ItemRequestOptions? _, CancellationToken _) =>
+                    {
+                        Assert.Equal(new PartitionKey(id), partition);
+                        if (!Blocked.Contains(id))
+                        {
+                            throw new CosmosException("Not found", HttpStatusCode.NotFound, 0, "test", 0);
+                        }
+                        Mock<ItemResponse<BlockedDevice>> response = new Mock<ItemResponse<BlockedDevice>>();
+                        response.SetupGet(r => r.Resource)
+                            .Returns(new BlockedDevice() { DeviceId = id, Reason = "Private moderation reason" });
+                        return response.Object;
+                    });
+                Provider = new DeviceBlocklistProvider(Log.Object,
+                    new BlockedDevicesDatabase(NullLogger<BlockedDevicesDatabase>.Instance, Container.Object));
+            }
+
+            public void Fail(Exception failure)
+            {
+                Container.Setup(c => c.ReadItemAsync<BlockedDevice>(It.IsAny<string>(), It.IsAny<PartitionKey>(),
+                        null, It.IsAny<CancellationToken>()))
+                    .ThrowsAsync(failure);
+            }
+        }
+
+        [Fact]
+        public async Task UsesExactDeviceIdAndPartitionForPointReads()
+        {
+            Fixture fixture = new Fixture();
+            fixture.Blocked.Add("device-1");
+
+            Assert.True(await fixture.Provider.IsBlocked("device-1"));
+            Assert.False(await fixture.Provider.IsBlocked("DEVICE-1"));
+            Assert.False(await fixture.Provider.IsBlocked("device-10"));
+
+            foreach (string id in new[] { "device-1", "DEVICE-1", "device-10" })
+            {
+                fixture.Container.Verify(c => c.ReadItemAsync<BlockedDevice>(
+                    id, new PartitionKey(id), null, CancellationToken.None), Times.Once);
+            }
+            fixture.Container.VerifyNoOtherCalls();
+            Assert.Empty(fixture.Log.Invocations);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("   ")]
+        public async Task NoDeviceIdDoesNotAccessStorage(string? deviceId)
+        {
+            Fixture fixture = new Fixture();
+
+            Assert.False(await fixture.Provider.IsBlocked(deviceId));
+
+            fixture.Container.VerifyNoOtherCalls();
+        }
+
+        [Fact]
+        public async Task ReadsEveryTimeAndObservesBlockAndUnblockWithoutCaching()
+        {
+            Fixture fixture = new Fixture();
+
+            Assert.False(await fixture.Provider.IsBlocked("device-1"));
+            fixture.Blocked.Add("device-1");
+            Assert.True(await fixture.Provider.IsBlocked("device-1"));
+            fixture.Blocked.Remove("device-1");
+            Assert.False(await fixture.Provider.IsBlocked("device-1"));
+
+            fixture.Container.Verify(c => c.ReadItemAsync<BlockedDevice>("device-1",
+                new PartitionKey("device-1"), null, CancellationToken.None), Times.Exactly(3));
+        }
+
+        [Theory]
+        [InlineData(HttpStatusCode.Unauthorized)]
+        [InlineData(HttpStatusCode.Forbidden)]
+        [InlineData(HttpStatusCode.RequestTimeout)]
+        [InlineData(HttpStatusCode.TooManyRequests)]
+        [InlineData(HttpStatusCode.ServiceUnavailable)]
+        public async Task LogsAndFailsOpenOnCosmosFailureWithoutCaching(HttpStatusCode status)
+        {
+            Fixture fixture = new Fixture();
+            fixture.Fail(new CosmosException("Unavailable", status, 0, "test", 0));
+
+            Assert.False(await fixture.Provider.IsBlocked("device-1"));
+            Assert.False(await fixture.Provider.IsBlocked("device-1"));
+
+            fixture.Container.Verify(c => c.ReadItemAsync<BlockedDevice>("device-1",
+                new PartitionKey("device-1"), null, CancellationToken.None), Times.Exactly(2));
+            Assert.Equal(2, fixture.Log.Invocations.Count(i => i.Method.Name == "Log" &&
+                i.Arguments[0].Equals(LogLevel.Error)));
+        }
+
+        public static IEnumerable<object[]> StorageFailures()
+        {
+            yield return [new HttpRequestException("Network unavailable")];
+            yield return [new TimeoutException("Request timed out")];
+            yield return [new OperationCanceledException("SDK timeout")];
+            yield return [new AuthenticationFailedException("Azure credentials unavailable")];
+            yield return [new JsonReaderException("Unreadable document")];
+        }
+
+        [Theory]
+        [MemberData(nameof(StorageFailures))]
+        public async Task LogsAndFailsOpenOnExpectedStorageFailure(Exception failure)
+        {
+            Fixture fixture = new Fixture();
+            fixture.Fail(failure);
+
+            Assert.False(await fixture.Provider.IsBlocked("device-1"));
+
+            Assert.Contains(fixture.Log.Invocations, i => i.Method.Name == "Log" &&
+                i.Arguments[0].Equals(LogLevel.Error) && ReferenceEquals(failure, i.Arguments[3]));
+        }
+
+        [Fact]
+        public async Task DoesNotCacheFailureWhenStorageRecovers()
+        {
+            Fixture fixture = new Fixture();
+            fixture.Container.SetupSequence(c => c.ReadItemAsync<BlockedDevice>("device-1",
+                    new PartitionKey("device-1"), null, CancellationToken.None))
+                .ThrowsAsync(new CosmosException("Unavailable", HttpStatusCode.ServiceUnavailable, 0, "test", 0))
+                .ReturnsAsync(Mock.Of<ItemResponse<BlockedDevice>>(r =>
+                    r.Resource == new BlockedDevice() { DeviceId = "device-1", Reason = "Private reason" }));
+
+            Assert.False(await fixture.Provider.IsBlocked("device-1"));
+            Assert.True(await fixture.Provider.IsBlocked("device-1"));
+        }
+
+        [Fact]
+        public async Task ForwardsCancellationToken()
+        {
+            Fixture fixture = new Fixture();
+            using CancellationTokenSource cancellation = new CancellationTokenSource();
+
+            Assert.False(await fixture.Provider.IsBlocked("device-1", cancellation.Token));
+
+            fixture.Container.Verify(c => c.ReadItemAsync<BlockedDevice>("device-1",
+                new PartitionKey("device-1"), null, cancellation.Token), Times.Once);
+        }
+
+        [Fact]
+        public async Task AlreadyCanceledRequestDoesNotAccessStorage()
+        {
+            Fixture fixture = new Fixture();
+            using CancellationTokenSource cancellation = new CancellationTokenSource();
+            cancellation.Cancel();
+
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+                fixture.Provider.IsBlocked("device-1", cancellation.Token));
+
+            fixture.Container.VerifyNoOtherCalls();
+            Assert.Empty(fixture.Log.Invocations);
+        }
+
+        [Fact]
+        public async Task CallerCancellationDuringReadIsNotAnAllowDecision()
+        {
+            Fixture fixture = new Fixture();
+            using CancellationTokenSource cancellation = new CancellationTokenSource();
+            fixture.Container.Setup(c => c.ReadItemAsync<BlockedDevice>("device-1",
+                    new PartitionKey("device-1"), null, cancellation.Token))
+                .Callback(cancellation.Cancel)
+                .ThrowsAsync(new OperationCanceledException(cancellation.Token));
+
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+                fixture.Provider.IsBlocked("device-1", cancellation.Token));
+
+            Assert.Empty(fixture.Log.Invocations);
+        }
+
+        [Fact]
+        public async Task UnexpectedErrorsAreNotSwallowed()
+        {
+            Fixture fixture = new Fixture();
+            InvalidOperationException failure = new InvalidOperationException("Programming error");
+            fixture.Fail(failure);
+
+            Assert.Same(failure, await Assert.ThrowsAsync<InvalidOperationException>(() =>
+                fixture.Provider.IsBlocked("device-1")));
+            Assert.Empty(fixture.Log.Invocations);
+        }
+    }
+}

--- a/SeattleCarsInBikeLanes.Tests/FeedProviderTests.cs
+++ b/SeattleCarsInBikeLanes.Tests/FeedProviderTests.cs
@@ -1,0 +1,303 @@
+using System.ServiceModel.Syndication;
+using System.Text;
+using System.Xml;
+using Azure;
+using Azure.Storage;
+using Azure.Storage.Blobs;
+using Azure.Storage.Blobs.Models;
+using Microsoft.Azure.Cosmos;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using SeattleCarsInBikeLanes.Database;
+using SeattleCarsInBikeLanes.Database.Models;
+using SeattleCarsInBikeLanes.Providers;
+
+namespace SeattleCarsInBikeLanes.Tests
+{
+    public class FeedProviderTests
+    {
+        private const string ReportId = "abcdef0123456789abcdef0123456789.0";
+        private static readonly DateTime CreatedAt = new DateTime(2026, 9, 1, 0, 0, 0, DateTimeKind.Utc);
+
+        [Fact]
+        public async Task AddReportedItemToFeed_ReplacesDuplicatesInEachFeedIndependently()
+        {
+            MemoryFeedBlob rss = new MemoryFeedBlob(true,
+                                        [FeedItem("rss-first"), FeedItem(ReportId), FeedItem(ReportId), FeedItem("rss-last")]);
+            MemoryFeedBlob atom = new MemoryFeedBlob(false,
+                [FeedItem(ReportId), FeedItem("atom-only"), FeedItem(ReportId)]);
+            FeedProvider provider = CreateProvider(rss, atom);
+
+            await provider.AddReportedItemToFeed(Report("updated"));
+
+            Assert.Equal(new[] { ReportId, "rss-first", "rss-last" }, rss.ReadItems().Select(i => i.Id));
+            Assert.Equal(new[] { ReportId, "atom-only" }, atom.ReadItems().Select(i => i.Id));
+            AssertUpdatedItem(rss.ReadItems()[0], "updated");
+            AssertUpdatedItem(atom.ReadItems()[0], "updated");
+            Assert.Equal("rss-first", rss.ReadItems()[1].Title.Text);
+            Assert.Equal("atom-only", atom.ReadItems()[1].Title.Text);
+            Assert.Equal(FeedProvider.RssContentType, rss.ContentType);
+            Assert.Equal(FeedProvider.AtomContentType, atom.ContentType);
+        }
+
+        [Fact]
+        public async Task AddReportedItemToFeed_RepeatedRetriesReplaceSocialAndImageUrls()
+        {
+            MemoryFeedBlob rss = new MemoryFeedBlob(true, []);
+            MemoryFeedBlob atom = new MemoryFeedBlob(false, []);
+            FeedProvider provider = CreateProvider(rss, atom);
+
+            await provider.AddReportedItemToFeed(Report("original"));
+            await provider.AddReportedItemToFeed(Report("updated"));
+            await provider.AddReportedItemToFeed(Report("updated"));
+
+            AssertUpdatedItem(Assert.Single(rss.ReadItems()), "updated");
+            AssertUpdatedItem(Assert.Single(atom.ReadItems()), "updated");
+            Assert.DoesNotContain("original", Html(rss.ReadItems()[0]));
+            Assert.DoesNotContain("original", Html(atom.ReadItems()[0]));
+        }
+
+        [Fact]
+        public async Task AddReportedItemToFeed_RetryAfterAtomWriteFailureDoesNotDuplicateRssOrEvictExtraItems()
+        {
+            var existing = Enumerable.Range(0, 100).Select(i => FeedItem($"existing-{i}")).ToList();
+            MemoryFeedBlob rss = new MemoryFeedBlob(true, existing);
+            MemoryFeedBlob atom = new MemoryFeedBlob(false, existing);
+            RequestFailedException failure = new RequestFailedException(503, "Atom upload failed");
+            atom.UploadFailure = failure;
+            FeedProvider provider = CreateProvider(rss, atom);
+
+            var exception = await Assert.ThrowsAsync<RequestFailedException>(() =>
+                provider.AddReportedItemToFeed(Report("original")));
+
+            Assert.Same(failure, exception);
+            AssertUpdatedItem(rss.ReadItems()[0], "original");
+            Assert.DoesNotContain(atom.ReadItems(), i => i.Id == ReportId);
+            Assert.Equal(100, atom.ReadItems().Count);
+            Assert.Equal(1, rss.UploadAttempts);
+            Assert.Equal(1, atom.UploadAttempts);
+
+            atom.UploadFailure = null;
+            await provider.AddReportedItemToFeed(Report("updated"));
+            await provider.AddReportedItemToFeed(Report("updated"));
+
+            var expectedIds = new[] { ReportId }.Concat(Enumerable.Range(0, 99).Select(i => $"existing-{i}"));
+            Assert.Equal(expectedIds, rss.ReadItems().Select(i => i.Id));
+            Assert.Equal(expectedIds, atom.ReadItems().Select(i => i.Id));
+            AssertUpdatedItem(rss.ReadItems()[0], "updated");
+            AssertUpdatedItem(atom.ReadItems()[0], "updated");
+            Assert.DoesNotContain("original", Html(rss.ReadItems()[0]));
+            Assert.Equal(3, rss.UploadAttempts);
+            Assert.Equal(3, atom.UploadAttempts);
+        }
+
+        [Fact]
+        public async Task AddReportedItemToFeed_PropagatesRssWriteFailureWithoutWritingAtom()
+        {
+            MemoryFeedBlob rss = new MemoryFeedBlob(true, [FeedItem("rss-only")]);
+            MemoryFeedBlob atom = new MemoryFeedBlob(false, [FeedItem("atom-only")]);
+            RequestFailedException failure = new RequestFailedException(503, "RSS upload failed");
+            rss.UploadFailure = failure;
+
+            var exception = await Assert.ThrowsAsync<RequestFailedException>(() =>
+                CreateProvider(rss, atom).AddReportedItemToFeed(Report("updated")));
+
+            Assert.Same(failure, exception);
+            Assert.Equal("rss-only", Assert.Single(rss.ReadItems()).Id);
+            Assert.Equal("atom-only", Assert.Single(atom.ReadItems()).Id);
+            Assert.Equal(1, rss.UploadAttempts);
+            Assert.Equal(0, atom.UploadAttempts);
+        }
+
+        [Theory]
+        [InlineData(99)]
+        [InlineData(100)]
+        [InlineData(105)]
+        public async Task AddReportedItemToFeed_PreservesUnrelatedItemsWithinTheHundredItemCap(int count)
+        {
+            var existing = Enumerable.Range(0, count).Select(i => FeedItem($"existing-{i}")).ToList();
+            MemoryFeedBlob rss = new MemoryFeedBlob(true, existing);
+            MemoryFeedBlob atom = new MemoryFeedBlob(false, existing);
+
+            await CreateProvider(rss, atom).AddReportedItemToFeed(Report("updated"));
+
+            var expectedIds = new[] { ReportId }.Concat(Enumerable.Range(0, 99).Select(i => $"existing-{i}"));
+            Assert.Equal(expectedIds, rss.ReadItems().Select(i => i.Id));
+            Assert.Equal(expectedIds, atom.ReadItems().Select(i => i.Id));
+        }
+
+        [Theory]
+        [InlineData(ReportId)]
+        [InlineData("12345678901234567890123456789012.0")]
+        [InlineData("00000000000000000000000000000001.0")]
+        [InlineData("abcdef01-2345-6789-abcd-ef0123456789.0")]
+        [InlineData("not-a-tweet.0")]
+        [InlineData("+123456789.0")]
+        [InlineData("-123456789.0")]
+        [InlineData(" 123456789.0")]
+        [InlineData("123,456,789.0")]
+        [InlineData("1e9.0")]
+        [InlineData("１２３４５６７８９.0")]
+        [InlineData("18446744073709551616.0")]
+        public async Task AddReportedItemToFeed_DoesNotInventTwitterLinksForNonSnowflakeIds(string id)
+        {
+            MemoryFeedBlob rss = new MemoryFeedBlob(true, []);
+            MemoryFeedBlob atom = new MemoryFeedBlob(false, []);
+            ReportedItem report = Report("updated");
+            report.TweetId = id;
+
+            await CreateProvider(rss, atom).AddReportedItemToFeed(report);
+
+            Assert.DoesNotContain("Twitter post", Html(Assert.Single(rss.ReadItems())));
+            Assert.DoesNotContain("twitter.com", Html(rss.ReadItems()[0]));
+            Assert.DoesNotContain("Twitter post", Html(Assert.Single(atom.ReadItems())));
+            Assert.DoesNotContain("twitter.com", Html(atom.ReadItems()[0]));
+        }
+
+        [Theory]
+        [InlineData("1234567890123456789")]
+        [InlineData("1234567890123456789.0")]
+        [InlineData("1234567890123456789.2")]
+        public async Task AddReportedItemToFeed_PreservesLegacyNumericTwitterLinks(string id)
+        {
+            MemoryFeedBlob rss = new MemoryFeedBlob(true, []);
+            MemoryFeedBlob atom = new MemoryFeedBlob(false, []);
+            ReportedItem report = Report("updated");
+            report.TweetId = id;
+
+            await CreateProvider(rss, atom).AddReportedItemToFeed(report);
+
+            const string expectedLink = "https://twitter.com/carbikelanesea/status/1234567890123456789";
+            Assert.Contains(expectedLink, Html(Assert.Single(rss.ReadItems())));
+            Assert.Contains(expectedLink, Html(Assert.Single(atom.ReadItems())));
+        }
+
+        [Theory]
+        [InlineData(ReportId)]
+        [InlineData("1234567890123456789.0")]
+        public async Task AddReportedItemToFeed_PreservesExplicitTwitterLinkInsteadOfLegacyFallback(string id)
+        {
+            MemoryFeedBlob rss = new MemoryFeedBlob(true, []);
+            MemoryFeedBlob atom = new MemoryFeedBlob(false, []);
+            ReportedItem report = Report("updated");
+            report.TweetId = id;
+            report.TwitterLink = "https://twitter.com/explicit/status/987654321";
+
+            await CreateProvider(rss, atom).AddReportedItemToFeed(report);
+
+            Assert.Contains(report.TwitterLink, Html(Assert.Single(rss.ReadItems())));
+            Assert.Contains(report.TwitterLink, Html(Assert.Single(atom.ReadItems())));
+            Assert.DoesNotContain("carbikelanesea/status", Html(rss.ReadItems()[0]));
+            Assert.DoesNotContain("carbikelanesea/status", Html(atom.ReadItems()[0]));
+        }
+
+        private static ReportedItem Report(string version)
+        {
+            return new ReportedItem()
+            {
+                TweetId = ReportId,
+                CreatedAt = CreatedAt,
+                NumberOfCars = 2,
+                LocationString = "Test location",
+                ImageUrls = [$"https://images.example.com/{version}.jpg"],
+                MastodonLink = $"https://mastodon.example.com/@test/{version}",
+                BlueskyLink = $"https://bsky.app/profile/test/post/{version}",
+                ThreadsLink = $"https://www.threads.net/@test/post/{version}"
+            };
+        }
+
+        private static SyndicationItem FeedItem(string id)
+        {
+            return new SyndicationItem(id, "Unrelated content", null, id, new DateTimeOffset(CreatedAt));
+        }
+
+        private static string Html(SyndicationItem item)
+        {
+            return Assert.IsType<TextSyndicationContent>(item.Content ?? item.Summary).Text;
+        }
+
+        private static void AssertUpdatedItem(SyndicationItem item, string version)
+        {
+            Assert.Equal(ReportId, item.Id);
+            Assert.Equal("2 cars @ Test location", item.Title.Text);
+            string html = Html(item);
+            Assert.Contains($"https://images.example.com/{version}.jpg", html);
+            Assert.Contains($"https://mastodon.example.com/@test/{version}", html);
+            Assert.Contains($"https://bsky.app/profile/test/post/{version}", html);
+            Assert.Contains($"https://www.threads.net/@test/post/{version}", html);
+        }
+
+        private static FeedProvider CreateProvider(MemoryFeedBlob rss, MemoryFeedBlob atom)
+        {
+            Mock<BlobContainerClient> container = new Mock<BlobContainerClient>(MockBehavior.Strict);
+            container.Setup(c => c.GetBlobClient("rss.xml")).Returns(rss.Client.Object);
+            container.Setup(c => c.GetBlobClient("atom.xml")).Returns(atom.Client.Object);
+            ReportedItemsDatabase database = new ReportedItemsDatabase(NullLogger<ReportedItemsDatabase>.Instance,
+                new Mock<Container>(MockBehavior.Strict).Object);
+            return new FeedProvider(NullLogger<FeedProvider>.Instance, database, container.Object);
+        }
+
+        private sealed class MemoryFeedBlob
+        {
+            private BinaryData content;
+
+            public Mock<BlobClient> Client { get; } = new Mock<BlobClient>(MockBehavior.Strict);
+            public Exception? UploadFailure { get; set; }
+            public int UploadAttempts { get; private set; }
+            public string? ContentType { get; private set; }
+
+            public MemoryFeedBlob(bool rss, IEnumerable<SyndicationItem> items)
+            {
+                SyndicationFeed feed = new SyndicationFeed("Reports", "Reported cars",
+                                                    new Uri("https://seattle.carinbikelane.com"), "urn:test:feed", new DateTimeOffset(CreatedAt))
+                {
+                    Items = items
+                };
+                using MemoryStream stream = new MemoryStream();
+                using (var writer = XmlWriter.Create(stream, new XmlWriterSettings() { Encoding = new UTF8Encoding(false) }))
+                {
+                    if (rss)
+                    {
+                        new Rss20FeedFormatter(feed).WriteTo(writer);
+                    }
+                    else
+                    {
+                        new Atom10FeedFormatter(feed).WriteTo(writer);
+                    }
+                }
+                content = BinaryData.FromBytes(stream.ToArray());
+
+                Client.Setup(c => c.DownloadContentAsync())
+                    .Returns(() => Task.FromResult(Response.FromValue(
+                        BlobsModelFactory.BlobDownloadResult(content), Mock.Of<Response>())));
+                Client.Setup(c => c.UploadAsync(It.IsAny<Stream>(), It.IsAny<BlobHttpHeaders>(),
+                        null, null, null, null, default, CancellationToken.None))
+                    .Returns((Stream data, BlobHttpHeaders headers, IDictionary<string, string>? metadata,
+                        BlobRequestConditions? conditions, IProgress<long>? progress, AccessTier? accessTier,
+                        StorageTransferOptions transferOptions, CancellationToken cancellationToken) =>
+                    {
+                        UploadAttempts++;
+                        if (UploadFailure != null)
+                        {
+                            return Task.FromException<Azure.Response<BlobContentInfo>>(UploadFailure);
+                        }
+
+                        content = BinaryData.FromStream(data);
+                        ContentType = headers.ContentType;
+                        return Task.FromResult(Response.FromValue(
+                            BlobsModelFactory.BlobContentInfo(eTag: new ETag("test"),
+                                lastModified: DateTimeOffset.UtcNow, contentHash: null, versionId: null,
+                                encryptionKeySha256: null, encryptionScope: null, blobSequenceNumber: 0),
+                            Mock.Of<Response>()));
+                    });
+            }
+
+            public List<SyndicationItem> ReadItems()
+            {
+                using var stream = content.ToStream();
+                using var reader = XmlReader.Create(stream);
+                return SyndicationFeed.Load(reader).Items.ToList();
+            }
+        }
+    }
+}

--- a/SeattleCarsInBikeLanes.Tests/MastodonCredentialVerifierTests.cs
+++ b/SeattleCarsInBikeLanes.Tests/MastodonCredentialVerifierTests.cs
@@ -1,0 +1,118 @@
+using System.Net;
+using SeattleCarsInBikeLanes.Providers;
+
+namespace SeattleCarsInBikeLanes.Tests
+{
+    public class MastodonCredentialVerifierTests
+    {
+        [Fact]
+        public async Task DeadlineCoversAStalledBodyAfterSuccessfulHeaders()
+        {
+            using HttpClient client = new HttpClient(new ResponseHandler(() => new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StreamContent(new StalledStream())
+            }));
+            MastodonCredentialVerifier verifier = new MastodonCredentialVerifier(client, TimeSpan.FromMilliseconds(100));
+            await Assert.ThrowsAsync<ProviderUnavailableException>(() =>
+                verifier.VerifyAsync("https://example.test", "test-token", default).WaitAsync(TimeSpan.FromSeconds(5)));
+        }
+
+        [Fact]
+        public async Task CallerCancellationDuringBodyReadIsNotCredentialRejectionOrProviderFallback()
+        {
+            using CancellationTokenSource cancellation = new CancellationTokenSource();
+            using HttpClient client = new HttpClient(new ResponseHandler(() => new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StreamContent(new StalledStream(cancellation.Cancel))
+            }));
+            MastodonCredentialVerifier verifier = new MastodonCredentialVerifier(client, TimeSpan.FromSeconds(10));
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+                verifier.VerifyAsync("https://example.test", "test-token", cancellation.Token));
+        }
+
+        [Fact]
+        public async Task CompleteIdentityStillSucceedsWithinDeadline()
+        {
+            using HttpClient client = new HttpClient(new ResponseHandler(() => new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("""{"id":"account","username":"rider"}""")
+            }));
+            MastodonCredentialVerifier verifier = new MastodonCredentialVerifier(client, TimeSpan.FromSeconds(1));
+            Assert.Equal(new VerifiedMastodonAccount("https://example.test", "account", "rider"),
+                await verifier.VerifyAsync("https://example.test", "test-token", default));
+        }
+
+        private sealed class ResponseHandler : HttpMessageHandler
+        {
+            private readonly Func<HttpResponseMessage> response;
+
+            public ResponseHandler(Func<HttpResponseMessage> response)
+            {
+                this.response = response;
+            }
+
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                return Task.FromResult(response());
+            }
+        }
+
+        private sealed class StalledStream : Stream
+        {
+            private readonly Action? onRead;
+
+            public StalledStream(Action? onRead = null)
+            {
+                this.onRead = onRead;
+            }
+
+            public override bool CanRead => true;
+            public override bool CanSeek => false;
+            public override bool CanWrite => false;
+            public override long Length => throw new NotSupportedException();
+            public override long Position
+            {
+                get
+                {
+                    throw new NotSupportedException();
+                }
+                set
+                {
+                    throw new NotSupportedException();
+                }
+            }
+
+            public override void Flush()
+            {
+                throw new NotSupportedException();
+            }
+
+            public override int Read(byte[] buffer, int offset, int count)
+            {
+                throw new NotSupportedException();
+            }
+
+            public override async ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
+            {
+                onRead?.Invoke();
+                await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+                return 0;
+            }
+
+            public override long Seek(long offset, SeekOrigin origin)
+            {
+                throw new NotSupportedException();
+            }
+
+            public override void SetLength(long value)
+            {
+                throw new NotSupportedException();
+            }
+
+            public override void Write(byte[] buffer, int offset, int count)
+            {
+                throw new NotSupportedException();
+            }
+        }
+    }
+}

--- a/SeattleCarsInBikeLanes.Tests/ReportCleanupServiceTests.cs
+++ b/SeattleCarsInBikeLanes.Tests/ReportCleanupServiceTests.cs
@@ -1,0 +1,62 @@
+using Azure.Storage.Blobs;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using SeattleCarsInBikeLanes.Providers;
+
+namespace SeattleCarsInBikeLanes.Tests
+{
+    public class ReportCleanupServiceTests
+    {
+        [Fact]
+        public async Task InvalidRecordFailureIsLoggedWithoutStoppingTheService()
+        {
+            InvalidDataException failure = new InvalidDataException("Invalid report record.");
+            Mock<ReportStore> reports = CreateReports(failure);
+            TaskCompletionSource logged = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            Mock<ILogger<ReportCleanupService>> logger = new Mock<ILogger<ReportCleanupService>>();
+            logger.Setup(log => log.Log(LogLevel.Error, It.IsAny<EventId>(),
+                    It.IsAny<It.IsAnyType>(), failure, It.IsAny<Func<It.IsAnyType, Exception?, string>>()))
+                .Callback(() =>
+                {
+                    logged.TrySetResult();
+                });
+            using ReportCleanupService service = new ReportCleanupService(reports.Object, logger.Object);
+
+            try
+            {
+                await service.StartAsync(CancellationToken.None);
+                await logged.Task.WaitAsync(TimeSpan.FromSeconds(10));
+
+                Assert.NotNull(service.ExecuteTask);
+                Assert.False(service.ExecuteTask.IsCompleted);
+                reports.Verify(store => store.CleanupAsync(It.IsAny<CancellationToken>()), Times.Once);
+            }
+            finally
+            {
+                await service.StopAsync(CancellationToken.None);
+            }
+        }
+
+        [Fact]
+        public async Task UnexpectedFailuresAreNotSwallowed()
+        {
+            InvalidOperationException failure = new InvalidOperationException("Unexpected cleanup bug.");
+            Mock<ReportStore> reports = CreateReports(failure);
+            using ReportCleanupService service = new ReportCleanupService(reports.Object, NullLogger<ReportCleanupService>.Instance);
+
+            await service.StartAsync(CancellationToken.None);
+
+            InvalidOperationException actual = await Assert.ThrowsAsync<InvalidOperationException>(
+                () => service.ExecuteTask!.WaitAsync(TimeSpan.FromSeconds(10)));
+            Assert.Same(failure, actual);
+        }
+
+        private static Mock<ReportStore> CreateReports(Exception failure)
+        {
+            Mock<ReportStore> reports = new Mock<ReportStore>(Mock.Of<BlobContainerClient>(), NullLogger<ReportStore>.Instance, TimeProvider.System);
+            reports.Setup(store => store.CleanupAsync(It.IsAny<CancellationToken>())).ThrowsAsync(failure);
+            return reports;
+        }
+    }
+}

--- a/SeattleCarsInBikeLanes.Tests/ReportStoreTests.cs
+++ b/SeattleCarsInBikeLanes.Tests/ReportStoreTests.cs
@@ -1,0 +1,1985 @@
+using System.Collections.Concurrent;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Azure;
+using Azure.Storage;
+using Azure.Storage.Blobs;
+using Azure.Storage.Blobs.Models;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using SeattleCarsInBikeLanes.Core.Contracts;
+using SeattleCarsInBikeLanes.Providers;
+using SeattleCarsInBikeLanes.Storage.Models;
+
+namespace SeattleCarsInBikeLanes.Tests
+{
+    public class ReportStoreTests
+    {
+        private const string Id = "0123456789abcdef0123456789abcdef";
+        private const string RecordName = ReportStore.BlobPrefix + Id + ".json";
+        private static readonly ReportAttribution Anonymous = new ReportAttribution();
+        private static readonly string[] InvalidRecordKinds =
+        [
+            "json", "schema", "oversized", "photos-null", "photo-null", "metadata-null", "photos-empty",
+            "receipt-null", "attribution-null", "attribution-invalid", "receipt-submission",
+            "attempt-invalid", "attempt-null", "foreign-photo", "foreign-report-photo", "unsafe-photo", "photo-attempt",
+            "metadata-report", "metadata-report-missing", "metadata-device", "document-device",
+            "etag-null", "etag-empty", "etag-wildcard",
+            "moderation-id", "moderation-kind", "moderation-started", "moderation-photo-null",
+            "moderation-metadata-null", "moderation-without-owner", "moderation-reference", "moderation-context",
+            "started-overflow", "started-utc-overflow", "started-missing", "preparing-with-receipt",
+            "abandoned-with-receipt", "accepted-cleanup", "cleanup-null", "cleanup-null-item", "cleanup-late-null-item",
+            "cleanup-foreign", "cleanup-unknown-own", "cleanup-unconditional-photo", "cleanup-etag-mismatch",
+            "cleanup-incomplete", "cleanup-duplicate", "retired-without-owner", "compacted-with-inventory"
+        ];
+
+        public static IEnumerable<object[]> InvalidRecords()
+        {
+            return InvalidRecordKinds.Select(kind => new object[] { kind });
+        }
+
+        public static IEnumerable<object[]> InvalidCleanupRecords()
+        {
+            return InvalidRecordKinds.SelectMany(kind => new[] { new object[] { kind, true }, new object[] { kind, false } });
+        }
+
+        [Theory]
+        [InlineData("0123456789abcdef0123456789abcdef", true)]
+        [InlineData("ABCDEF0123456789abcdef0123456789", false)]
+        [InlineData("0123456789abcdef0123456789abcde", false)]
+        [InlineData("../0123456789abcdef0123456789abc", false)]
+        [InlineData(null, false)]
+        public void RequiresLowercase128BitIds(string? id, bool valid)
+        {
+            Assert.Equal(valid, ReportStore.IsValidReportId(id));
+        }
+
+        [Fact]
+        public void KeepsAllPermanentStorageUnderTheEstablishedFinalizedUploadPrefix()
+        {
+            Assert.Equal("finalizedupload/", ReportStore.FinalizedUploadPrefix);
+            Assert.Equal("finalizedupload/reports/", ReportStore.BlobPrefix);
+            Assert.Equal("finalizedupload/photos/", ReportStore.PhotoPrefix);
+        }
+
+        [Fact]
+        public async Task RetiringNewReportLeavesUnadoptedFlatUploadsUntouched()
+        {
+            MemoryBlobs blobs = new MemoryBlobs();
+            blobs.Seed("finalizedupload/existing.jpeg", [1, 2, 3]);
+            blobs.Seed("finalizedupload/existing.json", Encoding.UTF8.GetBytes("""{"SubmissionId":"existing"}"""));
+            ReportStore store = CreateStore(blobs);
+            await store.CommitAsync(Id, null, Anonymous, Prepare(blobs));
+            SubmissionReport owned = await store.BeginModerationAsync(Id, "deleting");
+
+            await store.RetireAsync(Id, owned.Moderation!.Id);
+            await store.CleanupAsync();
+
+            Assert.True(blobs.Contains("finalizedupload/existing.jpeg"));
+            Assert.True(blobs.Contains("finalizedupload/existing.json"));
+            Assert.Empty(blobs.Names(ReportStore.PhotoPrefix));
+            Assert.True(blobs.Contains(RecordName));
+        }
+
+        [Fact]
+        public async Task AcceptsTheWholeSetWithCheckedSeparateJpegsAndImmutableReceipt()
+        {
+            MemoryBlobs blobs = new MemoryBlobs();
+            ReportStore store = CreateStore(blobs);
+            PreparedSubmissionPhoto[] photos = Prepare(blobs, 4);
+
+            blobs.Before = async operation =>
+            {
+                if (operation.Kind == "photo")
+                {
+                    using JsonDocument record = JsonDocument.Parse(blobs.Bytes(RecordName));
+                    Assert.Equal("Preparing", record.RootElement.GetProperty("State").GetString());
+                    Assert.Equal(4, record.RootElement.GetProperty("Photos").GetArrayLength());
+                    Assert.Empty(await Pending(store));
+                }
+            };
+
+            SubmissionReceipt receipt = await store.CommitAsync(Id, "device", Anonymous, photos);
+            SubmissionReport report = Assert.Single(await Pending(store));
+            Assert.Equal(receipt, report.Receipt);
+            Assert.NotNull(report.Version);
+            Assert.Equal(4, report.Photos.Count);
+            Assert.Equal("preparation", receipt.SubmissionId);
+            Assert.DoesNotContain("\"Version\"", blobs.Text(RecordName));
+            for (int index = 0; index < photos.Length; index++)
+            {
+                SubmissionPhoto photo = report.Photos[index];
+                Assert.StartsWith(ReportStore.PhotoPrefix + Id + "/", photo.BlobName);
+                Assert.Equal(blobs.Bytes(photos[index].BlobName), blobs.Bytes(photo.BlobName));
+                Assert.Equal(blobs.Version(photo.BlobName), photo.ETag);
+                Assert.Equal("device", photo.Metadata.DeviceId);
+                Assert.Equal(Id, photo.Metadata.ReportId);
+                Assert.Contains(blobs.Operations, op => op.Kind == "stream" && op.Name == photos[index].BlobName &&
+                    op.Conditions?.IfMatch.ToString() == photos[index].ETag);
+                Assert.Contains(blobs.Operations, op => op.Kind == "properties" && op.Name == photo.BlobName &&
+                    op.Conditions?.IfMatch.ToString() == photo.ETag);
+            }
+        }
+
+        [Fact]
+        public async Task ReconcilesBeforeValidatingExpiredInputsAndKeepsFirstAttribution()
+        {
+            MemoryBlobs blobs = new MemoryBlobs();
+            ReportStore store = CreateStore(blobs);
+            ReportAttribution first = new ReportAttribution(BlueskyDid: "did:plc:first");
+            SubmissionReceipt accepted = await store.CommitAsync(Id, null, first, Prepare(blobs));
+            blobs.Remove("initialupload/photo0.jpeg");
+
+            SubmissionReceipt retry = await store.CommitAsync(Id, null, new ReportAttribution("invalid"), []);
+
+            Assert.Equal(accepted, retry);
+            Assert.Equal(first, (await store.GetAsync(Id, null))!.Receipt.Attribution);
+            Assert.Single(blobs.Names(ReportStore.PhotoPrefix));
+        }
+
+        [Theory]
+        [InlineData(null, "device")]
+        [InlineData("device", null)]
+        [InlineData("device", "other-device")]
+        public async Task DoesNotRebindAnyAcceptedSubmittingContext(string? original, string? replacement)
+        {
+            MemoryBlobs blobs = new MemoryBlobs();
+            ReportStore store = CreateStore(blobs);
+            await store.CommitAsync(Id, original, Anonymous, Prepare(blobs));
+            await Assert.ThrowsAsync<ReportDeviceMismatchException>(() => store.GetAsync(Id, replacement));
+            await Assert.ThrowsAsync<ReportDeviceMismatchException>(() => store.CommitAsync(Id, replacement, Anonymous, []));
+        }
+
+        [Theory]
+        [InlineData("Preparing")]
+        [InlineData("Accepted")]
+        public async Task RecoversLostCoordinatorWriteResponses(string state)
+        {
+            MemoryBlobs blobs = new MemoryBlobs();
+            ReportStore store = CreateStore(blobs);
+            bool injected = false;
+            blobs.After = op =>
+            {
+                if (!injected && op.State == state)
+                {
+                    injected = true;
+                    throw Unavailable();
+                }
+                return Task.CompletedTask;
+            };
+            SubmissionReceipt receipt = await store.CommitAsync(Id, null, Anonymous, Prepare(blobs));
+            Assert.True(injected);
+            Assert.Equal(receipt, (await store.GetAsync(Id, null))!.Receipt);
+            Assert.Single(blobs.Names(ReportStore.PhotoPrefix));
+        }
+
+        [Fact]
+        public async Task UnavailableReconciliationDoesNotUndoAnAcceptedReport()
+        {
+            MemoryBlobs blobs = new MemoryBlobs();
+            ReportStore store = CreateStore(blobs);
+            int unavailableReads = 0;
+            blobs.After = op =>
+            {
+                if (op.State == "Accepted")
+                {
+                    unavailableReads = 2;
+                    throw Unavailable();
+                }
+                return Task.CompletedTask;
+            };
+            blobs.Before = op =>
+            {
+                if (op.Kind == "read" && unavailableReads-- > 0)
+                {
+                    throw Unavailable();
+                }
+
+                return Task.CompletedTask;
+            };
+            await Assert.ThrowsAsync<RequestFailedException>(() =>
+                store.CommitAsync(Id, null, new ReportAttribution("did:plc:first"), Prepare(blobs)));
+            Assert.Contains("\"State\":\"Accepted\"", blobs.Text(RecordName));
+
+            SubmissionReceipt recovered = await store.CommitAsync(Id, null, new ReportAttribution("invalid"), []);
+            Assert.Equal("did:plc:first", recovered.Attribution.BlueskyDid);
+            Assert.Single(blobs.Names(ReportStore.PhotoPrefix));
+        }
+
+        [Fact]
+        public async Task LostReservationWithUnavailableReconciliationRemainsFencedUntilTakeover()
+        {
+            MemoryBlobs blobs = new MemoryBlobs();
+            ManualClock clock = new ManualClock();
+            ReportStore store = CreateStore(blobs, clock);
+            int unavailableReads = 0;
+            bool failed = false;
+            blobs.After = op =>
+            {
+                if (!failed && op.State == "Preparing")
+                {
+                    failed = true;
+                    unavailableReads = 1;
+                    throw Unavailable();
+                }
+                return Task.CompletedTask;
+            };
+            blobs.Before = op => op.Kind == "read" && unavailableReads-- > 0
+                ? throw Unavailable() : Task.CompletedTask;
+            await Assert.ThrowsAsync<RequestFailedException>(() => store.CommitAsync(Id, null, Anonymous, Prepare(blobs)));
+            Assert.Empty(blobs.Names(ReportStore.PhotoPrefix));
+            await Assert.ThrowsAsync<ReportInProgressException>(() => store.CommitAsync(Id, null, Anonymous, []));
+            clock.Advance(ReportStore.PreparationTimeout);
+            SubmissionReceipt receipt = await store.CommitAsync(Id, null, Anonymous, Prepare(blobs, 1, "retry"));
+            Assert.Equal("retry", receipt.SubmissionId);
+        }
+
+        [Theory]
+        [InlineData("record", "Preparing", false)]
+        [InlineData("photo", null, false)]
+        [InlineData("photo", null, true)]
+        [InlineData("record", "Accepted", false)]
+        public async Task FailedAttemptCanRetryWithFreshPreparationWithoutLeakingPendingPhotos(
+            string kind, string? state, bool after)
+        {
+            MemoryBlobs blobs = new MemoryBlobs();
+            ReportStore store = CreateStore(blobs);
+            bool failed = false;
+            Task Fail(Operation op)
+            {
+                if (!failed && op.Kind == kind && (state is null || op.State == state))
+                {
+                    failed = true;
+                    throw Unavailable();
+                }
+                return Task.CompletedTask;
+            }
+            if (after)
+            {
+                blobs.After = Fail;
+            }
+            else
+            {
+                blobs.Before = Fail;
+            }
+
+            await Assert.ThrowsAsync<RequestFailedException>(() => store.CommitAsync(Id, null, Anonymous, Prepare(blobs, 2)));
+            Assert.True(failed);
+            Assert.Null(await store.GetAsync(Id, null));
+            Assert.Empty(await Pending(store));
+            string[] old = blobs.Names(ReportStore.PhotoPrefix);
+            PreparedSubmissionPhoto[] fresh = Prepare(blobs, 2, "fresh");
+            SubmissionReceipt retry = await store.CommitAsync(Id, null, new ReportAttribution("did:plc:retry"), fresh);
+            Assert.Equal("fresh", retry.SubmissionId);
+            SubmissionReport report = Assert.Single(await Pending(store));
+            Assert.DoesNotContain(report.Photos, p => old.Contains(p.BlobName));
+            await store.CleanupAsync();
+            Assert.Equal(report.Photos.Select(p => p.BlobName).Order(), blobs.Names(ReportStore.PhotoPrefix).Order());
+        }
+
+        [Fact]
+        public async Task AConcurrentFreshAttemptSeesProgressThenTheOriginalReceipt()
+        {
+            MemoryBlobs blobs = new MemoryBlobs();
+            ReportStore store = CreateStore(blobs);
+            Gate gate = new Gate();
+            blobs.Before = op => op.Kind == "photo" ? gate.Pause() : Task.CompletedTask;
+            Task<SubmissionReceipt> first = store.CommitAsync(Id, null, new ReportAttribution("did:plc:first"), Prepare(blobs));
+            await gate.Entered.Task;
+
+            ReportInProgressException progress = await Assert.ThrowsAsync<ReportInProgressException>(
+                () => store.CommitAsync(Id, null, new ReportAttribution("did:plc:second"), Prepare(blobs, 1, "second")));
+            Assert.True(progress.RetryAfter > TimeSpan.Zero);
+            await Assert.ThrowsAsync<ReportInProgressException>(() => store.GetAsync(Id, null));
+            Assert.Empty(await Pending(store));
+            gate.Resume();
+
+            SubmissionReceipt receipt = await first;
+            Assert.Equal(receipt, await store.CommitAsync(Id, null, Anonymous, []));
+            Assert.Equal("did:plc:first", receipt.Attribution.BlueskyDid);
+        }
+
+        [Fact]
+        public async Task SimultaneousReservationsUseCreateConditionsAndOneWinner()
+        {
+            MemoryBlobs blobs = new MemoryBlobs();
+            ReportStore store = CreateStore(blobs);
+            Gate gate = new Gate();
+            int prepares = 0;
+            blobs.Before = op => op.State == "Preparing" && Interlocked.Increment(ref prepares) == 1
+                ? gate.Pause() : Task.CompletedTask;
+            Task<SubmissionReceipt> first = store.CommitAsync(Id, null, new ReportAttribution("did:plc:first"), Prepare(blobs));
+            await gate.Entered.Task;
+            SubmissionReceipt winner = await store.CommitAsync(Id, null, new ReportAttribution("did:plc:second"), Prepare(blobs, 1, "second"));
+            gate.Resume();
+            Assert.Equal(winner, await first);
+            Assert.Single(blobs.Names(ReportStore.PhotoPrefix));
+            Assert.All(blobs.Operations.Where(op => op.State == "Preparing"), op =>
+                Assert.Equal(ETag.All, op.Conditions!.IfNoneMatch));
+        }
+
+        [Fact]
+        public async Task TakeoverFencesOldWriterAndUsesDisjointAttemptPaths()
+        {
+            MemoryBlobs blobs = new MemoryBlobs();
+            ManualClock clock = new ManualClock();
+            ReportStore store = CreateStore(blobs, clock);
+            Gate gate = new Gate();
+            int uploads = 0;
+            blobs.Before = op => op.Kind == "photo" && Interlocked.Increment(ref uploads) == 1
+                ? gate.Pause() : Task.CompletedTask;
+            Task<SubmissionReceipt> old = store.CommitAsync(Id, null, new ReportAttribution("did:plc:old"), Prepare(blobs));
+            await gate.Entered.Task;
+            string oldVersion = blobs.Version(RecordName);
+            clock.Advance(ReportStore.PreparationTimeout + TimeSpan.FromSeconds(1));
+
+            SubmissionReceipt winner = await store.CommitAsync(Id, null, new ReportAttribution("did:plc:new"), Prepare(blobs, 1, "new"));
+            Assert.NotEqual(oldVersion, blobs.Version(RecordName));
+            gate.Resume();
+            Assert.Equal(winner, await old);
+            Assert.Equal(2, blobs.Names(ReportStore.PhotoPrefix).Length);
+            Assert.Equal("new", winner.SubmissionId);
+            await store.CleanupAsync();
+            Assert.Single(blobs.Names(ReportStore.PhotoPrefix));
+            Assert.Equal(winner, (await store.GetAsync(Id, null))!.Receipt);
+        }
+
+        [Fact]
+        public async Task ExpiryCleanupFencesBeforeDeletingAndCollectsRepeatedLateWrites()
+        {
+            MemoryBlobs blobs = new MemoryBlobs();
+            ManualClock clock = new ManualClock();
+            ReportStore store = CreateStore(blobs, clock);
+            Gate gate = new Gate();
+            string? delayedPhoto = null;
+            blobs.Before = op =>
+            {
+                if (op.Kind == "photo")
+                {
+                    delayedPhoto = op.Name;
+                    return gate.Pause();
+                }
+                return Task.CompletedTask;
+            };
+            Task<SubmissionReceipt> old = store.CommitAsync(Id, null, Anonymous, Prepare(blobs));
+            await gate.Entered.Task;
+            string version = blobs.Version(RecordName);
+            clock.Advance(ReportStore.PreparationTimeout + TimeSpan.FromSeconds(1));
+            await store.CleanupAsync();
+            Assert.NotEqual(version, blobs.Version(RecordName));
+            Assert.Contains("\"State\":\"Abandoned\"", blobs.Text(RecordName));
+            gate.Resume();
+            await Assert.ThrowsAsync<ReportInProgressException>(() => old);
+            Assert.True(blobs.Contains(delayedPhoto!));
+
+            await store.CleanupAsync();
+            Assert.False(blobs.Contains(delayedPhoto!));
+            blobs.Seed(delayedPhoto!, [1, 2, 3]);
+            await store.CleanupAsync();
+            Assert.False(blobs.Contains(delayedPhoto!));
+            Assert.Null(await store.GetAsync(Id, null));
+        }
+
+        [Fact]
+        public async Task CleanupLosingTheAbandonCasCannotDeleteAcceptedPhotos()
+        {
+            MemoryBlobs blobs = new MemoryBlobs();
+            ManualClock clock = new ManualClock();
+            ReportStore store = CreateStore(blobs, clock);
+            Gate accept = new Gate();
+            Gate abandon = new Gate();
+            blobs.Before = op => op.State == "Accepted" ? accept.Pause() :
+                op.State == "Abandoned" ? abandon.Pause() : Task.CompletedTask;
+            Task<SubmissionReceipt> commit = store.CommitAsync(Id, null, Anonymous, Prepare(blobs));
+            await accept.Entered.Task;
+            clock.Advance(ReportStore.PreparationTimeout + TimeSpan.FromSeconds(1));
+            Task cleanup = store.CleanupAsync();
+            await abandon.Entered.Task;
+            accept.Resume();
+            SubmissionReceipt receipt = await commit;
+            abandon.Resume();
+            await cleanup;
+            Assert.Single(blobs.Names(ReportStore.PhotoPrefix));
+            Assert.Equal(receipt, (await store.GetAsync(Id, null))!.Receipt);
+        }
+
+        [Fact]
+        public async Task CleanupDoesNotInferSafetyFromMissingRecordsOrUncertainModeration()
+        {
+            MemoryBlobs blobs = new MemoryBlobs();
+            ManualClock clock = new ManualClock();
+            ReportStore store = CreateStore(blobs, clock);
+            await store.CommitAsync(Id, null, Anonymous, Prepare(blobs));
+            await store.BeginModerationAsync(Id, "publishing");
+            string orphan = $"{ReportStore.PhotoPrefix}{new string('a', 32)}/{new string('b', 32)}/0.jpeg";
+            blobs.Seed(orphan, [8, 9]);
+            clock.Advance(TimeSpan.FromDays(900));
+            await store.CleanupAsync();
+            Assert.Equal(2, blobs.Names(ReportStore.PhotoPrefix).Length);
+            Assert.NotNull(Assert.Single(await Pending(store)).Moderation);
+        }
+
+        [Theory]
+        [InlineData(false, false)]
+        [InlineData(true, false)]
+        [InlineData(false, true)]
+        [InlineData(true, true)]
+        public async Task FailedCleanupReadCannotAuthorizeDeletingPhotos(bool photoSweep, bool ioFailure)
+        {
+            MemoryBlobs blobs = new MemoryBlobs();
+            ReportStore store = CreateStore(blobs);
+            await store.CommitAsync(Id, null, Anonymous, Prepare(blobs));
+            Exception failure = ioFailure ? new IOException("Storage read failed.") : Unavailable();
+            int reads = 0;
+            blobs.Before = op => op.Kind == "read" && ++reads == (photoSweep ? 2 : 1)
+                ? throw failure : Task.CompletedTask;
+            Assert.Same(failure, await Record.ExceptionAsync(() => store.CleanupAsync()));
+            Assert.Single(blobs.Names(ReportStore.PhotoPrefix));
+            Assert.DoesNotContain(blobs.Operations, op => op.Kind == "delete");
+        }
+
+        [Theory]
+        [MemberData(nameof(InvalidCleanupRecords))]
+        public async Task CleanupQuarantinesInvalidRecordsAndTheirPhotosAcrossBothSweeps(
+            string corruption, bool recordListed)
+        {
+            MemoryBlobs blobs = new MemoryBlobs();
+            Mock<ILogger<ReportStore>> logger = new Mock<ILogger<ReportStore>>();
+            ReportStore store = new ReportStore(blobs.Container.Object, logger.Object);
+            await store.CommitAsync(Id, null, Anonymous, Prepare(blobs, 2));
+            string unsafePrefix = ReportStore.PhotoPrefix + Id + "/";
+            blobs.Seed($"{unsafePrefix}{new string('b', 32)}/late.jpeg", [8, 9]);
+            const string unrelatedPhoto = "initialupload/unrelated.jpeg";
+            blobs.Seed(unrelatedPhoto, [5, 6]);
+            string unrelatedReportPhoto = $"{ReportStore.PhotoPrefix}{new string('c', 32)}/{new string('d', 32)}/0.jpeg";
+            blobs.Seed(unrelatedReportPhoto, [6, 7]);
+            Dictionary<string, (byte[] Content, string Version)> unsafePhotos = blobs.Names(unsafePrefix)
+                .Append(unrelatedPhoto).Append(unrelatedReportPhoto)
+                .ToDictionary(name => name, name => (blobs.Bytes(name), blobs.Version(name)));
+            byte[] invalidRecord = InvalidRecordBytes(blobs.Bytes(RecordName), corruption);
+            string invalidVersion = blobs.Seed(RecordName, invalidRecord);
+
+            string otherId = new string('a', 32);
+            SubmissionReceipt otherReceipt = await store.CommitAsync(otherId, null, Anonymous, Prepare(blobs, 1, "other"));
+            string otherPhoto = Assert.Single(blobs.Names(ReportStore.PhotoPrefix + otherId + "/"));
+            SubmissionReport owned = await store.BeginModerationAsync(otherId, "deleting");
+            blobs.Before = op => op.Kind == "delete" ? throw Unavailable() : Task.CompletedTask;
+            await store.RetireAsync(otherId, owned.Moderation!.Id);
+            blobs.Before = null;
+            string otherOrphan = $"{ReportStore.PhotoPrefix}{otherId}/{new string('b', 32)}/late.jpeg";
+            if (!recordListed)
+            {
+                // A coordinator created after the first listing is only discovered by its photos.
+                blobs.Container.Setup(c => c.GetBlobsAsync(BlobTraits.None, BlobStates.None,
+                        ReportStore.BlobPrefix, It.IsAny<CancellationToken>()))
+                    .Returns(AsyncPageable<BlobItem>.FromPages([Page<BlobItem>.FromValues(
+                        [BlobsModelFactory.BlobItem(name: ReportStore.BlobPrefix + otherId + ".json")],
+                        null, Mock.Of<Response>())]));
+            }
+
+            for (int sweep = 0; sweep < 2; sweep++)
+            {
+                blobs.Seed(otherOrphan, [3, 4]);
+                blobs.Operations.Clear();
+
+                await store.CleanupAsync();
+
+                Assert.Equal(invalidRecord, blobs.Bytes(RecordName));
+                Assert.Equal(invalidVersion, blobs.Version(RecordName));
+                Assert.All(unsafePhotos, photo =>
+                {
+                    Assert.Equal(photo.Value.Content, blobs.Bytes(photo.Key));
+                    Assert.Equal(photo.Value.Version, blobs.Version(photo.Key));
+                });
+                Assert.Single(blobs.Operations, op => op.Kind == "read" && op.Name == RecordName);
+                Assert.DoesNotContain(blobs.Operations, op =>
+                    op.Kind is "record" or "delete" && (op.Name == RecordName || unsafePhotos.ContainsKey(op.Name)));
+                Assert.False(blobs.Contains(otherOrphan));
+                Assert.False(blobs.Contains(otherPhoto));
+                Assert.Contains("\"Cleanup\":[]", blobs.Text(ReportStore.BlobPrefix + otherId + ".json"));
+                Assert.Equal(otherReceipt, (await store.GetAsync(otherId, null))!.Receipt);
+            }
+
+            logger.Verify(log => log.Log(LogLevel.Warning, It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((state, _) => state.ToString()!.Contains(Id)),
+                It.Is<Exception>(ex => ex is InvalidDataException || ex is JsonException),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()), Times.Exactly(2));
+        }
+
+        [Fact]
+        public async Task CleanupQuarantinesCorruptionFoundWhileReconcilingAnExpiredReservation()
+        {
+            MemoryBlobs blobs = new MemoryBlobs();
+            ManualClock clock = new ManualClock();
+            ReportStore store = CreateStore(blobs, clock);
+            byte[]? reservation = null;
+            blobs.Before = op =>
+            {
+                if (op.Name == RecordName && op.State == "Preparing")
+                {
+                    reservation = op.Content;
+                }
+
+                return Task.CompletedTask;
+            };
+            await store.CommitAsync(Id, null, Anonymous, Prepare(blobs));
+            string photo = Assert.Single(blobs.Names(ReportStore.PhotoPrefix));
+            blobs.Seed(RecordName, reservation!);
+            clock.Advance(ReportStore.PreparationTimeout);
+
+            string otherId = new string('a', 32);
+            await store.CommitAsync(otherId, null, Anonymous, Prepare(blobs, 1, "other"));
+            string otherOrphan = $"{ReportStore.PhotoPrefix}{otherId}/{new string('b', 32)}/late.jpeg";
+            blobs.Seed(otherOrphan, [3, 4]);
+            byte[] invalidRecord = InvalidRecordBytes(reservation!, "schema");
+            string? invalidVersion = null;
+            blobs.Before = op =>
+            {
+                if (op.Name == RecordName && op.State == "Abandoned")
+                {
+                    invalidVersion = blobs.Seed(RecordName, invalidRecord);
+                    throw Unavailable();
+                }
+                return Task.CompletedTask;
+            };
+            blobs.Operations.Clear();
+
+            await store.CleanupAsync();
+
+            Assert.NotNull(invalidVersion);
+            Assert.Equal(invalidRecord, blobs.Bytes(RecordName));
+            Assert.Equal(invalidVersion, blobs.Version(RecordName));
+            Assert.True(blobs.Contains(photo));
+            Assert.DoesNotContain(blobs.Operations, op => op.Kind == "delete" && op.Name == photo);
+            Assert.Equal(2, blobs.Operations.Count(op => op.Kind == "read" && op.Name == RecordName));
+            Assert.False(blobs.Contains(otherOrphan));
+        }
+
+        [Theory]
+        [InlineData(503, "ServerBusy")]
+        [InlineData(403, "AuthorizationFailure")]
+        [InlineData(404, "ContainerNotFound")]
+        public async Task ReadFailuresNeverBecomeAbsence(int status, string errorCode)
+        {
+            MemoryBlobs blobs = new MemoryBlobs();
+            blobs.Before = op => op.Kind == "read"
+                ? throw new RequestFailedException(status, "Failure", errorCode, null) : Task.CompletedTask;
+            ReportStore store = CreateStore(blobs);
+            await Assert.ThrowsAsync<RequestFailedException>(() => store.GetAsync(Id, null));
+            await Assert.ThrowsAsync<RequestFailedException>(() => store.CommitAsync(Id, null, Anonymous, []));
+            Assert.Empty(blobs.Names(ReportStore.BlobPrefix));
+        }
+
+        [Theory]
+        [InlineData(256 * 1024 + 1L)]
+        [InlineData(long.MaxValue)]
+        public async Task OversizedRecordHeadersAreRejectedBeforeOpeningTheBody(long length)
+        {
+            MemoryBlobs blobs = new MemoryBlobs();
+            ReportStore store = CreateStore(blobs);
+            await store.CommitAsync(Id, null, Anonymous, Prepare(blobs));
+            byte[] record = blobs.Bytes(RecordName);
+            string version = blobs.Version(RecordName);
+            string photo = Assert.Single(blobs.Names(ReportStore.PhotoPrefix));
+            blobs.PropertyLength = name => name == RecordName ? length : null;
+            blobs.Operations.Clear();
+
+            await Assert.ThrowsAsync<InvalidDataException>(() => store.GetAsync(Id, null));
+            await Assert.ThrowsAsync<InvalidDataException>(() => store.CommitAsync(Id, null, Anonymous, []));
+            await store.CleanupAsync();
+
+            Assert.Equal(record, blobs.Bytes(RecordName));
+            Assert.Equal(version, blobs.Version(RecordName));
+            Assert.True(blobs.Contains(photo));
+            Assert.DoesNotContain(blobs.Operations, op => op.Kind is "record-stream" or "record" or "delete");
+        }
+
+        [Fact]
+        public async Task RecordReadsPinTheCheckedVersionAndRetryConcurrentChanges()
+        {
+            MemoryBlobs blobs = new MemoryBlobs();
+            ReportStore store = CreateStore(blobs);
+            SubmissionReceipt receipt = await store.CommitAsync(Id, null, Anonymous, Prepare(blobs));
+            string originalVersion = blobs.Version(RecordName);
+            string? replacementVersion = null;
+            blobs.After = op =>
+            {
+                if (op.Kind == "read" && op.Name == RecordName && replacementVersion is null)
+                {
+                    replacementVersion = blobs.Seed(RecordName, blobs.Bytes(RecordName));
+                }
+
+                return Task.CompletedTask;
+            };
+            blobs.Operations.Clear();
+
+            SubmissionReport report = (await store.GetAsync(Id, null))!;
+
+            Assert.Equal(receipt, report.Receipt);
+            Assert.Equal(replacementVersion, report.Version);
+            Assert.NotEqual(originalVersion, report.Version);
+            Assert.Equal(2, blobs.Operations.Count(op => op.Kind == "read" && op.Name == RecordName));
+            Assert.Collection(blobs.Operations.Where(op => op.Kind == "record-stream"),
+                op => Assert.Equal(originalVersion, op.Conditions!.IfMatch.ToString()),
+                op => Assert.Equal(replacementVersion, op.Conditions!.IfMatch.ToString()));
+        }
+
+        [Fact]
+        public async Task RepeatedRecordChangesRemainRetryableWithoutAuthorizingDeletion()
+        {
+            MemoryBlobs blobs = new MemoryBlobs();
+            ReportStore store = CreateStore(blobs);
+            SubmissionReceipt receipt = await store.CommitAsync(Id, null, Anonymous, Prepare(blobs));
+            RequestFailedException failure = new RequestFailedException(412, "Record changed", "ConditionNotMet", null);
+            blobs.Before = op => op.Kind == "record-stream" ? throw failure : Task.CompletedTask;
+            blobs.Operations.Clear();
+
+            Assert.Same(failure, await Assert.ThrowsAsync<RequestFailedException>(() => store.CleanupAsync()));
+
+            Assert.Equal(3, blobs.Operations.Count(op => op.Kind == "read"));
+            Assert.Equal(3, blobs.Operations.Count(op => op.Kind == "record-stream"));
+            Assert.DoesNotContain(blobs.Operations, op => op.Kind is "record" or "delete");
+            Assert.Single(blobs.Names(ReportStore.PhotoPrefix));
+            blobs.Before = null;
+            Assert.Equal(receipt, (await store.GetAsync(Id, null))!.Receipt);
+        }
+
+        [Fact]
+        public async Task ARecordRemovedDuringConditionalDownloadCannotAuthorizePhotoDeletion()
+        {
+            MemoryBlobs blobs = new MemoryBlobs();
+            ReportStore store = CreateStore(blobs);
+            await store.CommitAsync(Id, null, Anonymous, Prepare(blobs));
+            blobs.Before = op =>
+            {
+                if (op.Kind == "record-stream")
+                {
+                    blobs.Remove(RecordName);
+                }
+
+                return Task.CompletedTask;
+            };
+            blobs.Operations.Clear();
+
+            Assert.Null(await store.GetAsync(Id, null));
+            await store.CleanupAsync();
+
+            Assert.Single(blobs.Names(ReportStore.PhotoPrefix));
+            Assert.DoesNotContain(blobs.Operations, op => op.Kind == "delete");
+        }
+
+        [Theory]
+        [InlineData(503, "ServerBusy")]
+        [InlineData(403, "AuthorizationFailure")]
+        [InlineData(404, "ContainerNotFound")]
+        [InlineData(412, "LeaseIdMismatchWithBlobOperation")]
+        public async Task RecordStreamStorageFailuresAreNotAbsenceOrQuarantine(int status, string errorCode)
+        {
+            MemoryBlobs blobs = new MemoryBlobs();
+            ReportStore store = CreateStore(blobs);
+            await store.CommitAsync(Id, null, Anonymous, Prepare(blobs));
+            RequestFailedException failure = new RequestFailedException(status, "Read failure", errorCode, null);
+            blobs.Before = op => op.Kind == "record-stream" ? throw failure : Task.CompletedTask;
+            blobs.Operations.Clear();
+
+            Assert.Same(failure, await Assert.ThrowsAsync<RequestFailedException>(() => store.GetAsync(Id, null)));
+            Assert.Same(failure, await Assert.ThrowsAsync<RequestFailedException>(() => store.CleanupAsync()));
+
+            Assert.Equal(2, blobs.Operations.Count(op => op.Kind == "record-stream"));
+            Assert.DoesNotContain(blobs.Operations, op => op.Kind is "record" or "delete");
+            Assert.Single(blobs.Names(ReportStore.PhotoPrefix));
+        }
+
+        [Fact]
+        public async Task RecordBodyIoFailuresPropagateWithoutAuthorizingDeletion()
+        {
+            MemoryBlobs blobs = new MemoryBlobs();
+            ReportStore store = CreateStore(blobs);
+            await store.CommitAsync(Id, null, Anonymous, Prepare(blobs));
+            IOException failure = new IOException("Record body interrupted.");
+            blobs.RecordStreamFactory = (_, _) => new FailedReadStream(failure);
+            blobs.Operations.Clear();
+
+            Assert.Same(failure, await Assert.ThrowsAsync<IOException>(() => store.GetAsync(Id, null)));
+            Assert.Same(failure, await Assert.ThrowsAsync<IOException>(() => store.CleanupAsync()));
+
+            Assert.DoesNotContain(blobs.Operations, op => op.Kind is "record" or "delete");
+            Assert.Single(blobs.Names(ReportStore.PhotoPrefix));
+        }
+
+        [Theory]
+        [InlineData("short")]
+        [InlineData("long")]
+        [InlineData("endless")]
+        [InlineData("oversized-header")]
+        public async Task CleanupBoundsInvalidRecordStreamsAndPreservesTheirPhotos(string failure)
+        {
+            MemoryBlobs blobs = new MemoryBlobs();
+            ReportStore store = CreateStore(blobs);
+            await store.CommitAsync(Id, null, Anonymous, Prepare(blobs));
+            string photo = Assert.Single(blobs.Names(ReportStore.PhotoPrefix));
+            byte[] record = blobs.Bytes(RecordName);
+            string version = blobs.Version(RecordName);
+            string otherId = new string('a', 32);
+            await store.CommitAsync(otherId, null, Anonymous, Prepare(blobs, 1, "other"));
+            string orphan = $"{ReportStore.PhotoPrefix}{otherId}/{new string('b', 32)}/late.jpeg";
+            blobs.Seed(orphan, [1, 2]);
+            List<ObservedReadStream> streams = [];
+            blobs.RecordStreamFactory = (name, bytes) =>
+            {
+                if (name != RecordName)
+                {
+                    return new MemoryStream(bytes, writable: false);
+                }
+
+                ObservedReadStream stream = failure switch
+                {
+                    "short" => new ObservedReadStream(bytes[..^1]),
+                    "long" => new ObservedReadStream([.. bytes, 255]),
+                    "endless" => new ObservedReadStream([], endless: true),
+                    _ => new ObservedReadStream(bytes)
+                };
+                streams.Add(stream);
+                return stream;
+            };
+            if (failure == "endless")
+            {
+                blobs.PropertyLength = name => name == RecordName ? 256 * 1024 : null;
+                blobs.StreamLength = blobs.PropertyLength;
+            }
+            else if (failure == "oversized-header")
+            {
+                blobs.StreamLength = name => name == RecordName ? long.MaxValue : null;
+            }
+            blobs.Operations.Clear();
+
+            await store.CleanupAsync();
+
+            ObservedReadStream observed = Assert.Single(streams);
+            Assert.True(observed.IsDisposed);
+            Assert.Equal(failure switch
+            {
+                "short" => record.Length - 1,
+                "long" => record.Length + 1,
+                "endless" => 256 * 1024 + 1,
+                _ => 0
+            }, observed.BytesRead);
+            Assert.Equal(record, blobs.Bytes(RecordName));
+            Assert.Equal(version, blobs.Version(RecordName));
+            Assert.True(blobs.Contains(photo));
+            Assert.False(blobs.Contains(orphan));
+            Assert.DoesNotContain(blobs.Operations, op => op.Kind == "delete" && op.Name == photo);
+
+            await Assert.ThrowsAsync<InvalidDataException>(() => store.GetAsync(Id, null));
+            await Assert.ThrowsAsync<InvalidDataException>(() => store.CommitAsync(Id, null, Anonymous, []));
+            Assert.All(streams, stream => Assert.True(stream.IsDisposed));
+        }
+
+        [Theory]
+        [MemberData(nameof(InvalidRecords))]
+        public async Task CorruptRecordsAreNotTreatedAsAbsent(string corruption)
+        {
+            MemoryBlobs blobs = new MemoryBlobs();
+            ReportStore store = CreateStore(blobs);
+            await store.CommitAsync(Id, null, Anonymous, Prepare(blobs));
+            byte[] invalidRecord = InvalidRecordBytes(blobs.Bytes(RecordName), corruption);
+            string invalidVersion = blobs.Seed(RecordName, invalidRecord);
+            blobs.Operations.Clear();
+
+            if (corruption == "json")
+            {
+                await Assert.ThrowsAnyAsync<JsonException>(() => store.GetAsync(Id, null));
+                await Assert.ThrowsAnyAsync<JsonException>(() => store.CommitAsync(Id, null, Anonymous, []));
+            }
+            else
+            {
+                await Assert.ThrowsAsync<InvalidDataException>(() => store.GetAsync(Id, null));
+                await Assert.ThrowsAsync<InvalidDataException>(() => store.CommitAsync(Id, null, Anonymous, []));
+            }
+
+            Assert.Equal(invalidRecord, blobs.Bytes(RecordName));
+            Assert.Equal(invalidVersion, blobs.Version(RecordName));
+            Assert.DoesNotContain(blobs.Operations, op => op.Kind is "record" or "photo" or "delete");
+        }
+
+        [Fact]
+        public async Task ExistenceRetainsAbandonedAndRetiredCoordinatorRecords()
+        {
+            MemoryBlobs blobs = new MemoryBlobs();
+            ReportStore store = CreateStore(blobs);
+            Assert.False(await store.ExistsAsync(Id));
+            blobs.Before = op => op.Kind == "photo" ? throw Unavailable() : Task.CompletedTask;
+            await Assert.ThrowsAsync<RequestFailedException>(() => store.CommitAsync(Id, null, Anonymous, Prepare(blobs)));
+            Assert.True(await store.ExistsAsync(Id));
+            Assert.Null(await store.GetAsync(Id, null));
+            blobs.Before = null;
+            await store.CommitAsync(Id, null, Anonymous, Prepare(blobs));
+            SubmissionReport owned = await store.BeginModerationAsync(Id, "deleting");
+            await store.RetireAsync(Id, owned.Moderation!.Id);
+            Assert.True(await store.ExistsAsync(Id));
+        }
+
+        [Theory]
+        [InlineData("empty")]
+        [InlineData("count")]
+        [InlineData("length")]
+        [InlineData("zero")]
+        [InlineData("etag")]
+        [InlineData("duplicate")]
+        [InlineData("order")]
+        [InlineData("source")]
+        [InlineData("date")]
+        [InlineData("latitude")]
+        [InlineData("longitude")]
+        [InlineData("cars")]
+        [InlineData("report")]
+        [InlineData("device")]
+        [InlineData("metadata-size")]
+        public async Task RejectsInvalidBoundsAndMetadataBeforePersisting(string invalid)
+        {
+            MemoryBlobs blobs = new MemoryBlobs();
+            PreparedSubmissionPhoto[] photos = Prepare(blobs);
+            switch (invalid)
+            {
+                case "empty":
+                    photos = [];
+                    break;
+                case "count":
+                    photos = Prepare(blobs, 5);
+                    break;
+                case "length":
+                    photos[0] = photos[0] with
+                    {
+                        Length = ReportStore.MaxPhotoBytes + 1L
+                    };
+                    break;
+                case "zero":
+                    photos[0] = photos[0] with
+                    {
+                        Length = 0
+                    };
+                    break;
+                case "etag":
+                    photos[0] = photos[0] with
+                    {
+                        ETag = "*"
+                    };
+                    break;
+                case "duplicate":
+                    photos = [photos[0], photos[0]];
+                    break;
+                case "order":
+                    photos[0].Metadata.PhotoNumber = 1;
+                    break;
+                case "source":
+                    photos[0] = photos[0] with
+                    {
+                        BlobName = ReportStore.BlobPrefix + "stolen.jpeg"
+                    };
+                    break;
+                case "date":
+                    photos[0].Metadata.PhotoDateTime = null;
+                    break;
+                case "latitude":
+                    photos[0].Metadata.PhotoLatitude = "NaN";
+                    break;
+                case "longitude":
+                    photos[0].Metadata.PhotoLongitude = "-180";
+                    break;
+                case "cars":
+                    photos[0].Metadata.NumberOfCars = 0;
+                    break;
+                case "report":
+                    photos[0].Metadata.ReportId = new string('b', 32);
+                    break;
+                case "device":
+                    photos[0].Metadata.DeviceId = "someone";
+                    break;
+                case "metadata-size":
+                    photos[0].Metadata.PhotoCrossStreet = new string('x', 300_000);
+                    break;
+            }
+            await Assert.ThrowsAsync<ArgumentException>(() => CreateStore(blobs).CommitAsync(Id, null, Anonymous, photos));
+            Assert.Empty(blobs.Names(ReportStore.BlobPrefix));
+            Assert.Empty(blobs.Names(ReportStore.PhotoPrefix));
+        }
+
+        [Theory]
+        [InlineData(nameof(FinalizedPhotoUploadMetadata.TwitterAccessToken))]
+        [InlineData(nameof(FinalizedPhotoUploadMetadata.MastodonAccessToken))]
+        [InlineData(nameof(FinalizedPhotoUploadMetadata.ThreadsAccessToken))]
+        [InlineData(nameof(FinalizedPhotoUploadMetadata.BlueskyAccessJwt))]
+        [InlineData(nameof(FinalizedPhotoUploadMetadata.BlueskyAdminDid))]
+        [InlineData(nameof(FinalizedPhotoUploadMetadata.TwitterLink))]
+        public async Task RejectsSecretsAndAdminFieldsBeforeAnyRecoveryWrite(string property)
+        {
+            MemoryBlobs blobs = new MemoryBlobs();
+            PreparedSubmissionPhoto[] photos = Prepare(blobs);
+            typeof(FinalizedPhotoUploadMetadata).GetProperty(property)!.SetValue(photos[0].Metadata, "secret-value");
+            await Assert.ThrowsAsync<ArgumentException>(() => CreateStore(blobs).CommitAsync(Id, null, Anonymous, photos));
+            Assert.Empty(blobs.Names(ReportStore.BlobPrefix));
+        }
+
+        [Theory]
+        [InlineData("changed-version")]
+        [InlineData("checked-length")]
+        [InlineData("short-stream")]
+        [InlineData("long-stream")]
+        [InlineData("destination-length")]
+        public async Task VerifiesSourceConditionsActualStreamLengthAndDestination(string failure)
+        {
+            MemoryBlobs blobs = new MemoryBlobs();
+            PreparedSubmissionPhoto[] photos = Prepare(blobs);
+            switch (failure)
+            {
+                case "changed-version":
+                    blobs.Seed(photos[0].BlobName, [1, 2, 3]);
+                    break;
+                case "checked-length":
+                    photos[0] = photos[0] with
+                    {
+                        Length = photos[0].Length + 1
+                    };
+                    break;
+                case "short-stream":
+                    blobs.StreamBytes = bytes => bytes[..^1];
+                    break;
+                case "long-stream":
+                    blobs.StreamBytes = bytes => [.. bytes, 255];
+                    break;
+                case "destination-length":
+                    blobs.PropertyLength = name => name.StartsWith(ReportStore.PhotoPrefix) ? 999 : null;
+                    break;
+            }
+            ReportStore store = CreateStore(blobs);
+            Exception? exception = await Record.ExceptionAsync(() => store.CommitAsync(Id, null, Anonymous, photos));
+            if (failure == "destination-length")
+            {
+                Assert.IsType<InvalidDataException>(exception);
+            }
+            else
+            {
+                Assert.IsType<PreparationExpiredException>(exception);
+            }
+
+            Assert.Null(await store.GetAsync(Id, null));
+            Assert.Empty(await Pending(store));
+            await store.CleanupAsync();
+            Assert.Empty(blobs.Names(ReportStore.PhotoPrefix));
+        }
+
+        [Theory]
+        [InlineData(404, "BlobNotFound")]
+        [InlineData(412, "ConditionNotMet")]
+        public async Task MissingOrChangedSourceHasADedicatedExpiryError(int status, string errorCode)
+        {
+            MemoryBlobs blobs = new MemoryBlobs();
+            ReportStore store = CreateStore(blobs);
+            blobs.Before = op => op.Kind == "stream"
+                ? throw new RequestFailedException(status, "Source changed", errorCode, null) : Task.CompletedTask;
+            PreparationExpiredException error = await Assert.ThrowsAsync<PreparationExpiredException>(() =>
+                store.CommitAsync(Id, null, Anonymous, Prepare(blobs)));
+            Assert.IsAssignableFrom<IOException>(error);
+            Assert.Null(await store.GetAsync(Id, null));
+        }
+
+        [Fact]
+        public async Task SourceExpiryDuringStreamingIsNotConfusedWithDestinationFailure()
+        {
+            MemoryBlobs blobs = new MemoryBlobs()
+            {
+                StreamFactory = _ => new FailedReadStream(
+                    new RequestFailedException(412, "Source changed during retry", "ConditionNotMet", null))
+            };
+            await Assert.ThrowsAsync<PreparationExpiredException>(() =>
+                CreateStore(blobs).CommitAsync(Id, null, Anonymous, Prepare(blobs)));
+        }
+
+        [Theory]
+        [InlineData("stream", 404, "ContainerNotFound")]
+        [InlineData("stream", 412, "LeaseIdMissing")]
+        [InlineData("photo", 404, "ContainerNotFound")]
+        [InlineData("photo", 412, "ConditionNotMet")]
+        [InlineData("record", 409, "ContainerBeingDeleted")]
+        public async Task NonSourceFailuresAreNotReportedAsExpiredPreparation(string kind, int status, string errorCode)
+        {
+            MemoryBlobs blobs = new MemoryBlobs();
+            ReportStore store = CreateStore(blobs);
+            bool injected = false;
+            blobs.Before = op =>
+            {
+                if (!injected && op.Kind == kind)
+                {
+                    injected = true;
+                    throw new RequestFailedException(status, "Storage failure", errorCode, null);
+                }
+                return Task.CompletedTask;
+            };
+            RequestFailedException error = await Assert.ThrowsAsync<RequestFailedException>(() =>
+                store.CommitAsync(Id, null, Anonymous, Prepare(blobs)));
+            Assert.Equal(errorCode, error.ErrorCode);
+        }
+
+        [Theory]
+        [InlineData("https://twitter.com/example/status/123")]
+        [InlineData("http://twitter.com/example/status/123")]
+        public async Task ModerationOwnsTheWholeCanonicalSetAndPreservesSubmittedFactsAndReceipt(string twitterLink)
+        {
+            MemoryBlobs blobs = new MemoryBlobs();
+            ReportStore store = CreateStore(blobs);
+            await store.CommitAsync(Id, null, new ReportAttribution("did:plc:original"), Prepare(blobs, 2));
+            SubmissionReport original = await store.GetForModerationAsync(Id);
+            List<FinalizedPhotoUploadMetadata> edits = original.Photos.Select(p => p.Metadata).ToList();
+            edits[0].NumberOfCars = 4;
+            edits[0].BlueskySubmittedBy = "Edited attribution";
+            edits[0].TwitterLink = twitterLink;
+
+            SubmissionReport owned = await store.BeginModerationAsync(Id, "publishing", edits, original.Version);
+            Assert.Equal(original.Receipt, owned.Receipt);
+            Assert.Equal(original.Photos.Select(p => p.BlobName), owned.Photos.Select(p => p.BlobName));
+            Assert.Equal(4, owned.Photos[0].Metadata.NumberOfCars);
+            Assert.Equal(twitterLink, owned.Photos[0].Metadata.TwitterLink);
+            using JsonDocument stored = JsonDocument.Parse(blobs.Bytes(RecordName));
+            Assert.Equal(1, stored.RootElement.GetProperty("Photos")[0].GetProperty("Metadata").GetProperty("NumberOfCars").GetInt32());
+            Assert.Equal(JsonValueKind.Null, stored.RootElement.GetProperty("Photos")[0]
+                .GetProperty("Metadata").GetProperty("TwitterLink").ValueKind);
+            Assert.Equal(twitterLink, stored.RootElement.GetProperty("ModerationPhotos")[0]
+                .GetProperty("Metadata").GetProperty("TwitterLink").GetString());
+            Assert.NotNull(Assert.Single(await Pending(store)).Moderation);
+            await Assert.ThrowsAsync<ReportConflictException>(() => store.BeginModerationAsync(Id, "deleting"));
+            await Assert.ThrowsAsync<ReportConflictException>(() => store.ReleaseModerationAsync(Id, "not-owner"));
+            await Assert.ThrowsAsync<ReportConflictException>(() => store.RetireAsync(Id, "not-owner"));
+
+            await store.ReleaseModerationAsync(Id, owned.Moderation!.Id);
+            Assert.Null((await store.GetForModerationAsync(Id)).Moderation);
+            Assert.Equal(1, (await store.GetForModerationAsync(Id)).Photos[0].Metadata.NumberOfCars);
+            await Assert.ThrowsAsync<ReportConflictException>(() =>
+                store.BeginModerationAsync(Id, "deleting", expectedVersion: original.Version));
+        }
+
+        [Fact]
+        public async Task SimultaneousPublishAndDeleteCannotBothOwnTheReport()
+        {
+            MemoryBlobs blobs = new MemoryBlobs();
+            ReportStore store = CreateStore(blobs);
+            await store.CommitAsync(Id, null, Anonymous, Prepare(blobs));
+            Gate gate = new Gate();
+            int calls = 0;
+            blobs.Before = op => op.ModerationKind is not null && Interlocked.Increment(ref calls) == 1
+                ? gate.Pause() : Task.CompletedTask;
+            Task<SubmissionReport> publish = store.BeginModerationAsync(Id, "publishing");
+            await gate.Entered.Task;
+            SubmissionReport deletion = await store.BeginModerationAsync(Id, "deleting");
+            gate.Resume();
+            await Assert.ThrowsAsync<ReportConflictException>(() => publish);
+            Assert.Equal("deleting", deletion.Moderation!.Kind);
+            Assert.Equal(deletion.Moderation, (await store.GetForModerationAsync(Id)).Moderation);
+        }
+
+        [Fact]
+        public async Task RejectsPartialReorderedAndSecretModerationOverrides()
+        {
+            MemoryBlobs blobs = new MemoryBlobs();
+            ReportStore store = CreateStore(blobs);
+            await store.CommitAsync(Id, null, Anonymous, Prepare(blobs, 2));
+            SubmissionReport report = await store.GetForModerationAsync(Id);
+            FinalizedPhotoUploadMetadata[] metadata = report.Photos.Select(p => p.Metadata).ToArray();
+            await Assert.ThrowsAsync<ArgumentException>(() => store.BeginModerationAsync(Id, "publishing", [metadata[0]]));
+            await Assert.ThrowsAsync<ArgumentException>(() => store.BeginModerationAsync(Id, "publishing", metadata.Reverse().ToArray()));
+            metadata[0].MastodonAccessToken = "secret";
+            await Assert.ThrowsAsync<ArgumentException>(() => store.BeginModerationAsync(Id, "publishing", metadata));
+            Assert.Equal(report.Version, (await store.GetForModerationAsync(Id)).Version);
+            Assert.DoesNotContain("secret", blobs.Text(RecordName));
+        }
+
+        [Theory]
+        [InlineData("date")]
+        [InlineData("latitude")]
+        [InlineData("longitude")]
+        [InlineData("cars")]
+        [InlineData("report")]
+        [InlineData("device")]
+        [InlineData("twitterlink-scheme")]
+        [InlineData("twitterlink-relative")]
+        [InlineData("twitterlink-credentials")]
+        public async Task RejectsInvalidModerationMetadataBeforeTakingOwnership(string invalid)
+        {
+            MemoryBlobs blobs = new MemoryBlobs();
+            ReportStore store = CreateStore(blobs);
+            await store.CommitAsync(Id, null, Anonymous, Prepare(blobs));
+            SubmissionReport original = await store.GetForModerationAsync(Id);
+            FinalizedPhotoUploadMetadata metadata = original.Photos[0].Metadata;
+            switch (invalid)
+            {
+                case "date":
+                    metadata.PhotoDateTime = null;
+                    break;
+                case "latitude":
+                    metadata.PhotoLatitude = "NaN";
+                    break;
+                case "longitude":
+                    metadata.PhotoLongitude = "-180";
+                    break;
+                case "cars":
+                    metadata.NumberOfCars = 0;
+                    break;
+                case "report":
+                    metadata.ReportId = new string('b', 32);
+                    break;
+                case "device":
+                    metadata.DeviceId = "another-device";
+                    break;
+                case "twitterlink-scheme":
+                    metadata.TwitterLink = "javascript:alert(1)";
+                    break;
+                case "twitterlink-relative":
+                    metadata.TwitterLink = "/example/status/123";
+                    break;
+                case "twitterlink-credentials":
+                    metadata.TwitterLink = "https://user:secret@twitter.com/example/status/123";
+                    break;
+            }
+            await Assert.ThrowsAsync<ArgumentException>(() => store.BeginModerationAsync(Id, "publishing", [metadata]));
+            SubmissionReport unchanged = await store.GetForModerationAsync(Id);
+            Assert.Equal(original.Version, unchanged.Version);
+            Assert.Null(unchanged.Moderation);
+        }
+
+        [Fact]
+        public async Task RecoversLostModerationAndRetirementResponses()
+        {
+            MemoryBlobs blobs = new MemoryBlobs();
+            ReportStore store = CreateStore(blobs);
+            SubmissionReceipt receipt = await store.CommitAsync(Id, null, Anonymous, Prepare(blobs));
+            blobs.After = op => op.Kind == "record" ? throw Unavailable() : Task.CompletedTask;
+            SubmissionReport owned = await store.BeginModerationAsync(Id, "deleting");
+            await store.RetireAsync(Id, owned.Moderation!.Id);
+            await store.RetireAsync(Id, owned.Moderation.Id);
+            Assert.Empty(blobs.Names(ReportStore.PhotoPrefix));
+            Assert.Empty(await Pending(store));
+            Assert.Equal(receipt, await store.CommitAsync(Id, null, Anonymous, []));
+            Assert.True((await store.GetAsync(Id, null))!.Retired);
+            await Assert.ThrowsAsync<ReportConflictException>(() => store.GetForModerationAsync(Id));
+        }
+
+        [Fact]
+        public async Task RetirementPersistsInventoryBeforeDeletingAndResumesPartialCleanup()
+        {
+            MemoryBlobs blobs = new MemoryBlobs();
+            ReportStore store = CreateStore(blobs);
+            SubmissionReceipt receipt = await store.CommitAsync(Id, null, Anonymous, Prepare(blobs, 2));
+            SubmissionReport owned = await store.BeginModerationAsync(Id, "publishing");
+            int deletions = 0;
+            blobs.Before = op =>
+            {
+                if (op.Kind == "delete")
+                {
+                    using JsonDocument record = JsonDocument.Parse(blobs.Bytes(RecordName));
+                    Assert.Equal("Retired", record.RootElement.GetProperty("State").GetString());
+                    Assert.Equal(2, record.RootElement.GetProperty("Cleanup").GetArrayLength());
+                    if (Interlocked.Increment(ref deletions) == 2)
+                    {
+                        throw Unavailable();
+                    }
+                }
+                return Task.CompletedTask;
+            };
+            await store.RetireAsync(Id, owned.Moderation!.Id);
+            Assert.Single(blobs.Names(ReportStore.PhotoPrefix));
+            Assert.Empty(await Pending(store));
+            Assert.Equal(receipt, (await store.GetAsync(Id, null))!.Receipt);
+
+            await CreateStore(blobs).CleanupAsync();
+            Assert.Empty(blobs.Names(ReportStore.PhotoPrefix));
+            Assert.Empty((await store.GetAsync(Id, null))!.Photos);
+            Assert.Contains("\"Cleanup\":[]", blobs.Text(RecordName));
+            Assert.Equal(receipt, await store.CommitAsync(Id, null, new ReportAttribution("changed"), []));
+        }
+
+        [Fact]
+        public async Task DoesNotDeleteAnythingIfTheRetirementTransitionFailed()
+        {
+            MemoryBlobs blobs = new MemoryBlobs();
+            ReportStore store = CreateStore(blobs);
+            await store.CommitAsync(Id, null, Anonymous, Prepare(blobs));
+            SubmissionReport owned = await store.BeginModerationAsync(Id, "deleting");
+            blobs.Before = op => op.State == "Retired" ? throw Unavailable() : Task.CompletedTask;
+            await Assert.ThrowsAsync<RequestFailedException>(() => store.RetireAsync(Id, owned.Moderation!.Id));
+            Assert.Single(blobs.Names(ReportStore.PhotoPrefix));
+            Assert.Single(await Pending(store));
+            Assert.DoesNotContain(blobs.Operations, op => op.Kind == "delete");
+        }
+
+        [Fact]
+        public async Task LegacyAdoptionPreservesReferencesSanitizesCredentialsAndRetiresSidecars()
+        {
+            MemoryBlobs blobs = new MemoryBlobs();
+            ReportStore store = CreateStore(blobs);
+            const string legacyId = "old-submission";
+            SubmissionPhoto[] photos = Prepare(blobs, 2, legacyId).Select(p =>
+            {
+                string path = $"finalizedupload/{p.Metadata.PhotoId}.jpeg";
+                string etag = blobs.Seed(path, blobs.Bytes(p.BlobName));
+                blobs.Seed($"finalizedupload/{p.Metadata.PhotoId}.json", Encoding.UTF8.GetBytes("legacy metadata"));
+                p.Metadata.MastodonAccessToken = "old-secret";
+                p.Metadata.BlueskyAccessJwt = "old-admin-jwt";
+                p.Metadata.DeviceId = "untrusted";
+                p.Metadata.PhotoNumber += 10;
+                p.Metadata.PhotoDateTime = null;
+                p.Metadata.NumberOfCars = null;
+                return new SubmissionPhoto(p.Metadata, path, etag, p.Length);
+            }).ToArray();
+            blobs.After = op => op.State == "Accepted" ? throw Unavailable() : Task.CompletedTask;
+
+            SubmissionReport adopted = await store.AdoptLegacyAsync(legacyId, photos);
+
+            Assert.Equal(legacyId, adopted.Receipt.SubmissionId);
+            Assert.Equal(ReportStore.LegacyReportId(legacyId), adopted.Receipt.ReportId);
+            Assert.True(ReportStore.IsValidReportId(adopted.Receipt.ReportId));
+            Assert.NotEqual(ReportStore.LegacyReportId(legacyId), ReportStore.LegacyReportId("other"));
+            Assert.Equal(photos.Select(p => p.BlobName), adopted.Photos.Select(p => p.BlobName));
+            Assert.Null(adopted.DeviceId);
+            Assert.All(adopted.Photos, p =>
+            {
+                Assert.Null(p.Metadata.MastodonAccessToken);
+                Assert.Null(p.Metadata.BlueskyAccessJwt);
+                Assert.Equal("Seattle", p.Metadata.PhotoCrossStreet);
+            });
+            string adoptedRecord = ReportStore.BlobPrefix + adopted.Receipt.ReportId + ".json";
+            Assert.Equal(photos.SelectMany(p => new[]
+            {
+                p.BlobName, $"finalizedupload/{p.Metadata.PhotoId}.json"
+            }).Append(adoptedRecord).Order(), blobs.Names(ReportStore.FinalizedUploadPrefix).Order());
+            Assert.Empty(blobs.Names(ReportStore.PhotoPrefix));
+            Assert.DoesNotContain("old-secret", blobs.Text(ReportStore.BlobPrefix + adopted.Receipt.ReportId + ".json"));
+            Assert.Equal(adopted.Receipt, (await store.AdoptLegacyAsync(legacyId, [])).Receipt);
+            SubmissionReport owned = await store.BeginModerationAsync(adopted.Receipt.ReportId, "deleting");
+            await store.RetireAsync(adopted.Receipt.ReportId, owned.Moderation!.Id);
+            Assert.Equal(adoptedRecord, Assert.Single(blobs.Names(ReportStore.FinalizedUploadPrefix)));
+            SubmissionReport retired = await store.AdoptLegacyAsync(legacyId, []);
+            Assert.True(retired.Retired);
+            Assert.Equal(adopted.Receipt, retired.Receipt);
+            Assert.Empty(await Pending(store));
+        }
+
+        [Theory]
+        [InlineData("legacy-photo-foreign")]
+        [InlineData("legacy-sidecars-null")]
+        [InlineData("legacy-sidecar-null")]
+        [InlineData("legacy-sidecar-foreign")]
+        [InlineData("legacy-sidecar-duplicate")]
+        [InlineData("legacy-device")]
+        [InlineData("legacy-hash")]
+        public async Task CorruptLegacyRecordsCannotAuthorizeDeletingPhotosOrSidecars(string corruption)
+        {
+            MemoryBlobs blobs = new MemoryBlobs();
+            ReportStore store = CreateStore(blobs);
+            const string submissionId = "legacy-corrupt";
+            SubmissionPhoto[] photos = Prepare(blobs, 2, submissionId).Select(p =>
+            {
+                string name = $"finalizedupload/{p.Metadata.PhotoId}.jpeg";
+                string etag = blobs.Seed(name, blobs.Bytes(p.BlobName));
+                blobs.Seed($"finalizedupload/{p.Metadata.PhotoId}.json", [1, 2]);
+                return new SubmissionPhoto(p.Metadata, name, etag, p.Length);
+            }).ToArray();
+            SubmissionReport adopted = await store.AdoptLegacyAsync(submissionId, photos);
+            string id = adopted.Receipt.ReportId;
+            string recordName = ReportStore.BlobPrefix + id + ".json";
+            byte[] accepted = blobs.Bytes(recordName);
+            SubmissionReport owned = await store.BeginModerationAsync(id, "deleting");
+            blobs.Before = op => op.Kind == "delete" ? throw Unavailable() : Task.CompletedTask;
+            await store.RetireAsync(id, owned.Moderation!.Id);
+            blobs.Before = null;
+            byte[] retired = blobs.Bytes(recordName);
+            const string unrelatedPhoto = "initialupload/unrelated.jpeg";
+            blobs.Seed(unrelatedPhoto, [5, 6]);
+            Dictionary<string, (byte[] Content, string Version)> retained = blobs.Names("finalizedupload/")
+                .Where(name => name != recordName)
+                .Append(unrelatedPhoto).ToDictionary(name => name, name => (blobs.Bytes(name), blobs.Version(name)));
+
+            foreach (byte[] record in new[] { accepted, retired })
+            {
+                byte[] invalid = InvalidRecordBytes(record, corruption);
+                string version = blobs.Seed(recordName, invalid);
+                blobs.Operations.Clear();
+
+                await Assert.ThrowsAsync<InvalidDataException>(() => store.GetAsync(id, null));
+                await Assert.ThrowsAsync<InvalidDataException>(() => store.CommitAsync(id, null, Anonymous, []));
+                await store.CleanupAsync();
+
+                Assert.Equal(invalid, blobs.Bytes(recordName));
+                Assert.Equal(version, blobs.Version(recordName));
+                Assert.All(retained, blob =>
+                {
+                    Assert.Equal(blob.Value.Content, blobs.Bytes(blob.Key));
+                    Assert.Equal(blob.Value.Version, blobs.Version(blob.Key));
+                });
+                Assert.DoesNotContain(blobs.Operations, op => op.Kind is "record" or "delete");
+            }
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task SupportsDottedPhotoIdsWithoutTreatingThemAsPaths(bool legacy)
+        {
+            MemoryBlobs blobs = new MemoryBlobs();
+            ReportStore store = CreateStore(blobs);
+            PreparedSubmissionPhoto source = Prepare(blobs)[0];
+            source.Metadata.PhotoId = Id + ".0";
+            string name = $"{(legacy ? "finalizedupload" : "initialupload")}/{source.Metadata.PhotoId}.jpeg";
+            string etag = blobs.Seed(name, blobs.Bytes(source.BlobName));
+            if (legacy)
+            {
+                SubmissionReport report = await store.AdoptLegacyAsync(source.Metadata.SubmissionId,
+                                                    [new SubmissionPhoto(source.Metadata, name, etag, source.Length)]);
+                Assert.Equal(name, Assert.Single(report.Photos).BlobName);
+            }
+            else
+            {
+                await store.CommitAsync(Id, null, Anonymous, [source with { BlobName = name, ETag = etag }]);
+                Assert.Equal(Id + ".0", Assert.Single((await store.GetAsync(Id, null))!.Photos).Metadata.PhotoId);
+            }
+        }
+
+        [Theory]
+        [InlineData(".")]
+        [InlineData("..")]
+        [InlineData("../photo")]
+        [InlineData("parent/photo")]
+        [InlineData("parent\\photo")]
+        public async Task RejectsPathComponentsInPhotoIds(string photoId)
+        {
+            MemoryBlobs blobs = new MemoryBlobs();
+            PreparedSubmissionPhoto[] photos = Prepare(blobs);
+            photos[0].Metadata.PhotoId = photoId;
+            await Assert.ThrowsAsync<ArgumentException>(() => CreateStore(blobs).CommitAsync(Id, null, Anonymous, photos));
+            Assert.Empty(blobs.Names(ReportStore.BlobPrefix));
+        }
+
+        private static ReportStore CreateStore(MemoryBlobs blobs, TimeProvider? clock = null)
+        {
+            return new ReportStore(blobs.Container.Object, NullLogger<ReportStore>.Instance, clock);
+        }
+
+        private static byte[] InvalidRecordBytes(byte[] record, string corruption)
+        {
+            if (corruption == "json")
+            {
+                return Encoding.UTF8.GetBytes("{broken");
+            }
+
+            if (corruption == "oversized")
+            {
+                return new byte[256 * 1024 + 1];
+            }
+
+            JsonNode document = JsonNode.Parse(record)!;
+            JsonArray photos = document["Photos"]!.AsArray();
+            JsonNode photo = photos[0]!;
+            JsonNode metadata = photo["Metadata"]!;
+            if (corruption.StartsWith("moderation-", StringComparison.Ordinal) ||
+                corruption.StartsWith("cleanup-", StringComparison.Ordinal) ||
+                corruption is "retired-without-owner" or "compacted-with-inventory")
+            {
+                document["Moderation"] = new JsonObject()
+                {
+                    ["Id"] = new string('b', 32),
+                    ["Kind"] = "deleting",
+                    ["StartedAt"] = "2026-09-07T12:00:00+00:00"
+                };
+            }
+            if (corruption.StartsWith("moderation-", StringComparison.Ordinal))
+            {
+                document["ModerationPhotos"] = photos.DeepClone();
+            }
+
+            if (corruption.StartsWith("cleanup-", StringComparison.Ordinal) ||
+                corruption is "retired-without-owner" or "compacted-with-inventory")
+            {
+                document["State"] = "Retired";
+                document["Cleanup"] = new JsonArray(photos.Select(p => (JsonNode)new JsonObject()
+                {
+                    ["BlobName"] = p!["BlobName"]!.GetValue<string>(),
+                    ["ETag"] = p["ETag"]!.GetValue<string>()
+                }).ToArray());
+            }
+
+            switch (corruption)
+            {
+                case "schema":
+                    document["SchemaVersion"] = 2;
+                    break;
+                case "photos-null":
+                    document["Photos"] = null;
+                    break;
+                case "photo-null":
+                    photos[0] = null;
+                    break;
+                case "metadata-null":
+                    photo["Metadata"] = null;
+                    break;
+                case "photos-empty":
+                    document["Photos"] = new JsonArray();
+                    break;
+                case "receipt-null":
+                    document["Receipt"] = null;
+                    break;
+                case "attribution-null":
+                    document["Receipt"]!["Attribution"] = null;
+                    break;
+                case "attribution-invalid":
+                    document["Receipt"]!["Attribution"]!["BlueskyDid"] = "invalid";
+                    break;
+                case "receipt-submission":
+                    document["Receipt"]!["SubmissionId"] = "different-submission";
+                    break;
+                case "attempt-invalid":
+                    document["AttemptId"] = "../invalid";
+                    break;
+                case "attempt-null":
+                    document["AttemptId"] = null;
+                    break;
+                case "foreign-photo":
+                    photo["BlobName"] = "initialupload/unrelated.jpeg";
+                    break;
+                case "foreign-report-photo":
+                    photo["BlobName"] = $"{ReportStore.PhotoPrefix}{new string('c', 32)}/{new string('d', 32)}/0.jpeg";
+                    break;
+                case "unsafe-photo":
+                    photo["BlobName"] = photo["BlobName"]!.GetValue<string>() + "/../other.jpeg";
+                    break;
+                case "photo-attempt":
+                    photo["BlobName"] = $"{ReportStore.PhotoPrefix}{Id}/{new string('c', 32)}/0.jpeg";
+                    break;
+                case "metadata-report":
+                    metadata["ReportId"] = new string('c', 32);
+                    break;
+                case "metadata-report-missing":
+                    metadata["ReportId"] = null;
+                    break;
+                case "metadata-device":
+                    metadata["DeviceId"] = "other-device";
+                    break;
+                case "document-device":
+                    document["DeviceId"] = "device";
+                    break;
+                case "etag-null":
+                    photo["ETag"] = null;
+                    break;
+                case "etag-empty":
+                    photo["ETag"] = "";
+                    break;
+                case "etag-wildcard":
+                    photo["ETag"] = "*";
+                    break;
+                case "moderation-id":
+                    document["Moderation"]!["Id"] = "invalid";
+                    break;
+                case "moderation-kind":
+                    document["Moderation"]!["Kind"] = "invalid";
+                    break;
+                case "moderation-started":
+                    document["Moderation"]!["StartedAt"] = DateTimeOffset.MaxValue;
+                    break;
+                case "moderation-photo-null":
+                    document["ModerationPhotos"]![0] = null;
+                    break;
+                case "moderation-metadata-null":
+                    document["ModerationPhotos"]![0]!["Metadata"] = null;
+                    break;
+                case "moderation-without-owner":
+                    document["Moderation"] = null;
+                    break;
+                case "moderation-reference":
+                    document["ModerationPhotos"]![0]!["ETag"] = "\"other-version\"";
+                    break;
+                case "moderation-context":
+                    document["ModerationPhotos"]![0]!["Metadata"]!["DeviceId"] = "other";
+                    break;
+                case "started-overflow":
+                    document["StartedAt"] = DateTimeOffset.MaxValue;
+                    break;
+                case "started-utc-overflow":
+                    document["StartedAt"] = "9999-12-31T22:59:59-01:00";
+                    break;
+                case "started-missing":
+                    document.AsObject().Remove("StartedAt");
+                    break;
+                case "preparing-with-receipt":
+                    document["State"] = "Preparing";
+                    break;
+                case "abandoned-with-receipt":
+                    document["State"] = "Abandoned";
+                    break;
+                case "accepted-cleanup":
+                    document["Cleanup"] = new JsonArray();
+                    break;
+                case "cleanup-null":
+                    document["Cleanup"] = null;
+                    break;
+                case "cleanup-null-item":
+                    document["Cleanup"]![0] = null;
+                    break;
+                case "cleanup-late-null-item":
+                    document["Cleanup"]!.AsArray()[photos.Count - 1] = null;
+                    break;
+                case "cleanup-foreign":
+                    document["Cleanup"]![0]!["BlobName"] = "initialupload/unrelated.jpeg";
+                    document["Cleanup"]![0]!["ETag"] = null;
+                    break;
+                case "cleanup-unknown-own":
+                    document["Cleanup"]![0]!["BlobName"] = $"{ReportStore.PhotoPrefix}{Id}/{new string('b', 32)}/late.jpeg";
+                    document["Cleanup"]![0]!["ETag"] = null;
+                    break;
+                case "cleanup-unconditional-photo":
+                    document["Cleanup"]![0]!["ETag"] = null;
+                    break;
+                case "cleanup-etag-mismatch":
+                    document["Cleanup"]![0]!["ETag"] = "\"other-version\"";
+                    break;
+                case "cleanup-incomplete":
+                    document["Cleanup"]!.AsArray().RemoveAt(0);
+                    break;
+                case "cleanup-duplicate":
+                    document["Cleanup"]!.AsArray().Add(document["Cleanup"]![0]!.DeepClone());
+                    break;
+                case "retired-without-owner":
+                    document["Moderation"] = null;
+                    break;
+                case "compacted-with-inventory":
+                    document["Photos"] = new JsonArray();
+                    break;
+                case "legacy-photo-foreign":
+                    photo["BlobName"] = "initialupload/unrelated.jpeg";
+                    if (document["Cleanup"] is { } photoCleanup)
+                    {
+                        photoCleanup[0]!["BlobName"] = "initialupload/unrelated.jpeg";
+                    }
+
+                    break;
+                case "legacy-sidecars-null":
+                    document["LegacySidecars"] = null;
+                    break;
+                case "legacy-sidecar-null":
+                    document["LegacySidecars"]![0] = null;
+                    break;
+                case "legacy-sidecar-foreign":
+                    document["LegacySidecars"]![0] = "initialupload/unrelated.jpeg";
+                    if (document["Cleanup"] is { } sidecarCleanup)
+                    {
+                        sidecarCleanup[photos.Count]!["BlobName"] = "initialupload/unrelated.jpeg";
+                    }
+
+                    break;
+                case "legacy-sidecar-duplicate":
+                    document["LegacySidecars"]![1] = document["LegacySidecars"]![0]!.GetValue<string>();
+                    break;
+                case "legacy-device":
+                    document["DeviceId"] = "device";
+                    foreach (JsonNode? p in photos)
+                    {
+                        p!["Metadata"]!["DeviceId"] = "device";
+                    }
+
+                    break;
+                case "legacy-hash":
+                    document["Receipt"]!["SubmissionId"] = "different-legacy-submission";
+                    foreach (JsonNode? p in photos)
+                    {
+                        p!["Metadata"]!["SubmissionId"] = "different-legacy-submission";
+                    }
+
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(corruption));
+            }
+            return Encoding.UTF8.GetBytes(document.ToJsonString());
+        }
+
+        private static PreparedSubmissionPhoto[] Prepare(MemoryBlobs blobs, int count = 1, string submissionId = "preparation")
+        {
+            return Enumerable.Range(0, count).Select(index =>
+                                    {
+                                        string photoId = submissionId == "preparation" ? $"photo{index}" : $"{submissionId}-photo{index}";
+                                        string name = $"initialupload/{photoId}.jpeg";
+                                        byte[] bytes = [0xff, 0xd8, (byte)index, 0xff, 0xd9];
+                                        string etag = blobs.Seed(name, bytes);
+                                        return new PreparedSubmissionPhoto(new FinalizedPhotoUploadMetadata()
+                                        {
+                                            PhotoId = photoId,
+                                            SubmissionId = submissionId,
+                                            PhotoNumber = index,
+                                            PhotoDateTime = new DateTime(2026, 9, 7),
+                                            PhotoLatitude = "47.6",
+                                            PhotoLongitude = "-122.3",
+                                            PhotoCrossStreet = "Seattle",
+                                            NumberOfCars = 1,
+                                            Tags = []
+                                        }, name, etag, bytes.Length);
+                                    }).ToArray();
+        }
+
+        private static async Task<List<SubmissionReport>> Pending(ReportStore store)
+        {
+            List<SubmissionReport> result = [];
+            await foreach (SubmissionReport report in store.GetPendingAsync())
+            {
+                result.Add(report);
+            }
+
+            return result;
+        }
+
+        private static RequestFailedException Unavailable()
+        {
+            return new RequestFailedException(503, "Storage unavailable", "ServerBusy", null);
+        }
+
+        private sealed class ManualClock : TimeProvider
+        {
+            private DateTimeOffset now = new DateTimeOffset(2026, 9, 7, 12, 0, 0, TimeSpan.Zero);
+
+            public override DateTimeOffset GetUtcNow()
+            {
+                return now;
+            }
+
+            public void Advance(TimeSpan duration)
+            {
+                now += duration;
+            }
+        }
+
+        private sealed class Gate
+        {
+            public TaskCompletionSource Entered { get; } = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            private readonly TaskCompletionSource release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            public async Task Pause()
+            {
+                Entered.TrySetResult();
+                await release.Task.WaitAsync(TimeSpan.FromSeconds(15));
+            }
+
+            public void Resume()
+            {
+                release.TrySetResult();
+            }
+        }
+
+        private sealed class FailedReadStream : MemoryStream
+        {
+            private readonly Exception failure;
+
+            public FailedReadStream(Exception failure) : base(new byte[] { 1 })
+            {
+                this.failure = failure;
+            }
+
+            public override int Read(Span<byte> buffer)
+            {
+                throw failure;
+            }
+
+            public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
+            {
+                return ValueTask.FromException<int>(failure);
+            }
+        }
+
+        private sealed class ObservedReadStream : MemoryStream
+        {
+            private readonly bool endless;
+
+            public ObservedReadStream(byte[] bytes, bool endless = false) : base(bytes, writable: false)
+            {
+                this.endless = endless;
+            }
+
+            public int BytesRead { get; private set; }
+            public bool IsDisposed { get; private set; }
+
+            public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                int count;
+                if (endless)
+                {
+                    buffer.Span.Fill((byte)' ');
+                    count = buffer.Length;
+                }
+                else
+                {
+                    count = base.Read(buffer.Span);
+                }
+                BytesRead += count;
+                return ValueTask.FromResult(count);
+            }
+
+            protected override void Dispose(bool disposing)
+            {
+                IsDisposed = true;
+                base.Dispose(disposing);
+            }
+        }
+
+        private sealed record Operation(string Kind, string Name, BlobRequestConditions? Conditions = null, byte[]? Content = null)
+        {
+            public string? State => Property("State");
+            public string? ModerationKind => Property("Moderation", "Kind");
+            private string? Property(string name, string? child = null)
+            {
+                if (Kind != "record" || Content is null)
+                {
+                    return null;
+                }
+
+                using JsonDocument document = JsonDocument.Parse(Content);
+                JsonElement value = document.RootElement.GetProperty(name);
+                return value.ValueKind == JsonValueKind.Null ? null :
+                    child is null ? value.GetString() : value.GetProperty(child).GetString();
+            }
+        }
+
+        /// <summary>A distinct client and versioned byte stream per path, with atomic Azure request conditions.</summary>
+        private sealed class MemoryBlobs
+        {
+            private sealed record Stored(byte[] Bytes, string ETag);
+
+            private readonly Dictionary<string, Stored> storage = new Dictionary<string, Stored>(StringComparer.Ordinal);
+            private readonly ConcurrentDictionary<string, Mock<BlobClient>> clients = new ConcurrentDictionary<string, Mock<BlobClient>>(StringComparer.Ordinal);
+            private readonly object mutex = new object();
+            private int version;
+            public Mock<BlobContainerClient> Container { get; } = new Mock<BlobContainerClient>(MockBehavior.Strict);
+            public ConcurrentQueue<Operation> Operations { get; } = new ConcurrentQueue<Operation>();
+            public Func<Operation, Task>? Before { get; set; }
+            public Func<Operation, Task>? After { get; set; }
+            public Func<byte[], byte[]>? StreamBytes { get; set; }
+            public Func<byte[], Stream>? StreamFactory { get; set; }
+            public Func<string, byte[], Stream>? RecordStreamFactory { get; set; }
+            public Func<string, long?>? PropertyLength { get; set; }
+            public Func<string, long?>? StreamLength { get; set; }
+
+            public MemoryBlobs()
+            {
+                Container.Setup(c => c.GetBlobClient(It.IsAny<string>()))
+                                                    .Returns((string name) => clients.GetOrAdd(name, CreateBlob).Object);
+                Container.Setup(c => c.GetBlobsAsync(It.IsAny<BlobTraits>(), It.IsAny<BlobStates>(),
+                        It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                    .Returns((BlobTraits _, BlobStates _, string prefix, CancellationToken _) =>
+                    {
+                        BlobItem[] items;
+                        lock (mutex)
+                        {
+                            items = storage.Where(pair => pair.Key.StartsWith(prefix, StringComparison.Ordinal))
+                                                                                        .Select(pair => BlobsModelFactory.BlobItem(name: pair.Key,
+                                                                                            properties: BlobsModelFactory.BlobItemProperties(
+                                                                                                accessTierInferred: false, blobSequenceNumber: null, blobType: BlobType.Block,
+                                                                                                contentLength: pair.Value.Bytes.Length, eTag: new ETag(pair.Value.ETag),
+                                                                                                lastModified: DateTimeOffset.UtcNow))).ToArray();
+                        }
+                        return AsyncPageable<BlobItem>.FromPages([Page<BlobItem>.FromValues(items, null, Mock.Of<Response>())]);
+                    });
+            }
+
+            public string Seed(string name, byte[] bytes)
+            {
+                lock (mutex)
+                {
+                    string etag = $"\"{++version}\"";
+                    storage[name] = new Stored(bytes.ToArray(), etag);
+                    return etag;
+                }
+            }
+
+            public bool Contains(string name)
+            {
+                lock (mutex)
+                {
+                    return storage.ContainsKey(name);
+                }
+            }
+
+            public void Remove(string name)
+            {
+                lock (mutex)
+                {
+                    storage.Remove(name);
+                }
+            }
+
+            public byte[] Bytes(string name)
+            {
+                lock (mutex)
+                {
+                    return storage[name].Bytes.ToArray();
+                }
+            }
+
+            public string Text(string name)
+            {
+                return Encoding.UTF8.GetString(Bytes(name));
+            }
+
+            public string Version(string name)
+            {
+                lock (mutex)
+                {
+                    return storage[name].ETag;
+                }
+            }
+
+            public string[] Names(string prefix)
+            {
+                lock (mutex)
+                {
+                    return storage.Keys.Where(k => k.StartsWith(prefix)).ToArray();
+                }
+            }
+
+            private async Task Start(Operation operation)
+            {
+                Operations.Enqueue(operation);
+                if (Before is not null)
+                {
+                    await Before(operation);
+                }
+            }
+
+            private async Task End(Operation operation)
+            {
+                if (After is not null)
+                {
+                    await After(operation);
+                }
+            }
+
+            private Stored Read(string name, BlobRequestConditions? conditions = null)
+            {
+                lock (mutex)
+                {
+                    Check(name, conditions);
+                    return storage.TryGetValue(name, out Stored? value)
+                        ? value : throw new RequestFailedException(404, "Missing blob", "BlobNotFound", null);
+                }
+            }
+
+            private void Check(string name, BlobRequestConditions? conditions)
+            {
+                bool exists = storage.TryGetValue(name, out Stored? current);
+                if (conditions?.IfNoneMatch == ETag.All && exists ||
+                    conditions?.IfMatch is ETag match && (!exists || current!.ETag != match.ToString()))
+                {
+                    throw new RequestFailedException(412, "ETag condition failed", "ConditionNotMet", null);
+                }
+            }
+
+            private Mock<BlobClient> CreateBlob(string name)
+            {
+                Mock<BlobClient> blob = new Mock<BlobClient>(MockBehavior.Strict);
+                blob.SetupGet(c => c.Name).Returns(name);
+                blob.Setup(c => c.DownloadStreamingAsync(It.IsAny<BlobDownloadOptions>(), It.IsAny<CancellationToken>()))
+                    .Returns(async (BlobDownloadOptions options, CancellationToken _) =>
+                    {
+                        bool record = name.StartsWith(ReportStore.BlobPrefix, StringComparison.Ordinal);
+                        Operation op = new Operation(record ? "record-stream" : "stream", name, options.Conditions);
+                        await Start(op);
+                        Stored current = Read(name, options.Conditions);
+                        Stream stream = record
+                            ? RecordStreamFactory?.Invoke(name, current.Bytes) ?? new MemoryStream(current.Bytes, writable: false)
+                            : StreamFactory?.Invoke(current.Bytes) ??
+                                new MemoryStream(StreamBytes?.Invoke(current.Bytes) ?? current.Bytes, writable: false);
+                        BlobDownloadStreamingResult result = BlobsModelFactory.BlobDownloadStreamingResult(
+                            stream, Details(current, StreamLength?.Invoke(name)));
+                        await End(op);
+                        return Response.FromValue(result, Mock.Of<Response>());
+                    });
+                blob.Setup(c => c.GetPropertiesAsync(It.IsAny<BlobRequestConditions>(), It.IsAny<CancellationToken>()))
+                    .Returns(async (BlobRequestConditions? conditions, CancellationToken _) =>
+                    {
+                        Operation op = new Operation(name.StartsWith(ReportStore.BlobPrefix, StringComparison.Ordinal)
+                                                                            ? "read" : "properties", name, conditions);
+                        await Start(op);
+                        Stored current = Read(name, conditions);
+                        BlobProperties properties = BlobsModelFactory.BlobProperties(
+                            contentLength: PropertyLength?.Invoke(name) ?? current.Bytes.Length,
+                            eTag: new ETag(current.ETag));
+                        await End(op);
+                        return Response.FromValue(properties, Mock.Of<Response>());
+                    });
+                blob.Setup(c => c.UploadAsync(It.IsAny<BinaryData>(), It.IsAny<BlobUploadOptions>(), It.IsAny<CancellationToken>()))
+                    .Returns(async (BinaryData data, BlobUploadOptions options, CancellationToken _) =>
+                    {
+                        Operation op = new Operation("record", name, options.Conditions, data.ToArray());
+                        await Start(op);
+                        string etag;
+                        lock (mutex)
+                        {
+                            Check(name, options.Conditions);
+                            etag = Seed(name, data.ToArray());
+                        }
+                        await End(op);
+                        return Uploaded(etag);
+                    });
+                blob.Setup(c => c.UploadAsync(It.IsAny<Stream>(), It.IsAny<BlobUploadOptions>(), It.IsAny<CancellationToken>()))
+                    .Returns(async (Stream stream, BlobUploadOptions options, CancellationToken token) =>
+                    {
+                        Operation op = new Operation("photo", name, options.Conditions);
+                        await Start(op);
+                        Assert.Equal("image/jpeg", options.HttpHeaders.ContentType);
+                        Assert.Equal(ETag.All, options.Conditions.IfNoneMatch);
+                        Assert.Equal(StorageChecksumAlgorithm.Auto, options.TransferValidation.ChecksumAlgorithm);
+                        Assert.Equal(1, options.TransferOptions.MaximumConcurrency);
+                        using MemoryStream copy = new MemoryStream();
+                        await stream.CopyToAsync(copy, token);
+                        string etag;
+                        lock (mutex)
+                        {
+                            Check(name, options.Conditions);
+                            etag = Seed(name, copy.ToArray());
+                        }
+                        await End(op);
+                        return Uploaded(etag);
+                    });
+                blob.Setup(c => c.DeleteIfExistsAsync(It.IsAny<DeleteSnapshotsOption>(), It.IsAny<BlobRequestConditions>(),
+                        It.IsAny<CancellationToken>()))
+                    .Returns(async (DeleteSnapshotsOption _, BlobRequestConditions? conditions, CancellationToken _) =>
+                    {
+                        Operation op = new Operation("delete", name, conditions);
+                        await Start(op);
+                        bool deleted;
+                        lock (mutex)
+                        {
+                            if (!storage.ContainsKey(name))
+                            {
+                                return Response.FromValue(false, Mock.Of<Response>());
+                            }
+
+                            Check(name, conditions);
+                            deleted = storage.Remove(name);
+                        }
+                        await End(op);
+                        return Response.FromValue(deleted, Mock.Of<Response>());
+                    });
+                return blob;
+            }
+
+            private static BlobDownloadDetails Details(Stored blob, long? length = null)
+            {
+                return BlobsModelFactory.BlobDownloadDetails(
+                                                contentLength: length ?? blob.Bytes.Length, eTag: new ETag(blob.ETag));
+            }
+
+            private static Response<BlobContentInfo> Uploaded(string etag)
+            {
+                return Response.FromValue(
+                                                BlobsModelFactory.BlobContentInfo(eTag: new ETag(etag), lastModified: DateTimeOffset.UtcNow,
+                                                    contentHash: null, versionId: null, encryptionKeySha256: null, encryptionScope: null, blobSequenceNumber: 0),
+                                                Mock.Of<Response>());
+            }
+        }
+    }
+}

--- a/SeattleCarsInBikeLanes.Tests/ReportedItemsDatabaseTests.cs
+++ b/SeattleCarsInBikeLanes.Tests/ReportedItemsDatabaseTests.cs
@@ -1,0 +1,124 @@
+using System.Net;
+using Microsoft.Azure.Cosmos;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Newtonsoft.Json.Linq;
+using SeattleCarsInBikeLanes.Database;
+using SeattleCarsInBikeLanes.Database.Models;
+
+namespace SeattleCarsInBikeLanes.Tests
+{
+    public class ReportedItemsDatabaseTests
+    {
+        private const string ReportId = "abcdef0123456789abcdef0123456789.0";
+
+        private static ReportedItemsDatabase CreateDatabase(Container container)
+        {
+            return new ReportedItemsDatabase(NullLogger<ReportedItemsDatabase>.Instance, container);
+        }
+
+        [Fact]
+        public async Task SavePublishedReportAsync_ReplacesTheSameIdAndPartitionOnRetry()
+        {
+            Dictionary<(string Id, PartitionKey PartitionKey), ReportedItem> savedItems = new Dictionary<(string Id, PartitionKey PartitionKey), ReportedItem>();
+            Mock<Container> container = new Mock<Container>(MockBehavior.Strict);
+            container.Setup(c => c.UpsertItemAsync(It.IsAny<ReportedItem>(), It.IsAny<PartitionKey?>(),
+                    null, It.IsAny<CancellationToken>()))
+                .Callback<ReportedItem, PartitionKey?, ItemRequestOptions?, CancellationToken>((item, partitionKey, _, _) =>
+                {
+                    Assert.Equal(new PartitionKey(item.TweetId), partitionKey);
+                    Assert.Equal(item.TweetId, JObject.FromObject(item).Value<string>("id"));
+                    savedItems[(item.TweetId, partitionKey!.Value)] = item;
+                })
+                .ReturnsAsync(Mock.Of<ItemResponse<ReportedItem>>());
+            ReportedItemsDatabase database = CreateDatabase(container.Object);
+            ReportedItem original = new ReportedItem() { TweetId = ReportId, ThreadsLink = "https://www.threads.net/@test/post/old" };
+            ReportedItem updated = new ReportedItem() { TweetId = ReportId, ThreadsLink = "https://www.threads.net/@test/post/new" };
+            ReportedItem unrelated = new ReportedItem() { TweetId = "unrelated.0" };
+
+            await database.SavePublishedReportAsync(unrelated);
+            await database.SavePublishedReportAsync(original);
+            await database.SavePublishedReportAsync(updated);
+            await database.SavePublishedReportAsync(updated);
+
+            Assert.Equal(2, savedItems.Count);
+            Assert.Same(updated, savedItems[(ReportId, new PartitionKey(ReportId))]);
+            Assert.Same(unrelated, savedItems[(unrelated.TweetId, new PartitionKey(unrelated.TweetId))]);
+            container.Verify(c => c.UpsertItemAsync(updated, new PartitionKey(ReportId), null, CancellationToken.None),
+                Times.Exactly(2));
+        }
+
+        [Fact]
+        public async Task SavePublishedReportAsync_ForwardsCancellationToken()
+        {
+            using CancellationTokenSource cancellation = new CancellationTokenSource();
+            ReportedItem item = new ReportedItem() { TweetId = ReportId };
+            Mock<Container> container = new Mock<Container>(MockBehavior.Strict);
+            container.Setup(c => c.UpsertItemAsync(item, new PartitionKey(ReportId), null, cancellation.Token))
+                .ReturnsAsync(Mock.Of<ItemResponse<ReportedItem>>());
+
+            await CreateDatabase(container.Object).SavePublishedReportAsync(item, cancellation.Token);
+
+            container.Verify(c => c.UpsertItemAsync(item, new PartitionKey(ReportId), null, cancellation.Token), Times.Once);
+        }
+
+        [Fact]
+        public async Task SavePublishedReportAsync_PropagatesCancellation()
+        {
+            using CancellationTokenSource cancellation = new CancellationTokenSource();
+            cancellation.Cancel();
+            ReportedItem item = new ReportedItem() { TweetId = ReportId };
+            OperationCanceledException failure = new OperationCanceledException(cancellation.Token);
+            Mock<Container> container = new Mock<Container>(MockBehavior.Strict);
+            container.Setup(c => c.UpsertItemAsync(item, new PartitionKey(ReportId), null, cancellation.Token))
+                .ThrowsAsync(failure);
+
+            var exception = await Assert.ThrowsAsync<OperationCanceledException>(() =>
+                CreateDatabase(container.Object).SavePublishedReportAsync(item, cancellation.Token));
+
+            Assert.Same(failure, exception);
+        }
+
+        [Theory]
+        [InlineData(HttpStatusCode.TooManyRequests)]
+        [InlineData(HttpStatusCode.ServiceUnavailable)]
+        public async Task SavePublishedReportAsync_PropagatesStorageFailures(HttpStatusCode statusCode)
+        {
+            ReportedItem item = new ReportedItem() { TweetId = ReportId };
+            CosmosException failure = new CosmosException("Storage unavailable", statusCode, 0, "test", 0);
+            Mock<Container> container = new Mock<Container>(MockBehavior.Strict);
+            container.Setup(c => c.UpsertItemAsync(item, new PartitionKey(ReportId), null, CancellationToken.None))
+                .ThrowsAsync(failure);
+
+            var exception = await Assert.ThrowsAsync<CosmosException>(() =>
+                CreateDatabase(container.Object).SavePublishedReportAsync(item));
+
+            Assert.Same(failure, exception);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData(" \t")]
+        public async Task SavePublishedReportAsync_RejectsMissingId(string? id)
+        {
+            Mock<Container> container = new Mock<Container>(MockBehavior.Strict);
+
+            await Assert.ThrowsAnyAsync<ArgumentException>(() =>
+                CreateDatabase(container.Object).SavePublishedReportAsync(new ReportedItem() { TweetId = id! }));
+
+            container.VerifyNoOtherCalls();
+        }
+
+        [Fact]
+        public async Task SavePublishedReportAsync_RejectsNullItem()
+        {
+            Mock<Container> container = new Mock<Container>(MockBehavior.Strict);
+
+            await Assert.ThrowsAsync<ArgumentNullException>(() =>
+                CreateDatabase(container.Object).SavePublishedReportAsync(null!));
+
+            container.VerifyNoOtherCalls();
+        }
+    }
+}

--- a/SeattleCarsInBikeLanes.Tests/TestFiles/AdminDeviceBlocks.html
+++ b/SeattleCarsInBikeLanes.Tests/TestFiles/AdminDeviceBlocks.html
@@ -1,0 +1,356 @@
+<!doctype html>
+<html lang="en">
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Admin device block browser checks</title>
+<h1>Admin device block browser checks</h1>
+<p>Exercises the production admin page and Bootstrap modal with an in-memory fake API.
+    Serve the repository root with a static HTTP server. No backend or Azure access is used.</p>
+<pre id="results">Running...</pre>
+<iframe id="admin" title="Admin page under test" style="width: 100%; height: 700px;"></iframe>
+<script>
+const checks = [];
+const assert = (condition, message) => { if (!condition) throw new Error(message); };
+const json = (body, status = 200) => new Response(JSON.stringify(body),
+    { status, headers: { 'Content-Type': 'application/json' } });
+const waitFor = async (condition, message = 'Timed out', attempts = 200) => {
+    for (let attempt = 0; attempt < attempts; attempt++) {
+        if (condition()) return;
+        await new Promise(resolve => setTimeout(resolve, 10));
+    }
+    throw new Error(message);
+};
+const frame = document.getElementById('admin');
+let records = new Map();
+let calls = [];
+let intercept = null;
+let pending = {};
+let submitCount = 0;
+const photo = (deviceId) => ({
+    deviceId, reportId: 'report', moderationStatus: 'Pending', reportVersion: 'version', canModerate: true,
+    photoId: 'photo', photoDateTime: '2026-09-08T10:30:00', numberOfCars: 1,
+    photoCrossStreet: 'Original location', photoLatitude: '47.6', photoLongitude: '-122.3'
+});
+window.adminDeviceBlocksFetch = async (url, options = {}) => {
+    calls.push({ url, ...options });
+    if (url.endsWith('/PendingPhotos')) return json(pending);
+    if (url.endsWith('/GetBlueskySession')) return json({});
+    assert(url === 'api/AdminPage/BlockedDevices', `Unexpected API call: ${url}`);
+    assert(options.cache === 'no-store', 'Blocklist request must bypass cache');
+    const overridden = intercept && await intercept(options);
+    if (overridden) return overridden;
+    if (!options.method) return json([...records].map(([deviceId, reason]) => ({ deviceId, reason })));
+    assert(options.headers['Content-Type'] === 'application/json', 'Mutation is not JSON');
+    const body = JSON.parse(options.body);
+    assert(Object.keys(body).sort().join(',') ===
+        (options.method === 'POST' ? 'deviceId,reason' : 'deviceId'), 'Unexpected payload fields / credentials');
+    if (options.method === 'POST') records.set(body.deviceId, body.reason);
+    else if (options.method === 'DELETE') records.delete(body.deviceId);
+    else throw new Error(`Unexpected method: ${options.method}`);
+    return new Response(null, { status: 204 });
+};
+
+const doc = () => frame.contentDocument;
+const el = id => doc().getElementById(id);
+const controller = () => frame.contentWindow.eval('adminDeviceBlocks');
+const controls = id => [...doc().querySelectorAll('[data-device-block-control]')]
+    .filter(control => control.dataset.deviceBlockControl === id);
+const block = id => controls(id)[0].querySelector('button');
+const unblock = id => [...el('blockedDevicesList').querySelectorAll('li')]
+    .find(row => row.querySelector('strong').textContent === id).querySelector('button');
+const writes = () => calls.filter(call => call.method);
+const shown = () => el('deviceBlockModal').classList.contains('show');
+const openBlock = async id => {
+    block(id).focus();
+    block(id).click();
+    await waitFor(() => doc().activeElement === el('deviceBlockReason'), 'Reason did not receive focus');
+};
+const cancel = async () => {
+    el('deviceBlockModalCancel').click();
+    await waitFor(() => !controller().action, 'Modal did not close');
+};
+const confirm = async () => {
+    el('deviceBlockModalConfirm').click();
+    await waitFor(() => !controller().busy, 'Mutation did not finish');
+};
+async function reset(initialRecords = [], reports = {
+    first: [photo('Device_A')], duplicate: [photo('Device_A')], second: [photo('device_B')],
+    noId: [photo(null)], blankId: [photo('   ')], invalidId: [photo('x'.repeat(129))]
+}) {
+    if (controller().action) await cancel();
+    records = new Map(initialRecords);
+    pending = reports;
+    intercept = null;
+    await controller().refresh();
+    await frame.contentWindow.displayPendingPhotos();
+    calls = [];
+    submitCount = 0;
+}
+async function check(name, run) {
+    try {
+        await run();
+        checks.push({ name, passed: true });
+    } catch (error) {
+        checks.push({ name, passed: false, error: error.message });
+    }
+    document.getElementById('results').textContent = checks.map(result =>
+        `${result.passed ? 'PASS' : 'FAIL'} ${result.name}${result.error ? ': ' + result.error : ''}`).join('\n');
+}
+
+(async () => {
+    const pageUrl = new URL('../../SeattleCarsInBikeLanes/wwwroot/admin.html', location.href);
+    const source = new DOMParser().parseFromString(await (await fetch(pageUrl)).text(), 'text/html');
+    // Keep the real Bootstrap and Luxon scripts; the map SDK is unrelated and must not contact Azure.
+    source.querySelectorAll('[src], [href]').forEach(element => {
+        if ((element.getAttribute('src') || element.getAttribute('href')).includes('atlas.microsoft.com')) element.remove();
+    });
+    const base = source.createElement('base');
+    base.href = pageUrl.href;
+    source.head.prepend(base);
+    const fake = source.createElement('script');
+    fake.textContent = 'window.fetch = (...args) => parent.adminDeviceBlocksFetch(...args);';
+    source.head.prepend(fake);
+    frame.srcdoc = '<!doctype html>' + source.documentElement.outerHTML;
+    await waitFor(() => {
+        try { return controller().status === 'known'; } catch { return false; }
+    }, 'Production page failed to load (Bootstrap/Luxon CDN access is required)', 2000);
+    doc().addEventListener('submit', () => submitCount++, true);
+
+    await check('Missing IDs have no action; duplicate IDs share status; invalid IDs cannot block', async () => {
+        await reset();
+        assert(!el('noId').querySelector('[data-device-block-control]'), 'Missing ID received a block action');
+        assert(!el('blankId').querySelector('[data-device-block-control]'), 'Blank ID received a block action');
+        assert(el('invalidId').querySelector('[data-device-block-control] button').disabled, 'Overlong ID was accepted');
+        assert(controls('Device_A').length === 2, 'Duplicate ID fixture missing');
+        assert(controls('Device_A').every(control => control.textContent.includes('Not blocked')), 'Initial status differs');
+        assert(block('Device_A').type === 'button', 'Block control can submit a report form');
+    });
+
+    await check('Open / cancel writes nothing, focuses the reason and restores the opener', async () => {
+        await reset();
+        const opener = block('Device_A');
+        await openBlock('Device_A');
+        assert(el('deviceBlockModal').getAttribute('role') === 'dialog', 'Bootstrap dialog semantics missing');
+        assert(el('deviceBlockReason').required && el('deviceBlockReason').maxLength === 1000, 'Reason constraints missing');
+        el('deviceBlockReason').value = 'Do not save';
+        await cancel();
+        assert(writes().length === 0, 'Opening / cancellation wrote a block');
+        assert(doc().activeElement === opener, 'Focus was not restored');
+        await openBlock('device_B');
+        assert(el('deviceBlockReason').value === '', 'Reason leaked to another device');
+        el('deviceBlockModal').dispatchEvent(new frame.contentWindow.KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+        await waitFor(() => !controller().action, 'Escape did not dismiss the idle modal');
+        assert(writes().length === 0, 'Escape sent a mutation');
+    });
+
+    await check('Blank and overlong reasons are rejected; trimmed 1,000-character reason is accepted', async () => {
+        await reset();
+        await openBlock('Device_A');
+        for (const reason of ['', ' \n\t ', 'x'.repeat(1001)]) {
+            el('deviceBlockReason').value = reason;
+            await confirm();
+            assert(writes().length === 0 && shown(), 'Invalid reason sent a mutation');
+            assert(el('deviceBlockReason').getAttribute('aria-invalid') === 'true', 'Invalid reason is not accessible');
+        }
+        el('deviceBlockReason').value = ` ${'x'.repeat(1000)} `;
+        await confirm();
+        await waitFor(() => !controller().action);
+        assert(records.get('Device_A') === 'x'.repeat(1000), 'Reason boundary or trim failed');
+        assert(writes().length === 1, 'Valid confirmation not sent exactly once');
+    });
+
+    await check('Writes lock the target, prevent duplicate confirms/dismissal and preserve moderation edits', async () => {
+        await reset();
+        const form = el('first_form');
+        const input = form.elements.location;
+        input.value = 'Unsaved moderation edit';
+        await openBlock('Device_A');
+        el('deviceBlockReason').value = ' repeated spam ';
+        let finish;
+        intercept = options => options.method ? new Promise(resolve => { finish = resolve; }) : null;
+        el('deviceBlockModalConfirm').click();
+        await waitFor(() => finish);
+        el('deviceBlockModalConfirm').dispatchEvent(new Event('click'));
+        controller().open('device_B', true, block('device_B'));
+        controller().modal.hide();
+        el('deviceBlockModal').dispatchEvent(new frame.contentWindow.KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+        assert(shown() && el('deviceBlockModalCancel').disabled, 'Modal dismissed during write');
+        assert(el('deviceBlockReason').readOnly, 'In-flight reason can change');
+        assert(el('deviceBlockModalTarget').textContent === 'Device_A', 'Target changed during write');
+        assert(controls('Device_A').every(control => control.querySelector('button').disabled), 'Duplicate card remained active');
+        assert(writes().length === 1, 'Duplicate confirmation sent a request');
+        records.set('Device_A', 'repeated spam');
+        finish(new Response(null, { status: 204 }));
+        await waitFor(() => !controller().action);
+        assert(el('first_form') === form && input.value === 'Unsaved moderation edit', 'Report form or edits replaced');
+        assert(submitCount === 0, 'Blocking submitted a report form');
+        assert(!calls.some(call => call.url.endsWith('/PendingPhotos')), 'Blocking reloaded pending reports');
+        assert(controls('Device_A').every(control => control.textContent.includes('Blocked')), 'Duplicate statuses differ');
+        assert(JSON.parse(writes()[0].body).deviceId === 'Device_A', 'Device ID casing changed');
+        assert(doc().activeElement === el('refreshBlockedDevicesButton'), 'Success did not restore usable focus');
+    });
+
+    await check('400 errors retain reason and message; corrected input retries; unrelated actions reset both', async () => {
+        await reset();
+        await openBlock('Device_A');
+        el('deviceBlockReason').value = ' Keep my reason ';
+        intercept = options => options.method ? json('Server validation detail', 400) : null;
+        await confirm();
+        assert(shown() && el('deviceBlockReason').value === ' Keep my reason ', 'Failed reason was lost');
+        assert(el('deviceBlockModalError').textContent.includes('Server validation detail'), 'Server error was hidden');
+        assert(!el('deviceBlockModalConfirm').disabled, 'Validation cannot be retried');
+        await cancel();
+        await openBlock('device_B');
+        assert(!el('deviceBlockReason').value && el('deviceBlockModalError').hidden, 'Error/reason leaked between actions');
+        el('deviceBlockReason').value = 'x';
+        intercept = null;
+        await confirm();
+        await waitFor(() => !controller().action);
+        assert(records.get('device_B') === 'x', 'Minimum-length reason did not succeed');
+    });
+
+    await check('Persisted reasons are plain text; unblock displays existing reason and sends no new one', async () => {
+        const reason = '<img src=x onerror="window.reasonExecuted=true"> & <script>bad()</scr' + 'ipt>\nSecond line';
+        await reset([['Device_A', reason]]);
+        assert(el('blockedDevicesList').textContent.includes(reason), 'Persisted reason changed');
+        assert(!el('blockedDevicesList').querySelector('img, script'), 'Reason interpreted as markup');
+        unblock('Device_A').click();
+        await waitFor(() => doc().activeElement === el('deviceBlockModalCancel'));
+        assert(el('deviceBlockSavedReason').textContent === reason, 'Unblock omitted saved reason');
+        assert(el('deviceBlockReasonGroup').hidden && !el('deviceBlockReason').required, 'Unblock requires a new reason');
+        await cancel();
+        assert(writes().length === 0, 'Cancel unblocked a device');
+        unblock('Device_A').click();
+        await waitFor(() => doc().activeElement === el('deviceBlockModalCancel'));
+        await confirm();
+        await waitFor(() => !controller().action);
+        assert(writes()[0].method === 'DELETE' && writes()[0].body === '{"deviceId":"Device_A"}', 'Wrong unblock payload');
+        assert(!records.has('Device_A') && el('blockedDevicesList').children.length === 0, 'Unblock list not updated');
+        assert(controls('Device_A').every(control => !control.querySelector('button').disabled), 'Unblock not reflected on cards');
+    });
+
+    await check('Blocked devices stay available with no pending reports', async () => {
+        await reset([['orphan-device', 'Report already deleted']], {});
+        assert(el('cardsDiv').textContent.includes('No pending'), 'Empty pending fixture failed');
+        assert(unblock('orphan-device') && el('blockedDevicesList').textContent.includes('Report already deleted'), 'Block lost with report');
+    });
+
+    await check('List failure marks status unknown, retains last known reasons, and leaves moderation usable', async () => {
+        await reset([['Device_A', 'Saved reason']]);
+        const form = el('first_form');
+        form.elements.location.value = 'Keep through outage';
+        intercept = () => json({ message: 'Storage unavailable' }, 503);
+        await controller().refresh();
+        assert(controller().status === 'unknown' && !el('blockedDevicesError').hidden, 'Failed list looked successful');
+        assert(el('blockedDevicesList').textContent.includes('Saved reason') && unblock('Device_A').disabled, 'Last known list not marked stale');
+        assert(controls('device_B')[0].textContent.includes('unknown') && block('device_B').disabled, 'Unknown means unblocked');
+        assert(!form.querySelector('button[type=submit]').disabled, 'Blocklist failure disabled moderation');
+        assert(el('first_form') === form && form.elements.location.value === 'Keep through outage', 'List refresh lost edits');
+        intercept = null;
+        el('refreshBlockedDevicesButton').click();
+        await waitFor(() => controller().status === 'known');
+        assert(el('blockedDevicesError').hidden && !block('device_B').disabled, 'Refresh did not recover');
+    });
+
+    await check('Out-of-order list successes/failures cannot overwrite newer state or a successful mutation', async () => {
+        await reset();
+        let finishOld;
+        intercept = () => new Promise(resolve => { finishOld = resolve; });
+        const old = controller().refresh();
+        await waitFor(() => finishOld);
+        intercept = null;
+        await controller().refresh();
+        await openBlock('Device_A');
+        el('deviceBlockReason').value = 'New block';
+        await confirm();
+        await waitFor(() => !controller().action);
+        finishOld(json([]));
+        await old;
+        assert(controller().records.has('Device_A'), 'Old list erased successful block');
+        intercept = () => new Promise(resolve => { finishOld = resolve; });
+        const olderFailure = controller().refresh();
+        await waitFor(() => controller().status === 'loading');
+        intercept = null;
+        await controller().refresh();
+        finishOld(json({ message: 'Old failure' }, 503));
+        await olderFailure;
+        assert(controller().status === 'known' && el('blockedDevicesError').hidden, 'Stale failure poisoned newer status');
+    });
+
+    await check('Lost mutation response reconciles without claiming success or discarding the entered reason', async () => {
+        await reset();
+        await openBlock('Device_A');
+        el('deviceBlockReason').value = ' Retain after disconnect ';
+        intercept = options => {
+            if (!options.method) return null;
+            records.set('Device_A', 'Retain after disconnect');
+            throw new frame.contentWindow.TypeError('Lost response after write');
+        };
+        await confirm();
+        assert(shown() && el('deviceBlockReason').value === ' Retain after disconnect ', 'Unconfirmed write closed or cleared dialog');
+        assert(el('deviceBlockModalError').textContent.includes('not confirmed') &&
+            el('deviceBlockModalError').textContent.includes('as blocked'), 'Outcome not explicitly reconciled');
+        assert(el('deviceBlockModalConfirm').disabled, 'Reconciled block can overwrite its reason');
+        assert(!el('deviceBlockModalError').textContent.includes('pending reports'), 'Wrong recovery guidance');
+        assert(writes().length === 1 && controller().records.has('Device_A'), 'Lost write was retried or missed');
+        await cancel();
+    });
+
+    await check('Uncertain mutation and failed reconciliation lock retry; modal refresh recovers without losing input/error', async () => {
+        await reset();
+        await openBlock('Device_A');
+        el('deviceBlockReason').value = 'Keep during outage';
+        intercept = options => json({ message: options.method ? 'Write unavailable' : 'Read unavailable' }, 503);
+        await confirm();
+        assert(controller().status === 'unknown' && el('deviceBlockModalConfirm').disabled, 'Uncertain state permits retry');
+        assert(!el('deviceBlockModalRefresh').hidden && !el('deviceBlockModalCancel').disabled, 'Recovery/cancel unavailable');
+        assert(el('deviceBlockReason').value === 'Keep during outage' &&
+            el('deviceBlockModalError').textContent.includes('Write unavailable'), 'Reason or original error lost');
+        intercept = null;
+        el('deviceBlockModalRefresh').click();
+        await waitFor(() => !controller().busy);
+        assert(!el('deviceBlockModalConfirm').disabled && el('deviceBlockModalError').textContent.includes('not blocked'), 'Modal refresh failed');
+        await confirm();
+        await waitFor(() => !controller().action);
+        assert(records.get('Device_A') === 'Keep during outage', 'Retry lost entered reason');
+    });
+
+    await check('Unblock failure retains saved reason and reconciles before allowing retry', async () => {
+        await reset([['Device_A', 'Saved reason']]);
+        unblock('Device_A').click();
+        await waitFor(() => doc().activeElement === el('deviceBlockModalCancel'));
+        intercept = options => options.method ? json({ message: 'Delete unavailable' }, 503) : null;
+        await confirm();
+        assert(shown() && el('deviceBlockSavedReason').textContent === 'Saved reason', 'Failed unblock lost reason');
+        assert(el('deviceBlockModalError').textContent.includes('Delete unavailable') &&
+            el('deviceBlockModalError').textContent.includes('as blocked'), 'Failed unblock did not reconcile');
+        intercept = null;
+        await confirm();
+        await waitFor(() => !controller().action);
+        assert(!records.has('Device_A'), 'Unblock retry failed');
+    });
+
+    await check('Malformed lists are unknown; unexpected mutation success is uncertain rather than accepted', async () => {
+        await reset();
+        intercept = () => json({});
+        await controller().refresh();
+        assert(controller().status === 'unknown', 'Malformed list became empty success');
+        intercept = null;
+        await controller().refresh();
+        await openBlock('Device_A');
+        el('deviceBlockReason').value = 'Check unexpected response';
+        intercept = options => options.method ? new Response('<html>Sign in</html>') : null;
+        await confirm();
+        assert(shown() && el('deviceBlockModalError').textContent.includes('unexpected response'), 'Unexpected status was accepted');
+        assert(el('deviceBlockModalError').textContent.includes('not blocked'), 'Unexpected response was not reconciled');
+        await cancel();
+    });
+})().catch(error => {
+    checks.push({ name: 'Harness setup', passed: false, error: error.message });
+    document.getElementById('results').textContent += '\nFAIL ' + error.message;
+}).finally(() => {
+    window.adminDeviceBlocksResults = checks;
+    document.title = checks.length && checks.every(result => result.passed) ? 'Admin block checks passed' : 'Admin block checks failed';
+});
+</script>
+</html>

--- a/SeattleCarsInBikeLanes.Tests/TestFiles/UploadFlow.html
+++ b/SeattleCarsInBikeLanes.Tests/TestFiles/UploadFlow.html
@@ -1,0 +1,242 @@
+<!doctype html>
+<html lang="en">
+<meta charset="utf-8">
+<title>Upload flow browser checks</title>
+<h1>Upload flow browser checks</h1>
+<p>Uses the production upload helpers with an in-memory fake server. No reports are sent.</p>
+<pre id="results">Running...</pre>
+<script src="../../SeattleCarsInBikeLanes/wwwroot/js/helpers.js"></script>
+<script src="../../SeattleCarsInBikeLanes/wwwroot/js/upload-report.js"></script>
+<script src="../../SeattleCarsInBikeLanes/wwwroot/js/admin-helpers.js"></script>
+<script>
+const checks = [];
+const assert = (condition, message) => { if (!condition) throw new Error(message); };
+const json = (body, status = 200) => new Response(JSON.stringify(body),
+    { status, headers: { 'Content-Type': 'application/json' } });
+const reject = (code, status) => json({ code, message: code }, status);
+const receipt = (id, attribution = {}) => ({
+    reportId: id, submissionId: id, submittedAt: '2026-09-08T00:00:00Z', attribution
+});
+const prepared = (attempt) => [{
+    photoId: `photo-${attempt}`, submissionId: attempt, photoNumber: 0
+}];
+const createReport = () => new ReportUpload([new File(['photo'], 'photo.jpg', { type: 'image/jpeg' })]);
+const draft = (cars = 2) => [{ ...prepared('old')[0], numberOfCars: cars }];
+const expectFailure = async (promise) => {
+    let failed = false;
+    try { await promise; } catch { failed = true; }
+    assert(failed, 'Expected failure');
+};
+
+async function check(name, run) {
+    const originalFetch = window.fetch;
+    try {
+        await run();
+        checks.push({ name, passed: true });
+    } catch (error) {
+        checks.push({ name, passed: false, error: error.message });
+    } finally {
+        window.fetch = originalFetch;
+    }
+}
+
+(async () => {
+    await check('Shared URLs, report header, envelope, and receipt', async () => {
+        const report = createReport();
+        const urls = [];
+        window.fetch = async (url, options) => {
+            urls.push(url);
+            assert(options.headers['X-Report-Id'] === report.id, 'Stable report header missing');
+            if (url.endsWith('/Initial')) {
+                assert(options.body.getAll('files').length === 1, 'Multipart files missing');
+                return json(prepared('first'));
+            }
+            const body = JSON.parse(options.body);
+            assert(body.photos[0].photoId === 'photo-first', 'Prepared reference missing');
+            assert(body.attribution.blueskyDid === 'did:plc:a', 'Explicit attribution missing');
+            return json(receipt(report.id, body.attribution));
+        };
+        await report.prepare();
+        await report.submit(draft(), { blueskyDid: 'did:plc:a' });
+        assert(urls.join(',') === 'api/Upload/Initial,api/Upload/Finalize', 'Wrong submission routes');
+        assert(report.receipt && !report.uncertain && report.files.length === 0, 'Acceptance not acknowledged');
+    });
+
+    await check('Lost success response resolves receipt without another finalization', async () => {
+        const report = createReport();
+        report.prepared = prepared('first');
+        let posts = 0;
+        window.fetch = async (url) => {
+            if (url.endsWith('/Finalize')) {
+                posts++;
+                throw new TypeError('Connection lost after acceptance');
+            }
+            return json(receipt(report.id, { blueskyDid: 'did:plc:a' }));
+        };
+        await expectFailure(report.submit(draft(), { blueskyDid: 'did:plc:a' }));
+        assert(report.uncertain, 'Lost response must be uncertain');
+        const accepted = await report.submit(draft(99), { blueskyDid: 'did:plc:b' });
+        assert(posts === 1 && accepted.attribution.blueskyDid === 'did:plc:a', 'Retry replaced accepted report');
+    });
+
+    await check('Duplicate clicks share one in-flight operation', async () => {
+        const report = createReport();
+        report.prepared = prepared('first');
+        let finish;
+        let calls = 0;
+        window.fetch = async () => { calls++; return new Promise(resolve => { finish = resolve; }); };
+        const first = report.submit(draft(), {});
+        const second = report.submit(draft(), {});
+        assert(first === second && calls === 1, 'Duplicate submission was sent');
+        finish(json(receipt(report.id)));
+        await first;
+    });
+
+    await check('In-progress receipt lookup never resubmits or clears frozen state', async () => {
+        const report = createReport();
+        report.prepared = prepared('first');
+        const urls = [];
+        window.fetch = async (url) => { urls.push(url); return reject('report_in_progress', 409); };
+        await expectFailure(report.submit(draft(), {}));
+        await expectFailure(report.submit(draft(99), {}));
+        assert(report.uncertain && report.request.photos[0].numberOfCars === 2, 'In-progress state was lost');
+        assert(urls.filter(url => url.endsWith('/Finalize')).length === 1, 'In-progress work was resent');
+    });
+
+    await check('Expired preparation retries new photos under the same report ID', async () => {
+        const report = createReport();
+        report.prepared = prepared('expired');
+        let posts = 0;
+        window.fetch = async (url, options) => {
+            assert(options.headers['X-Report-Id'] === report.id, 'Preparation changed report ID');
+            if (url.endsWith('/Initial')) return json(prepared('fresh'));
+            if (++posts === 1) return reject('preparation_expired', 410);
+            const body = JSON.parse(options.body);
+            assert(body.photos[0].photoId === 'photo-fresh', 'Expired reference reused');
+            assert(body.photos[0].numberOfCars === 2, 'User details lost');
+            return json(receipt(report.id));
+        };
+        await report.submit(draft(), {});
+        assert(posts === 2 && report.receipt, 'Repreparation did not complete');
+    });
+
+    await check('Definitive validation errors allow corrections without changing report identity', async () => {
+        const report = createReport();
+        report.prepared = prepared('first');
+        let posts = 0;
+        window.fetch = async (_, options) => {
+            if (++posts === 1) return reject('invalid_report', 400);
+            assert(JSON.parse(options.body).photos[0].numberOfCars === 3, 'Corrected value ignored');
+            return json(receipt(report.id));
+        };
+        await expectFailure(report.submit(draft(), {}));
+        assert(!report.uncertain && !report.request, 'Rejected request was frozen');
+        await report.submit(draft(3), {});
+    });
+
+    await check('Provider outage retains selected account while retrying', async () => {
+        const report = createReport();
+        report.prepared = prepared('first');
+        let posts = 0;
+        window.fetch = async (url, options) => {
+            if (url.includes('/Reports/')) return new Response(null, { status: 404 });
+            const body = JSON.parse(options.body);
+            assert(body.attribution.blueskyDid === 'did:plc:a', 'Retry adopted another account');
+            return ++posts === 1 ? reject('provider_unavailable', 503) : json(receipt(report.id, body.attribution));
+        };
+        await expectFailure(report.submit(draft(), { blueskyDid: 'did:plc:a' }));
+        await report.submit(draft(), { blueskyDid: 'did:plc:b' });
+    });
+
+    await check('Rejected credentials permit an explicit anonymous retry, not silent account switching', async () => {
+        const report = createReport();
+        report.prepared = prepared('first');
+        let posts = 0;
+        window.fetch = async (_, options) => {
+            if (++posts === 1) return reject('credential_rejected', 401);
+            assert(Object.keys(JSON.parse(options.body).attribution).length === 0, 'Explicit anonymity was lost');
+            return json(receipt(report.id));
+        };
+        await expectFailure(report.submit(draft(), { blueskyDid: 'did:plc:a' }));
+        assert(!report.uncertain, 'Credential rejection was treated as accepted');
+        await report.submit(draft(), {});
+    });
+
+    await check('Malformed success is uncertain and requires a valid receipt', async () => {
+        const report = createReport();
+        report.prepared = prepared('first');
+        window.fetch = async (url) => url.endsWith('/Finalize') ? json({}) : json(receipt(report.id));
+        await expectFailure(report.submit(draft(), {}));
+        assert(report.uncertain && !report.receipt, 'Malformed confirmation was accepted');
+        await report.submit(draft(), {});
+        assert(report.receipt, 'Receipt recovery failed');
+    });
+
+    await check('Incomplete initial photo set is not accepted', async () => {
+        const report = createReport();
+        window.fetch = async () => json([]);
+        await expectFailure(report.prepare());
+        assert(!report.prepared && report.files.length === 1, 'Incomplete preparation lost its source');
+    });
+
+    await check('Failed admin deletion requires reconciliation instead of success', async () => {
+        window.fetch = async () => json({ message: 'Report reserved for publishing' }, 409);
+        try {
+            await deletePendingPhoto({ reportId: 'report' });
+            throw new Error('Deletion incorrectly succeeded');
+        } catch (error) {
+            assert(error.status === 409 && error.refreshRequired, 'Conflict did not require refresh');
+        }
+    });
+
+    await check('Failed publication returns a retryable version without discarding the edited card', async () => {
+        window.fetch = async () => json({
+            message: 'Threads token expired; remove successful posts and retry.',
+            retryAllowed: true, reportVersion: 'after-release'
+        }, 502);
+        try {
+            await uploadTweet({ reportId: 'report' });
+            throw new Error('Publication incorrectly succeeded');
+        } catch (error) {
+            assert(error.retryAllowed && error.reportVersion === 'after-release', 'Retry version was lost');
+            assert(!error.refreshRequired, 'An editable failed card should stay in place');
+        }
+    });
+
+    await check('A failed publication without a confirmed pending version still requires refresh', async () => {
+        window.fetch = async () => json({ message: 'Storage unavailable', retryAllowed: true }, 503);
+        try {
+            await uploadTweet({ reportId: 'report' });
+            throw new Error('Publication incorrectly succeeded');
+        } catch (error) {
+            assert(!error.retryAllowed && error.refreshRequired, 'Unconfirmed state was treated as retryable');
+        }
+    });
+
+    await check('Lost admin response body requires reconciliation', async () => {
+        window.fetch = async () => ({ text: async () => { throw new TypeError('Body connection lost'); } });
+        try {
+            await deletePendingPhoto({ reportId: 'report' });
+            throw new Error('Deletion incorrectly succeeded');
+        } catch (error) {
+            assert(error.refreshRequired, 'Interrupted response did not require refresh');
+        }
+    });
+
+    await check('Malformed admin JSON does not become a success-shaped text response', async () => {
+        window.fetch = async () => new Response('{', { headers: { 'Content-Type': 'application/json' } });
+        try {
+            await getPendingPhotos();
+            throw new Error('Malformed response was accepted');
+        } catch (error) {
+            assert(error.refreshRequired, 'Malformed JSON did not require refresh');
+        }
+    });
+
+    window.uploadFlowResults = checks;
+    document.getElementById('results').textContent = checks.map(result =>
+        `${result.passed ? 'PASS' : 'FAIL'} ${result.name}${result.error ? ': ' + result.error : ''}`).join('\n');
+    document.title = checks.every(result => result.passed) ? 'Upload checks passed' : 'Upload checks failed';
+})();
+</script>
+</html>

--- a/SeattleCarsInBikeLanes.Tests/UploadContractTests.cs
+++ b/SeattleCarsInBikeLanes.Tests/UploadContractTests.cs
@@ -1,0 +1,94 @@
+using Microsoft.AspNetCore.Mvc;
+using SeattleCarsInBikeLanes.Controllers;
+using SeattleCarsInBikeLanes.Core.Contracts;
+using SeattleCarsInBikeLanes.Storage.Models;
+
+namespace SeattleCarsInBikeLanes.Tests
+{
+    public class UploadContractTests
+    {
+        [Fact]
+        public void InitialMetadataMapsToTheSharedResponse()
+        {
+            DateTime takenAt = new DateTime(2026, 8, 18, 12, 30, 0);
+            List<ImageTag> tags = new List<ImageTag>()
+            {
+                new ImageTag() { Name = "car", Confidence = 0.95f }
+            };
+            InitialPhotoUploadMetadata metadata = new InitialPhotoUploadMetadata(
+                "photo-1",
+                "submission-1",
+                0,
+                takenAt,
+                "47.60621",
+                "-122.33207",
+                "Pike St",
+                tags);
+
+            InitialPhotoUpload contract = metadata.ToContract("https://example.test/photo");
+
+            Assert.Equal("https://example.test/photo", contract.Uri);
+            Assert.Equal(metadata.PhotoId, contract.PhotoId);
+            Assert.Equal(metadata.SubmissionId, contract.SubmissionId);
+            Assert.Equal(takenAt, contract.PhotoDateTime);
+            Assert.Same(tags, contract.Tags);
+        }
+
+        [Fact]
+        public void FinalizeContractMapsOnlyClientWritableFields()
+        {
+            FinalizedPhotoUpload contract = new FinalizedPhotoUpload()
+            {
+                PhotoId = "photo-1",
+                SubmissionId = "submission-1",
+                PhotoNumber = 0,
+                NumberOfCars = 2,
+                TwitterAccessToken = "twitter-token",
+                MastodonAccessToken = "mastodon-token",
+                ThreadsAccessToken = "threads-token",
+                BlueskySubmittedBy = "Submitted by rider.bsky.social"
+            };
+
+            FinalizedPhotoUploadMetadata metadata =
+                FinalizedPhotoUploadMetadata.FromContract(contract);
+
+            Assert.Equal(contract.PhotoId, metadata.PhotoId);
+            Assert.Equal(contract.NumberOfCars, metadata.NumberOfCars);
+            Assert.Equal("twitter-token", metadata.TwitterAccessToken);
+            Assert.Equal("mastodon-token", metadata.MastodonAccessToken);
+            Assert.Equal("threads-token", metadata.ThreadsAccessToken);
+            Assert.Equal(contract.BlueskySubmittedBy, metadata.BlueskySubmittedBy);
+            Assert.Null(metadata.DeviceId);
+            Assert.Null(metadata.ReportId);
+            Assert.Null(metadata.BlueskyHandle);
+            Assert.Null(metadata.BlueskyUserDid);
+        }
+
+        [Fact]
+        public void LimitsEndpointReturnsTheSharedContract()
+        {
+            UploadController controller = new UploadController(
+                                        null!,
+                                        null!,
+                                        null!,
+                                        null!,
+                                        null!,
+                                        null!,
+                                        null!,
+                                        null!,
+                                        null!,
+                                        null!);
+
+            OkObjectResult result = Assert.IsType<OkObjectResult>(controller.GetLimits());
+            UploadLimits limits = Assert.IsType<UploadLimits>(result.Value);
+
+            Assert.Equal(UploadController.MaxPhotosPerReport, limits.MaxPhotosPerReport);
+            Assert.Equal(8 * 1024 * 1024, limits.MaxPhotoBytes);
+            Assert.Equal(32 * 1024 * 1024, limits.MaxReportBytes);
+            Assert.Equal(47.495082, limits.SouthLatitude);
+            Assert.Equal(-122.436522, limits.WestLongitude);
+            Assert.Equal(47.735525, limits.NorthLatitude);
+            Assert.Equal(-122.235787, limits.EastLongitude);
+        }
+    }
+}

--- a/SeattleCarsInBikeLanes.Tests/UploadDeviceBlockingTests.cs
+++ b/SeattleCarsInBikeLanes.Tests/UploadDeviceBlockingTests.cs
@@ -1,0 +1,165 @@
+using System.Net;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using SeattleCarsInBikeLanes.Controllers;
+using SeattleCarsInBikeLanes.Core.Contracts;
+using SeattleCarsInBikeLanes.Providers;
+using Cosmos = Microsoft.Azure.Cosmos;
+
+namespace SeattleCarsInBikeLanes.Tests
+{
+    public partial class UploadFinalizationTests
+    {
+        private const string BlockedInstallation = "installation-1";
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task BlockedDeviceCannotPrepareOrAcceptANewReport(bool initial)
+        {
+            using Fixture fixture = new Fixture();
+            using CancellationTokenSource cancellation = new CancellationTokenSource();
+            fixture.Controller.Request.Headers[UploadController.DeviceIdHeader] = BlockedInstallation;
+            fixture.DeviceBlocked = true;
+
+            IActionResult result = initial
+                ? await fixture.Controller.UploadPhoto(
+                    [new FormFile(new MemoryStream([1]), 0, 1, "files", "photo.jpg")], cancellation.Token)
+                : await fixture.Controller.FinalizeUpload(fixture.Prepare(4), cancellation.Token);
+
+            var rejection = Assert.IsType<ObjectResult>(result);
+            Assert.Equal(StatusCodes.Status403Forbidden, rejection.StatusCode);
+            Assert.Equal("This device can't submit reports.", rejection.Value);
+            fixture.BlockedDevices.Verify(d => d.IsBlockedAsync(BlockedInstallation, cancellation.Token), Times.Once);
+            fixture.BlockedDevices.VerifyNoOtherCalls();
+            fixture.Blobs.VerifyNoOtherCalls();
+            fixture.Analysis.VerifyNoOtherCalls();
+            fixture.Safety.VerifyNoOtherCalls();
+            fixture.Authentication.VerifyNoOtherCalls();
+            Assert.Empty(fixture.InitialMetadata);
+            Assert.Null(fixture.Committed);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task WebsiteSubmissionsDoNotConsultTheBlocklist(bool initial)
+        {
+            using Fixture fixture = new Fixture();
+            fixture.DeviceBlocked = true;
+
+            var result = await Submit(fixture, initial);
+
+            Assert.IsType<OkObjectResult>(result);
+            fixture.BlockedDevices.VerifyNoOtherCalls();
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task SubmissionFailsOpenIfCosmosDeniesBlocklistAccess(bool initial)
+        {
+            using Fixture fixture = new Fixture();
+            fixture.Controller.Request.Headers[UploadController.DeviceIdHeader] = BlockedInstallation;
+            fixture.BlockedDevices.Setup(d => d.IsBlockedAsync(BlockedInstallation, It.IsAny<CancellationToken>()))
+                .ThrowsAsync(new Cosmos.CosmosException("Private infrastructure detail",
+                    HttpStatusCode.Forbidden, 0, "test", 0));
+
+            Assert.IsType<OkObjectResult>(await Submit(fixture, initial));
+            fixture.BlockedDevices.Verify(d => d.IsBlockedAsync(BlockedInstallation, It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task FinalizeChecksOnceForTheWholeReportAndPreservesDeviceNormalization()
+        {
+            using Fixture fixture = new Fixture();
+            using CancellationTokenSource cancellation = new CancellationTokenSource();
+            fixture.Controller.Request.Headers[UploadController.DeviceIdHeader] = "  Device-_1  ";
+            var request = fixture.Prepare(4);
+            foreach (var metadata in fixture.Metadata.Values)
+            {
+                metadata.DeviceId = "Device-_1";
+            }
+
+            Assert.IsType<OkObjectResult>(await fixture.Controller.FinalizeUpload(request, cancellation.Token));
+
+            fixture.BlockedDevices.Verify(d => d.IsBlockedAsync("Device-_1", cancellation.Token), Times.Once);
+            fixture.BlockedDevices.VerifyNoOtherCalls();
+            Assert.Equal("Device-_1", fixture.LastDeviceId);
+        }
+
+        [Fact]
+        public async Task InitialChecksOnceForTheWholeReport()
+        {
+            using Fixture fixture = new Fixture();
+            using CancellationTokenSource cancellation = new CancellationTokenSource();
+            fixture.Controller.Request.Headers[UploadController.DeviceIdHeader] = BlockedInstallation;
+            fixture.ConfigureInitial();
+            byte[] jpeg = CreateJpeg();
+            var photos = Enumerable.Range(0, 4).Select(i =>
+                (IFormFile)new FormFile(new MemoryStream(jpeg), 0, jpeg.Length, "files", $"photo-{i}.jpg")).ToList();
+
+            Assert.IsType<OkObjectResult>(await fixture.Controller.UploadPhoto(photos, cancellation.Token));
+
+            fixture.BlockedDevices.Verify(d => d.IsBlockedAsync(BlockedInstallation, cancellation.Token), Times.Once);
+            fixture.BlockedDevices.VerifyNoOtherCalls();
+            Assert.Equal(4, fixture.InitialMetadata.Count);
+        }
+
+        [Fact]
+        public async Task NewlyBlockedDeviceStillRecoversAcceptedReceipt()
+        {
+            using Fixture fixture = new Fixture();
+            fixture.Controller.Request.Headers[UploadController.DeviceIdHeader] = BlockedInstallation;
+            fixture.Existing = new SubmissionReport(fixture.Receipt, BlockedInstallation, []);
+            fixture.DeviceBlocked = true;
+
+            var status = Assert.IsType<OkObjectResult>(await fixture.Controller.ReportStatus(Id));
+            var retry = Assert.IsType<OkObjectResult>(await fixture.Controller.FinalizeUpload(
+                new FinalizeReportRequest([], new ReportAttribution())));
+
+            Assert.Equal(fixture.Receipt, status.Value);
+            Assert.Equal(fixture.Receipt, retry.Value);
+            fixture.BlockedDevices.VerifyNoOtherCalls();
+            Assert.Null(fixture.Committed);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task RequestCancellationDuringDeviceCheckPropagates(bool initial)
+        {
+            using Fixture fixture = new Fixture();
+            using CancellationTokenSource cancellation = new CancellationTokenSource();
+            fixture.Controller.Request.Headers[UploadController.DeviceIdHeader] = BlockedInstallation;
+            fixture.BlockedDevices.Setup(d => d.IsBlockedAsync(BlockedInstallation, cancellation.Token))
+                .Callback(cancellation.Cancel)
+                .ThrowsAsync(new OperationCanceledException(cancellation.Token));
+
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => initial
+                ? fixture.Controller.UploadPhoto(
+                    [new FormFile(new MemoryStream([1]), 0, 1, "files", "photo.jpg")], cancellation.Token)
+                : fixture.Controller.FinalizeUpload(fixture.Prepare(), cancellation.Token));
+            Assert.Null(fixture.Committed);
+            fixture.Blobs.VerifyNoOtherCalls();
+        }
+
+        private static async Task<IActionResult> Submit(Fixture fixture, bool initial)
+        {
+            if (initial)
+            {
+                fixture.ConfigureInitial();
+                byte[] jpeg = CreateJpeg();
+                return await fixture.Controller.UploadPhoto(
+                    [new FormFile(new MemoryStream(jpeg), 0, jpeg.Length, "files", "photo.jpg")]);
+            }
+            var request = fixture.Prepare(4);
+            foreach (var metadata in fixture.Metadata.Values)
+            {
+                metadata.DeviceId = fixture.Controller.Request.Headers[UploadController.DeviceIdHeader].FirstOrDefault();
+            }
+            return await fixture.Controller.FinalizeUpload(request);
+        }
+    }
+}

--- a/SeattleCarsInBikeLanes.Tests/UploadFinalizationTests.cs
+++ b/SeattleCarsInBikeLanes.Tests/UploadFinalizationTests.cs
@@ -1,0 +1,1248 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Globalization;
+using System.Security.Claims;
+using System.Text;
+using System.Text.Json;
+using System.Xml.Linq;
+using Azure;
+using Azure.AI.ContentSafety;
+using Azure.AI.Vision.ImageAnalysis;
+using Azure.Core.Pipeline;
+using Azure.Maps.Search;
+using Azure.Security.KeyVault.Secrets;
+using Azure.Storage.Blobs;
+using Azure.Storage.Blobs.Models;
+using ImageMagick;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.WebUtilities;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Moq.Protected;
+using SeattleCarsInBikeLanes.Controllers;
+using SeattleCarsInBikeLanes.Core.Contracts;
+using SeattleCarsInBikeLanes.Database;
+using SeattleCarsInBikeLanes.Models;
+using SeattleCarsInBikeLanes.Providers;
+using SeattleCarsInBikeLanes.Storage.Models;
+using Cosmos = Microsoft.Azure.Cosmos;
+
+namespace SeattleCarsInBikeLanes.Tests
+{
+    public partial class UploadFinalizationTests
+    {
+        private const string Id = "0123456789abcdef0123456789abcdef";
+        private const string Did = "did:plc:verified";
+
+        [Theory]
+        [InlineData(1)]
+        [InlineData(2)]
+        [InlineData(3)]
+        [InlineData(4)]
+        public async Task AnonymousUsesOrderedCanonicalPhotosAndStripsUntrustedMetadata(int count)
+        {
+            using Fixture fixture = new Fixture();
+            var request = fixture.Prepare(count);
+            foreach (var photo in request.Photos)
+            {
+                photo.Attribute = true;
+                photo.TwitterAccessToken = photo.MastodonAccessToken = photo.ThreadsAccessToken = "secret";
+                photo.TwitterUsername = photo.MastodonUsername = photo.ThreadsUsername = "forged";
+                photo.MastodonEndpoint = "https://forged.test";
+                photo.TwitterSubmittedBy = photo.MastodonSubmittedBy = photo.BlueskySubmittedBy =
+                    photo.ThreadsSubmittedBy = "Submitted by forged";
+                photo.Tags = [new ImageTag() { Name = "forged", Confidence = 1 }];
+            }
+            fixture.Controller.Request.Headers.Authorization = "Bearer invalid";
+            fixture.Cookie = fixture.Bearer = Fixture.Auth(Did, "ambient.test");
+
+            var result = Assert.IsType<OkObjectResult>(await fixture.Controller.FinalizeUpload(request));
+
+            Assert.Equal(fixture.Receipt, Assert.IsType<SubmissionReceipt>(result.Value));
+            Assert.NotNull(fixture.Committed);
+            Assert.Equal(count, fixture.Committed.Count);
+            for (int i = 0; i < count; i++)
+            {
+                var source = fixture.Committed[i];
+                var metadata = source.Metadata;
+                Assert.Equal($"initialupload/photo-{i}.jpeg", source.BlobName);
+                Assert.Equal("\"photo-version\"", source.ETag);
+                Assert.Equal(23, source.Length);
+                Assert.Equal($"{Id}-{i}", metadata.PhotoId);
+                Assert.Equal(Id, metadata.SubmissionId);
+                Assert.Equal(Id, metadata.ReportId);
+                Assert.Equal(i, metadata.PhotoNumber);
+                Assert.Equal("car", Assert.Single(metadata.Tags).Name);
+                Assert.False(metadata.Attribute);
+                Assert.Null(metadata.BlueskyHandle);
+                Assert.Null(metadata.BlueskyUserDid);
+                Assert.Null(metadata.MastodonEndpoint);
+                Assert.Null(metadata.MastodonFullUsername);
+                Assert.Null(metadata.TwitterUsername);
+                Assert.Null(metadata.ThreadsUsername);
+                Assert.Null(metadata.TwitterAccessToken);
+                Assert.Null(metadata.MastodonAccessToken);
+                Assert.Null(metadata.ThreadsAccessToken);
+                Assert.Null(metadata.BlueskyAdminDid);
+                Assert.Null(metadata.BlueskyAccessJwt);
+                Assert.Null(metadata.TwitterLink);
+                Assert.Equal("Submission", metadata.BlueskySubmittedBy);
+                Assert.Equal("Submission", metadata.MastodonSubmittedBy);
+            }
+            fixture.Authentication.Verify(a => a.AuthenticateAsync(It.IsAny<HttpContext>(), It.IsAny<string>()), Times.Never);
+            fixture.Provider.VerifyNoOtherCalls();
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task BlueskyUsesOnlyTheSelectedSchemeAndVerifiedHandle(bool bearer)
+        {
+            using Fixture fixture = new Fixture();
+            var request = fixture.Prepare() with
+            {
+                Attribution = new ReportAttribution(BlueskyDid: Did)
+            };
+            fixture.Cookie = Fixture.Auth(bearer ? "did:plc:other" : Did, "cookie.test");
+            fixture.Bearer = Fixture.Auth(Did, "native.test");
+            if (bearer)
+            {
+                fixture.Controller.Request.Headers.Authorization = "Bearer native";
+            }
+
+            Assert.IsType<OkObjectResult>(await fixture.Controller.FinalizeUpload(request));
+
+            var photo = Assert.Single(fixture.Committed!).Metadata;
+            Assert.Equal(Did, photo.BlueskyUserDid);
+            Assert.Equal(bearer ? "native.test" : "cookie.test", photo.BlueskyHandle);
+            Assert.Equal($"Submitted by @{photo.BlueskyHandle}", photo.BlueskySubmittedBy);
+            fixture.Authentication.Verify(a => a.AuthenticateAsync(It.IsAny<HttpContext>(),
+                bearer ? BlueskyAuthDefaults.BearerScheme : BlueskyAuthDefaults.CookieScheme), Times.Once);
+            fixture.Authentication.VerifyNoOtherCalls();
+        }
+
+        [Theory]
+        [InlineData("Bearer expired")]
+        [InlineData("bearer expired")]
+        [InlineData("Bearer")]
+        [InlineData("Bearer\texpired")]
+        public async Task RejectedExplicitBearerNeverFallsBackToValidCookie(string header)
+        {
+            using Fixture fixture = new Fixture();
+            fixture.Cookie = Fixture.Auth(Did, "cookie.test");
+            fixture.Bearer = AuthenticateResult.Fail("expired");
+            fixture.Controller.Request.Headers.Authorization = header;
+
+            var result = await fixture.Controller.FinalizeUpload(fixture.Prepare() with
+            {
+                Attribution = new ReportAttribution(BlueskyDid: Did)
+            });
+
+            AssertError(result, 401, UploadErrors.CredentialRejected);
+            fixture.Authentication.Verify(a => a.AuthenticateAsync(It.IsAny<HttpContext>(), BlueskyAuthDefaults.CookieScheme), Times.Never);
+            Assert.Null(fixture.Committed);
+        }
+
+        [Fact]
+        public async Task BlueskyIdentityMismatchDoesNotSilentlySwitchAccounts()
+        {
+            using Fixture fixture = new Fixture();
+            fixture.Cookie = Fixture.Auth("did:plc:other", "other.test");
+            var result = await fixture.Controller.FinalizeUpload(fixture.Prepare() with
+            {
+                Attribution = new ReportAttribution(BlueskyDid: Did)
+            });
+            AssertError(result, 409, UploadErrors.IdentityMismatch);
+            Assert.Null(fixture.Committed);
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task MastodonAndCombinedAttributionUseCanonicalVerifiedIdentity(bool combined)
+        {
+            using Fixture fixture = new Fixture();
+            fixture.Cookie = Fixture.Auth(Did, "verified.test");
+            fixture.MastodonResponse(HttpStatusCode.OK, """{"id":"42","username":"actual"}""");
+            var request = fixture.Prepare(2) with
+            {
+                Attribution = new ReportAttribution(combined ? Did : null, "https://MASTODON.example:443/", "42")
+            };
+            foreach (var photo in request.Photos)
+            {
+                photo.MastodonAccessToken = "retained-token";
+            }
+
+            Assert.IsType<OkObjectResult>(await fixture.Controller.FinalizeUpload(request));
+
+            Assert.Equal("https://mastodon.example", fixture.CommittedAttribution!.MastodonServer);
+            foreach (var photo in fixture.Committed!)
+            {
+                Assert.Equal("@actual@mastodon.example", photo.Metadata.MastodonFullUsername);
+                Assert.Equal("actual", photo.Metadata.MastodonUsername);
+                Assert.Null(photo.Metadata.MastodonAccessToken);
+                Assert.Equal(combined ? Did : null, photo.Metadata.BlueskyUserDid);
+            }
+        }
+
+        [Theory]
+        [InlineData(401, 401, UploadErrors.CredentialRejected)]
+        [InlineData(403, 401, UploadErrors.CredentialRejected)]
+        [InlineData(429, 503, UploadErrors.ProviderUnavailable)]
+        [InlineData(503, 503, UploadErrors.ProviderUnavailable)]
+        [InlineData(200, 409, UploadErrors.IdentityMismatch)]
+        public async Task MastodonFailuresNeverFallBackToAnonymous(int providerStatus, int status, string code)
+        {
+            using Fixture fixture = new Fixture();
+            fixture.MastodonResponse((HttpStatusCode)providerStatus, """{"id":"other","username":"someone"}""");
+            var request = fixture.Prepare() with
+            {
+                Attribution = new ReportAttribution(null, "https://mastodon.example", "42")
+            };
+            request.Photos[0].MastodonAccessToken = "retained-token";
+
+            AssertError(await fixture.Controller.FinalizeUpload(request), status, code);
+            Assert.Null(fixture.Committed);
+        }
+
+        [Fact]
+        public async Task ProviderTimeoutIsRetryableButRequestCancellationPropagates()
+        {
+            using Fixture fixture = new Fixture();
+            fixture.Provider.Protected().Setup<Task<HttpResponseMessage>>("SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
+                .ThrowsAsync(new TaskCanceledException());
+            var request = fixture.Prepare() with
+            {
+                Attribution = new ReportAttribution(null, "https://mastodon.example", "42")
+            };
+            request.Photos[0].MastodonAccessToken = "retained-token";
+            AssertError(await fixture.Controller.FinalizeUpload(request), 503, UploadErrors.ProviderUnavailable);
+
+            using CancellationTokenSource cancellation = new CancellationTokenSource();
+            cancellation.Cancel();
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+                fixture.Controller.FinalizeUpload(request, cancellation.Token));
+            Assert.Null(fixture.Committed);
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task AcceptedReceiptWinsBeforeCredentialsAndInvalidFreshPreparation(bool retired)
+        {
+            using Fixture fixture = new Fixture();
+            var acceptedReceipt = fixture.Receipt with
+            {
+                Attribution = new ReportAttribution(Did)
+            };
+            fixture.Existing = new SubmissionReport(acceptedReceipt, null, [], Retired: retired);
+            fixture.Controller.Request.Headers.Authorization = "Bearer expired";
+            var result = Assert.IsType<OkObjectResult>(await fixture.Controller.FinalizeUpload(
+                new FinalizeReportRequest([], new ReportAttribution())));
+            Assert.Equal(acceptedReceipt, result.Value);
+            fixture.Authentication.VerifyNoOtherCalls();
+            fixture.Blobs.VerifyNoOtherCalls();
+            Assert.Null(fixture.Committed);
+        }
+
+        [Fact]
+        public async Task ReceiptLookupIsMinimalAndAllowsAnonymousWebsiteContext()
+        {
+            using Fixture fixture = new Fixture();
+            fixture.Existing = new SubmissionReport(fixture.Receipt, null, []);
+            var result = Assert.IsType<OkObjectResult>(await fixture.Controller.ReportStatus(Id));
+            Assert.Same(fixture.Receipt, result.Value);
+            Assert.Null(fixture.LastDeviceId);
+            fixture.Authentication.VerifyNoOtherCalls();
+        }
+
+        [Fact]
+        public async Task AbsentReceiptIs404ButUnknownStorageFailureIs503()
+        {
+            using Fixture fixture = new Fixture();
+            Assert.IsType<NotFoundResult>(await fixture.Controller.ReportStatus(Id));
+            fixture.Store.Setup(s => s.GetAsync(Id, It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+                .ThrowsAsync(new RequestFailedException(503, "sensitive provider message"));
+            AssertError(await fixture.Controller.ReportStatus(Id), 503, UploadErrors.ProviderUnavailable);
+            AssertError(await fixture.Controller.FinalizeUpload(fixture.Prepare()), 503, UploadErrors.ProviderUnavailable);
+        }
+
+        [Fact]
+        public async Task AStorageContainer404IsNotAnExpiredPreparation()
+        {
+            using Fixture fixture = new Fixture();
+            var request = fixture.Prepare();
+            fixture.Blobs.Setup(b => b.GetBlobClient("initialupload/photo-0.json"))
+                .Throws(new RequestFailedException(404, "private detail", "ContainerNotFound", null));
+            AssertError(await fixture.Controller.FinalizeUpload(request), 503, UploadErrors.ProviderUnavailable);
+        }
+
+        [Fact]
+        public async Task CommitStorageFailureDoesNotPretendToBeMissingOrAccepted()
+        {
+            using Fixture fixture = new Fixture();
+            fixture.Store.Setup(s => s.CommitAsync(Id, It.IsAny<string?>(), It.IsAny<ReportAttribution>(),
+                    It.IsAny<IReadOnlyList<PreparedSubmissionPhoto>>(), It.IsAny<CancellationToken>()))
+                .ThrowsAsync(new RequestFailedException(404, "private detail", "ContainerNotFound", null));
+            AssertError(await fixture.Controller.FinalizeUpload(fixture.Prepare()), 503, UploadErrors.ProviderUnavailable);
+        }
+
+        [Fact]
+        public async Task PreparationExpiringDuringCommitReturnsTypedGone()
+        {
+            using Fixture fixture = new Fixture();
+            fixture.Store.Setup(s => s.CommitAsync(Id, It.IsAny<string?>(), It.IsAny<ReportAttribution>(),
+                    It.IsAny<IReadOnlyList<PreparedSubmissionPhoto>>(), It.IsAny<CancellationToken>()))
+                .ThrowsAsync(new PreparationExpiredException());
+            AssertError(await fixture.Controller.FinalizeUpload(fixture.Prepare()), 410, UploadErrors.PreparationExpired);
+        }
+
+        [Fact]
+        public async Task ReceiptContextMismatchIsForbiddenBeforeAuthentication()
+        {
+            using Fixture fixture = new Fixture();
+            fixture.Store.Setup(s => s.GetAsync(Id, It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+                .ThrowsAsync(new UnauthorizedAccessException());
+            Assert.Equal(403, Assert.IsType<StatusCodeResult>(await fixture.Controller.ReportStatus(Id)).StatusCode);
+            Assert.Equal(403, Assert.IsType<StatusCodeResult>(
+                await fixture.Controller.FinalizeUpload(fixture.Prepare())).StatusCode);
+            fixture.Authentication.VerifyNoOtherCalls();
+        }
+
+        [Theory]
+        [InlineData("count")]
+        [InlineData("tooMany")]
+        [InlineData("duplicate")]
+        [InlineData("order")]
+        [InlineData("submission")]
+        [InlineData("path")]
+        [InlineData("date")]
+        [InlineData("latitude")]
+        [InlineData("longitude")]
+        [InlineData("outside")]
+        [InlineData("cars")]
+        [InlineData("fields")]
+        [InlineData("flags")]
+        [InlineData("length")]
+        public async Task InvalidPhotoSetsAreRejectedBeforeCommit(string invalid)
+        {
+            using Fixture fixture = new Fixture();
+            var request = fixture.Prepare(2);
+            switch (invalid)
+            {
+                case "count":
+                    request.Photos.Clear();
+                    break;
+                case "tooMany":
+                    request.Photos.AddRange([request.Photos[0], request.Photos[0], request.Photos[0]]);
+                    break;
+                case "duplicate":
+                    request.Photos[1].PhotoId = request.Photos[0].PhotoId;
+                    break;
+                case "order":
+                    request.Photos[1].PhotoNumber = 0;
+                    break;
+                case "submission":
+                    request.Photos[1].SubmissionId = "another";
+                    break;
+                case "path":
+                    request.Photos[0].PhotoId = "../other";
+                    break;
+                case "date":
+                    request.Photos[0].PhotoDateTime = null;
+                    break;
+                case "latitude":
+                    request.Photos[0].PhotoLatitude = "NaN";
+                    break;
+                case "longitude":
+                    request.Photos[0].PhotoLongitude = "-Infinity";
+                    break;
+                case "outside":
+                    request.Photos[0].PhotoLatitude = "48";
+                    break;
+                case "cars":
+                    request.Photos[0].NumberOfCars = 0;
+                    break;
+                case "fields":
+                    request.Photos[1].NumberOfCars = 3;
+                    break;
+                case "flags":
+                    request.Photos[1].UserSpecifiedLocation = true;
+                    break;
+                case "length":
+                    request.Photos[0].PhotoCrossStreet = new string('x', 1025);
+                    break;
+            }
+            Assert.IsType<BadRequestObjectResult>(await fixture.Controller.FinalizeUpload(request));
+            Assert.Null(fixture.Committed);
+        }
+
+        [Theory]
+        [InlineData("report")]
+        [InlineData("device")]
+        [InlineData("set")]
+        [InlineData("photo")]
+        [InlineData("order")]
+        public async Task PreparationMustMatchStoredReportContextAndSet(string mismatch)
+        {
+            using Fixture fixture = new Fixture();
+            var request = fixture.Prepare();
+            var stored = fixture.Metadata["photo-0"];
+            switch (mismatch)
+            {
+                case "report":
+                    stored.ReportId = new string('a', 32);
+                    break;
+                case "device":
+                    stored.DeviceId = "different-device";
+                    break;
+                case "set":
+                    stored.SubmissionId = "other";
+                    break;
+                case "photo":
+                    stored.PhotoId = "other";
+                    break;
+                case "order":
+                    stored.PhotoNumber = 3;
+                    break;
+            }
+            Assert.IsType<BadRequestObjectResult>(await fixture.Controller.FinalizeUpload(request));
+            Assert.Null(fixture.Committed);
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(8 * 1024 * 1024 + 1)]
+        public async Task SourceSizeLimitIsCheckedBeforeStorage(long length)
+        {
+            using Fixture fixture = new Fixture();
+            var request = fixture.Prepare();
+            fixture.SourceLength = length;
+            Assert.IsType<BadRequestObjectResult>(await fixture.Controller.FinalizeUpload(request));
+            Assert.Null(fixture.Committed);
+        }
+
+        [Theory]
+        [InlineData(404, 410, UploadErrors.PreparationExpired)]
+        [InlineData(412, 410, UploadErrors.PreparationExpired)]
+        [InlineData(503, 503, UploadErrors.ProviderUnavailable)]
+        public async Task MissingOrChangedPreparationDiffersFromStorageOutage(int storageStatus, int status, string code)
+        {
+            using Fixture fixture = new Fixture();
+            var request = fixture.Prepare();
+            fixture.Blobs.Setup(b => b.GetBlobClient("initialupload/photo-0.json"))
+                .Throws(new RequestFailedException(storageStatus, "private storage detail"));
+            AssertError(await fixture.Controller.FinalizeUpload(request), status, code);
+            Assert.Null(fixture.Committed);
+        }
+
+        [Fact]
+        public async Task DeviceHeaderBindsCanonicalMetadataAndAcceptedContext()
+        {
+            using Fixture fixture = new Fixture();
+            fixture.Controller.Request.Headers[UploadController.DeviceIdHeader] = "installation-1";
+            var request = fixture.Prepare();
+            fixture.Metadata["photo-0"].DeviceId = "installation-1";
+            Assert.IsType<OkObjectResult>(await fixture.Controller.FinalizeUpload(request));
+            Assert.Equal("installation-1", fixture.LastDeviceId);
+            Assert.Equal("installation-1", Assert.Single(fixture.Committed!).Metadata.DeviceId);
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData("invalid/report")]
+        [InlineData("not-hex")]
+        [InlineData("0123456789ABCDEF0123456789ABCDEF")]
+        public async Task InvalidReportIdIsRejectedBeforeStorage(string id)
+        {
+            using Fixture fixture = new Fixture();
+            fixture.Controller.Request.Headers[UploadController.ReportIdHeader] = id;
+            Assert.IsType<BadRequestObjectResult>(await fixture.Controller.FinalizeUpload(fixture.Prepare()));
+            fixture.Store.Verify(s => s.GetAsync(It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()), Times.Never);
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData("bad/device")]
+        [InlineData("two,devices")]
+        public async Task InvalidDeviceContextCannotBeUsedToClaimAReport(string device)
+        {
+            using Fixture fixture = new Fixture();
+            fixture.Controller.Request.Headers[UploadController.DeviceIdHeader] = device;
+            Assert.IsType<BadRequestObjectResult>(await fixture.Controller.FinalizeUpload(fixture.Prepare()));
+            fixture.Store.Verify(s => s.GetAsync(It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()), Times.Never);
+        }
+
+        [Fact]
+        public async Task SlackFailureCannotUndoAcceptance()
+        {
+            using Fixture fixture = new Fixture();
+            fixture.SlackHandler.Protected().Setup<Task<HttpResponseMessage>>("SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>()).ThrowsAsync(new HttpRequestException());
+            Assert.IsType<OkObjectResult>(await fixture.Controller.FinalizeUpload(fixture.Prepare()));
+            Assert.NotNull(fixture.Committed);
+        }
+
+        [Fact]
+        public async Task InitialRejectsImageValidationAsReadable400InsteadOfFaultedTask500()
+        {
+            using Fixture fixture = new Fixture();
+            byte[] bytes = Encoding.UTF8.GetBytes("not an image");
+            List<IFormFile> files = new List<IFormFile>() { new FormFile(new MemoryStream(bytes), 0, bytes.Length, "files", "bad.jpg") };
+            var result = Assert.IsType<BadRequestObjectResult>(await fixture.Controller.UploadPhoto(files));
+            Assert.Contains("Photo 1", Assert.IsType<string>(result.Value));
+        }
+
+        [Fact]
+        public async Task InitialChecksDeclaredByteLimitsBeforeReading()
+        {
+            using Fixture fixture = new Fixture();
+            Mock<IFormFile> file = new Mock<IFormFile>(MockBehavior.Strict);
+            file.SetupGet(f => f.Length).Returns(30_000_001);
+            Assert.IsType<BadRequestObjectResult>(await fixture.Controller.UploadPhoto([file.Object]));
+            file.Verify(f => f.OpenReadStream(), Times.Never);
+        }
+
+        [Fact]
+        public async Task InitialAcceptsOriginalsLargerThanThePreparedJpegLimit()
+        {
+            using Fixture fixture = new Fixture();
+            fixture.ConfigureInitial();
+            using MagickImage original = new MagickImage(MagickColors.White, 2048, 1600);
+            byte[] bitmap = original.ToByteArray(MagickFormat.Bmp);
+            Assert.True(bitmap.Length > 8 * 1024 * 1024);
+
+            var result = Assert.IsType<OkObjectResult>(await fixture.Controller.UploadPhoto(
+                [new FormFile(new MemoryStream(bitmap), 0, bitmap.Length, "files", "large.bmp")]));
+
+            Assert.Single(Assert.IsType<InitialPhotoUpload[]>(result.Value));
+            Assert.Single(fixture.InitialMetadata);
+        }
+
+        [Fact]
+        public async Task InitialBindsStableReportAndDeviceToFreshPreparationAndPreservesAnalysis()
+        {
+            using Fixture fixture = new Fixture();
+            fixture.ConfigureInitial();
+            fixture.Controller.Request.Headers[UploadController.DeviceIdHeader] = "installation-1";
+            byte[] jpeg = CreateJpeg();
+            var result = Assert.IsType<OkObjectResult>(await fixture.Controller.UploadPhoto(
+                [new FormFile(new MemoryStream(jpeg), 0, jpeg.Length, "files", "photo.jpg")]));
+            InitialPhotoUpload response = Assert.Single(Assert.IsType<InitialPhotoUpload[]>(result.Value));
+            InitialPhotoUploadMetadata stored = Assert.Single(fixture.InitialMetadata);
+            Assert.Equal(Id, stored.ReportId);
+            Assert.Equal("installation-1", stored.DeviceId);
+            Assert.NotEqual(Id, stored.SubmissionId);
+            Assert.Equal(stored.SubmissionId, response.SubmissionId);
+            Assert.Equal(stored.PhotoId, response.PhotoId);
+            Assert.Equal(0, response.PhotoNumber);
+            Assert.Equal(new DateTime(2026, 9, 7, 10, 0, 0), response.PhotoDateTime);
+            Assert.Equal("car", Assert.Single(response.Tags).Name);
+            Assert.StartsWith("https://account.blob.core.windows.net/uploads/initialupload/", response.Uri);
+            Assert.Contains("sig=", response.Uri);
+        }
+
+        [Fact]
+        public async Task InitialProviderFailureIs503AndDoesNotExposeItsException()
+        {
+            using Fixture fixture = new Fixture();
+            fixture.ConfigureInitial();
+            fixture.Analysis.Setup(a => a.AnalyzeAsync(It.IsAny<BinaryData>(), VisualFeatures.Tags,
+                    It.IsAny<ImageAnalysisOptions>(), It.IsAny<CancellationToken>()))
+                .ThrowsAsync(new RequestFailedException(503, "sensitive private upstream detail"));
+            byte[] jpeg = CreateJpeg();
+            AssertError(await fixture.Controller.UploadPhoto(
+                [new FormFile(new MemoryStream(jpeg), 0, jpeg.Length, "files", "photo.jpg")]),
+                503, UploadErrors.ProviderUnavailable);
+        }
+
+        [Fact]
+        public async Task InitialCollectsAsyncValidationErrorsWithoutLeakingFailedTasks()
+        {
+            using Fixture fixture = new Fixture();
+            fixture.ConfigureInitial();
+            fixture.Safety.Setup(s => s.AnalyzeImageAsync(It.IsAny<BinaryData>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(Response.FromValue(ContentSafetyModelFactory.AnalyzeImageResult(
+                    [ContentSafetyModelFactory.ImageCategoriesAnalysis(ImageCategory.Hate, 6)]), Mock.Of<Response>()));
+            byte[] invalid = Encoding.UTF8.GetBytes("not an image");
+            byte[] jpeg = CreateJpeg();
+            var result = Assert.IsType<BadRequestObjectResult>(await fixture.Controller.UploadPhoto(
+            [
+                new FormFile(new MemoryStream(invalid), 0, invalid.Length, "files", "invalid.jpg"),
+                new FormFile(new MemoryStream(jpeg), 0, jpeg.Length, "files", "photo.jpg")
+            ]));
+            string message = Assert.IsType<string>(result.Value);
+            Assert.Contains("Photo 1", message);
+            Assert.Contains("Photo 2: Photo does not pass content check.", message);
+            Assert.Empty(fixture.InitialMetadata);
+        }
+
+        [Fact]
+        public async Task InitialPreservesExifSeattleBoundsValidation()
+        {
+            using Fixture fixture = new Fixture();
+            using MagickImage image = new MagickImage(MagickColors.White, 16, 16);
+            ExifProfile profile = new ExifProfile();
+            profile.SetValue(ExifTag.GPSLatitude, [new Rational(50), new Rational(0), new Rational(0)]);
+            profile.SetValue(ExifTag.GPSLatitudeRef, "N");
+            profile.SetValue(ExifTag.GPSLongitude, [new Rational(122), new Rational(0), new Rational(0)]);
+            profile.SetValue(ExifTag.GPSLongitudeRef, "W");
+            image.SetProfile(profile);
+            byte[] jpeg = image.ToByteArray(MagickFormat.Jpeg);
+            var result = Assert.IsType<BadRequestObjectResult>(await fixture.Controller.UploadPhoto(
+                [new FormFile(new MemoryStream(jpeg), 0, jpeg.Length, "files", "photo.jpg")]));
+            AssertPhotoLocationLink(result.Value, 50, -122);
+            fixture.Analysis.VerifyNoOtherCalls();
+            fixture.Safety.VerifyNoOtherCalls();
+        }
+
+        [Theory]
+        [InlineData("CreateDate", "2026-09-07T10:00:00-07:00", false)]
+        [InlineData("DateTimeDigitized", "2026-09-07T10:00:00+14:00", true)]
+        [InlineData("DateTimeOriginal", "2026-09-07T10:00:00Z", false)]
+        public async Task InitialReadsXmpOnlyDatesAndSeattleGpsWithoutConvertingWallClock(
+            string field, string date, bool elements)
+        {
+            using Fixture fixture = new Fixture();
+            fixture.ConfigureInitial();
+            string xmp = Xmp(elements, (field, date),
+                ("GPSLatitude", "47,36.3726N"), ("GPSLongitude", "122,19.9242W"));
+
+            InitialPhotoUpload photo = await UploadMetadataPhoto(fixture, MetadataJpeg(xmp));
+
+            Assert.Equal(new DateTime(2026, 9, 7, 10, 0, 0), photo.PhotoDateTime);
+            Assert.Equal(DateTimeKind.Unspecified, photo.PhotoDateTime!.Value.Kind);
+            AssertCoordinate(47.60621, photo.PhotoLatitude);
+            AssertCoordinate(-122.33207, photo.PhotoLongitude);
+            Assert.Equal("Pike St", photo.PhotoCrossStreet);
+        }
+
+        [Theory]
+        [InlineData("47,36.3726N", "122,19.9242W")]
+        [InlineData("47,36,22.356N", "122,19,55.452W")]
+        [InlineData("47 deg 36' 22.356\" N", "122 deg 19' 55.452\" W")]
+        [InlineData("47° 36′ 22.356″ N", "122° 19′ 55.452″ W")]
+        [InlineData("47 36 22356/1000 N", "122 19 55452/1000 W")]
+        [InlineData("47.60621", "-122.33207")]
+        public async Task InitialReadsFractionalXmpCoordinateFormats(string latitude, string longitude)
+        {
+            using Fixture fixture = new Fixture();
+            fixture.ConfigureInitial();
+            InitialPhotoUpload photo = await UploadMetadataPhoto(fixture,
+                MetadataJpeg(Xmp(false, ("GPSLatitude", latitude), ("GPSLongitude", longitude))));
+            AssertCoordinate(47.60621, photo.PhotoLatitude);
+            AssertCoordinate(-122.33207, photo.PhotoLongitude);
+        }
+
+        [Theory]
+        [InlineData("50,0N", "122,0W", 50, -122)]
+        [InlineData("47,36.3726S", "122,19.9242W", -47.60621, -122.33207)]
+        [InlineData("47,36.3726N", "122,19.9242E", 47.60621, 122.33207)]
+        public async Task InitialRejectsOutsideSeattleXmpBeforeCallingAi(
+            string latitude, string longitude, double expectedLatitude, double expectedLongitude)
+        {
+            using Fixture fixture = new Fixture();
+            byte[] jpeg = MetadataJpeg(Xmp(false, ("GPSLatitude", latitude), ("GPSLongitude", longitude)));
+            var result = Assert.IsType<BadRequestObjectResult>(await fixture.Controller.UploadPhoto(
+                [new FormFile(new MemoryStream(jpeg), 0, jpeg.Length, "files", "xmp.jpg")]));
+            AssertPhotoLocationLink(result.Value, expectedLatitude, expectedLongitude);
+            fixture.Analysis.VerifyNoOtherCalls();
+            fixture.Safety.VerifyNoOtherCalls();
+            fixture.MapsHandler.VerifyNoOtherCalls();
+        }
+
+        [Theory]
+        [InlineData("en-US")]
+        [InlineData("fr-FR")]
+        public async Task OutsideSeattleMapLinkPreservesCoordinatesIndependentOfServerCulture(string culture)
+        {
+            CultureInfo originalCulture = CultureInfo.CurrentCulture;
+            try
+            {
+                CultureInfo.CurrentCulture = CultureInfo.GetCultureInfo(culture);
+                using Fixture fixture = new Fixture();
+                byte[] jpeg = MetadataJpeg(Xmp(false,
+                    ("GPSLatitude", "50.123456789"), ("GPSLongitude", "-122.3456789")));
+                var result = Assert.IsType<BadRequestObjectResult>(await fixture.Controller.UploadPhoto(
+                    [new FormFile(new MemoryStream(jpeg), 0, jpeg.Length, "files", "location.jpg")]));
+
+                AssertPhotoLocationLink(result.Value, 50.123456789, -122.3456789);
+                fixture.Analysis.VerifyNoOtherCalls();
+                fixture.Safety.VerifyNoOtherCalls();
+            }
+            finally
+            {
+                CultureInfo.CurrentCulture = originalCulture;
+            }
+        }
+
+        private static void AssertPhotoLocationLink(object? value, double latitude, double longitude)
+        {
+            string message = Assert.IsType<string>(value);
+            Assert.StartsWith("Photo 1: Photo not taken in Seattle.", message);
+            XElement? link = XElement.Parse($"<error>{message}</error>").Element("a");
+            Assert.NotNull(link);
+            Uri map = new Uri((string)link.Attribute("href")!);
+            Assert.Equal("https", map.Scheme);
+            Assert.Equal("bing.com", map.Host);
+            Assert.Equal("/maps", map.AbsolutePath);
+            var query = QueryHelpers.ParseQuery(map.Query);
+            string[] coordinates = query["cp"].ToString().Split('~');
+            Assert.Equal(2, coordinates.Length);
+            Assert.Equal(latitude, double.Parse(coordinates[0], CultureInfo.InvariantCulture), 8);
+            Assert.Equal(longitude, double.Parse(coordinates[1], CultureInfo.InvariantCulture), 8);
+            Assert.Equal("13", query["lvl"].ToString());
+            Assert.Equal($"point.{coordinates[0]}_{coordinates[1]}_Photo location___", query["sp"].ToString());
+            Assert.Equal($"{latitude.ToString("0.#####", CultureInfo.InvariantCulture)}, " +
+                longitude.ToString("0.#####", CultureInfo.InvariantCulture), link.Value);
+            Assert.Equal("_blank", (string?)link.Attribute("target"));
+            Assert.Equal("noopener noreferrer", (string?)link.Attribute("rel"));
+        }
+
+        [Fact]
+        public async Task InitialPrefersValidExifOverConflictingXmp()
+        {
+            using Fixture fixture = new Fixture();
+            fixture.ConfigureInitial();
+            ExifProfile exif = SeattleExif();
+            exif.SetValue(ExifTag.DateTimeDigitized, "2025:01:02 03:04:05");
+            InitialPhotoUpload photo = await UploadMetadataPhoto(fixture, MetadataJpeg(Xmp(false,
+                ("CreateDate", "2026-09-07T10:00:00Z"), ("GPSLatitude", "50,0N"), ("GPSLongitude", "122,0E")), exif));
+            Assert.Equal(new DateTime(2025, 1, 2, 3, 4, 5), photo.PhotoDateTime);
+            AssertCoordinate(47.6, photo.PhotoLatitude);
+            AssertCoordinate(-(122 + 20.0 / 60), photo.PhotoLongitude);
+        }
+
+        [Theory]
+        [InlineData("date")]
+        [InlineData("location")]
+        [InlineData("latitude")]
+        [InlineData("invalid")]
+        public async Task InitialFillsOnlyMissingOrInvalidExifFieldsFromXmp(string exifFields)
+        {
+            using Fixture fixture = new Fixture();
+            fixture.ConfigureInitial();
+            ExifProfile exif = exifFields == "location" ? SeattleExif() : new ExifProfile();
+            if (exifFields == "date")
+            {
+                exif.SetValue(ExifTag.DateTimeDigitized, "2025:01:02 03:04:05");
+            }
+
+            if (exifFields is "latitude" or "invalid")
+            {
+                exif.SetValue(ExifTag.GPSLatitude,
+                                                    [new Rational(47), new Rational(exifFields == "invalid" ? 60 : 36), new Rational(0)]);
+                exif.SetValue(ExifTag.GPSLatitudeRef, "N");
+            }
+            if (exifFields == "invalid")
+            {
+                exif.SetValue(ExifTag.DateTimeDigitized, "not-a-date");
+            }
+
+            InitialPhotoUpload photo = await UploadMetadataPhoto(fixture, MetadataJpeg(Xmp(false,
+                ("CreateDate", "2026-09-07T10:00:00.125-07:00"), ("GPSLatitude", "47,36.3726N"),
+                ("GPSLongitude", "122,19.9242W")), exif));
+            Assert.Equal(exifFields == "date" ? new DateTime(2025, 1, 2, 3, 4, 5) :
+                new DateTime(2026, 9, 7, 10, 0, 0, 125), photo.PhotoDateTime);
+            AssertCoordinate(exifFields is "location" or "latitude" ? 47.6 : 47.60621, photo.PhotoLatitude);
+            AssertCoordinate(exifFields == "location" ? -(122 + 20.0 / 60) : -122.33207, photo.PhotoLongitude);
+            if (exifFields == "invalid")
+            {
+                AssertMetadataWarning(fixture, "EXIF");
+            }
+        }
+
+        [Fact]
+        public async Task InitialReadsSeparateXmpReferencesAndTriesAlternateCaptureDates()
+        {
+            using Fixture fixture = new Fixture();
+            fixture.ConfigureInitial();
+            InitialPhotoUpload photo = await UploadMetadataPhoto(fixture, MetadataJpeg(Xmp(false,
+                ("CreateDate", "not-a-date"), ("DateTimeOriginal", "2026-09-07T10:00:00.125Z"),
+                ("GPSLatitude", "47,36.3726"), ("GPSLatitudeRef", "N"),
+                ("GPSLongitude", "122,19.9242"), ("GPSLongitudeRef", "W"))));
+            Assert.Equal(new DateTime(2026, 9, 7, 10, 0, 0, 125), photo.PhotoDateTime);
+            AssertCoordinate(47.60621, photo.PhotoLatitude);
+            AssertCoordinate(-122.33207, photo.PhotoLongitude);
+            AssertMetadataWarning(fixture, "XMP");
+        }
+
+        [Fact]
+        public async Task InitialLeavesMissingMetadataForTheReportForm()
+        {
+            using Fixture fixture = new Fixture();
+            fixture.ConfigureInitial();
+            InitialPhotoUpload photo = await UploadMetadataPhoto(fixture, MetadataJpeg());
+            Assert.Null(photo.PhotoDateTime);
+            Assert.Null(photo.PhotoLatitude);
+            Assert.Null(photo.PhotoLongitude);
+            Assert.DoesNotContain(fixture.Log.Invocations, i => i.Method.Name == "Log");
+        }
+
+        [Theory]
+        [InlineData("<broken>")]
+        [InlineData("<!DOCTYPE x [<!ENTITY location SYSTEM 'https://not-requested.invalid/private'>]><x>&location;</x>")]
+        public async Task InitialLogsMalformedOrUnsafeXmpWithoutDiscardingValidExif(string xmp)
+        {
+            using Fixture fixture = new Fixture();
+            fixture.ConfigureInitial();
+            ExifProfile exif = new ExifProfile();
+            exif.SetValue(ExifTag.DateTimeDigitized, "2025:01:02 03:04:05");
+            InitialPhotoUpload photo = await UploadMetadataPhoto(fixture, MetadataJpeg(xmp, exif));
+            Assert.Equal(new DateTime(2025, 1, 2, 3, 4, 5), photo.PhotoDateTime);
+            Assert.Null(photo.PhotoLatitude);
+            Assert.Null(photo.PhotoLongitude);
+            AssertMetadataWarning(fixture, "XMP");
+            Assert.DoesNotContain(fixture.Log.Invocations, i =>
+                i.Method.Name == "Log" && i.Arguments[2].ToString()!.Contains("not-requested.invalid"));
+        }
+
+        [Theory]
+        [InlineData("47,60N")]
+        [InlineData("NaN")]
+        [InlineData("47,36,1/0N")]
+        [InlineData("47,36E")]
+        public async Task InitialLogsMalformedXmpGpsAndLeavesLocationUnset(string latitude)
+        {
+            using Fixture fixture = new Fixture();
+            fixture.ConfigureInitial();
+            InitialPhotoUpload photo = await UploadMetadataPhoto(fixture,
+                MetadataJpeg(Xmp(false, ("GPSLatitude", latitude), ("GPSLongitude", "122,19.9242W"))));
+            Assert.Null(photo.PhotoLatitude);
+            Assert.Null(photo.PhotoLongitude);
+            AssertMetadataWarning(fixture, "XMP");
+        }
+
+        [Fact]
+        public async Task InitialBoundsXmpNestingAndIgnoresUnrelatedNamespaces()
+        {
+            using Fixture fixture = new Fixture();
+            fixture.ConfigureInitial();
+            string deep = string.Concat(Enumerable.Repeat("<nested>", 40)) +
+                string.Concat(Enumerable.Repeat("</nested>", 40));
+            InitialPhotoUpload photo = await UploadMetadataPhoto(fixture, MetadataJpeg(deep));
+            Assert.Null(photo.PhotoDateTime);
+            AssertMetadataWarning(fixture, "XMP");
+            fixture.InitialMetadata.Clear();
+            photo = await UploadMetadataPhoto(fixture, MetadataJpeg(
+                "<other xmlns='https://not-xmp.invalid/' CreateDate='2026-09-07T10:00:00Z' GPSLatitude='50,0N' GPSLongitude='122,0W'/>"));
+            Assert.Null(photo.PhotoDateTime);
+            Assert.Null(photo.PhotoLatitude);
+        }
+
+        [Fact]
+        public async Task InProgressHasTypedRetryableResponseAndRetryAfter()
+        {
+            using Fixture fixture = new Fixture();
+            fixture.Store.Setup(s => s.GetAsync(Id, It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+                .ThrowsAsync(new ReportInProgressException(TimeSpan.FromSeconds(2.5)));
+            AssertError(await fixture.Controller.ReportStatus(Id), 409, UploadErrors.ReportInProgress);
+            Assert.Equal("3", fixture.Controller.Response.Headers.RetryAfter);
+            AssertError(await fixture.Controller.FinalizeUpload(fixture.Prepare()), 409, UploadErrors.ReportInProgress);
+            fixture.Authentication.VerifyNoOtherCalls();
+        }
+
+        [Fact]
+        public async Task HttpRoutesBindSharedEnvelopeMultipartAndReceiptWithoutLegacyAlias()
+        {
+            using Fixture fixture = new Fixture();
+            WebApplicationBuilder builder = WebApplication.CreateBuilder();
+            builder.WebHost.ConfigureKestrel(options => options.Listen(IPAddress.Loopback, 0));
+            builder.Services.AddControllers().AddApplicationPart(typeof(UploadController).Assembly).AddControllersAsServices();
+            builder.Services.AddSingleton<IAuthenticationService>(fixture.Authentication.Object);
+            builder.Services.AddTransient(_ => fixture.NewController());
+            await using WebApplication app = builder.Build();
+            app.MapControllers();
+            await app.StartAsync();
+            using HttpClient client = new HttpClient() { BaseAddress = new Uri(app.Urls.Single()) };
+            client.DefaultRequestHeaders.Add(UploadController.ReportIdHeader, Id);
+
+            var request = fixture.Prepare();
+            client.DefaultRequestHeaders.Add(UploadController.DeviceIdHeader, BlockedInstallation);
+            fixture.DeviceBlocked = true;
+            using (MultipartFormDataContent blockedPhotos = new MultipartFormDataContent())
+            {
+                blockedPhotos.Add(new ByteArrayContent([1]), "files", "photo.jpg");
+                var blockedInitial = await client.PostAsync("/api/Upload/Initial", blockedPhotos);
+                Assert.Equal(HttpStatusCode.Forbidden, blockedInitial.StatusCode);
+                Assert.Equal("This device can't submit reports.", await blockedInitial.Content.ReadAsStringAsync());
+            }
+            var blockedFinalize = await client.PostAsJsonAsync("/api/Upload/Finalize", request);
+            Assert.Equal(HttpStatusCode.Forbidden, blockedFinalize.StatusCode);
+            Assert.Equal("This device can't submit reports.", await blockedFinalize.Content.ReadAsStringAsync());
+            fixture.Existing = new SubmissionReport(fixture.Receipt, BlockedInstallation, []);
+            Assert.Equal(fixture.Receipt, await client.GetFromJsonAsync<SubmissionReceipt>($"/api/Upload/Reports/{Id}"));
+            var blockedRetry = await client.PostAsJsonAsync("/api/Upload/Finalize", request);
+            Assert.Equal(HttpStatusCode.OK, blockedRetry.StatusCode);
+            Assert.Equal(fixture.Receipt, await blockedRetry.Content.ReadFromJsonAsync<SubmissionReceipt>());
+            fixture.Existing = null;
+            fixture.DeviceBlocked = false;
+            client.DefaultRequestHeaders.Remove(UploadController.DeviceIdHeader);
+
+            var invalidEnvelope = await client.PostAsync("/api/Upload/Finalize",
+                new StringContent("""{"photos":null,"attribution":null}""", Encoding.UTF8, "application/json"));
+            Assert.Equal(HttpStatusCode.BadRequest, invalidEnvelope.StatusCode);
+            var response = await client.PostAsJsonAsync("/api/Upload/Finalize", request);
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            Assert.Equal(fixture.Receipt, await response.Content.ReadFromJsonAsync<SubmissionReceipt>());
+
+            fixture.Existing = new SubmissionReport(fixture.Receipt, null, []);
+            Assert.Equal(fixture.Receipt, await client.GetFromJsonAsync<SubmissionReceipt>($"/api/Upload/Reports/{Id}"));
+            var retry = await client.PostAsJsonAsync("/api/Upload/Finalize", new
+            {
+                photos = Array.Empty<object>(),
+                attribution = new
+                {
+                }
+            });
+            Assert.Equal(HttpStatusCode.OK, retry.StatusCode);
+            var unpreparedRetry = await client.PostAsync("/api/Upload/Finalize",
+                new StringContent("""{"photos":null,"attribution":null}""", Encoding.UTF8, "application/json"));
+            Assert.True(unpreparedRetry.IsSuccessStatusCode, await unpreparedRetry.Content.ReadAsStringAsync());
+            var legacy = await client.PostAsJsonAsync("/api/Upload/Finalize", request.Photos);
+            Assert.Equal(HttpStatusCode.BadRequest, legacy.StatusCode);
+            var alias = await client.PostAsJsonAsync("/api/Upload/FinalizeMobile", request);
+            Assert.Equal(HttpStatusCode.NotFound, alias.StatusCode);
+
+            using MultipartFormDataContent multipart = new MultipartFormDataContent();
+            multipart.Add(new ByteArrayContent(Encoding.UTF8.GetBytes("not an image")), "files", "invalid.jpg");
+            var initial = await client.PostAsync("/api/Upload/Initial", multipart);
+            Assert.Equal(HttpStatusCode.BadRequest, initial.StatusCode);
+            Assert.Contains("Photo 1", await initial.Content.ReadAsStringAsync());
+
+            fixture.ConfigureInitial();
+            using MultipartFormDataContent validMultipart = new MultipartFormDataContent();
+            validMultipart.Add(new ByteArrayContent(CreateJpeg()), "files", "photo.jpg");
+            var prepared = await client.PostAsync("/api/Upload/Initial", validMultipart);
+            Assert.Equal(HttpStatusCode.OK, prepared.StatusCode);
+            Assert.Single((await prepared.Content.ReadFromJsonAsync<InitialPhotoUpload[]>())!);
+
+            client.DefaultRequestHeaders.Remove(UploadController.ReportIdHeader);
+            Assert.Equal(HttpStatusCode.BadRequest, (await client.PostAsJsonAsync("/api/Upload/Finalize", request)).StatusCode);
+            await app.StopAsync();
+        }
+
+        private static byte[] CreateJpeg()
+        {
+            using MagickImage image = new MagickImage(MagickColors.White, 16, 16);
+            ExifProfile profile = new ExifProfile();
+            profile.SetValue(ExifTag.DateTimeDigitized, "2026:09:07 10:00:00");
+            image.SetProfile(profile);
+            return image.ToByteArray(MagickFormat.Jpeg);
+        }
+
+        private static string Xmp(bool elements, params (string Name, string Value)[] fields)
+        {
+            XNamespace rdf = "http://www.w3.org/1999/02/22-rdf-syntax-ns#";
+            XNamespace xmp = "http://ns.adobe.com/xap/1.0/";
+            XNamespace exif = "http://ns.adobe.com/exif/1.0/";
+            XElement description = new XElement(rdf + "Description", new XAttribute(XNamespace.Xmlns + "xmp", xmp),
+                new XAttribute(XNamespace.Xmlns + "exif", exif));
+            foreach (var field in fields)
+            {
+                XName name = (field.Name == "CreateDate" ? xmp : exif) + field.Name;
+                description.Add(elements ? (object)new XElement(name, field.Value) : new XAttribute(name, field.Value));
+            }
+            return new XElement(XName.Get("xmpmeta", "adobe:ns:meta/"),
+                new XElement(rdf + "RDF", description)).ToString(SaveOptions.DisableFormatting);
+        }
+
+        private static byte[] MetadataJpeg(string? xmp = null, ExifProfile? exif = null)
+        {
+            using MagickImage image = new MagickImage(MagickColors.White, 16, 16);
+            if (exif is not null)
+            {
+                image.SetProfile(exif);
+            }
+
+            byte[] jpeg = image.ToByteArray(MagickFormat.Jpeg);
+            if (xmp is null)
+            {
+                return jpeg;
+            }
+            // Inject a genuine JPEG APP1 packet without ImageMagick synchronizing conflicting EXIF/XMP.
+            byte[] packet = Encoding.UTF8.GetBytes("http://ns.adobe.com/xap/1.0/\0" + xmp);
+            int length = packet.Length + 2;
+            Assert.InRange(length, 2, ushort.MaxValue);
+            using MemoryStream output = new MemoryStream();
+            output.Write(jpeg.AsSpan(0, 2));
+            output.WriteByte(0xff);
+            output.WriteByte(0xe1);
+            output.WriteByte((byte)(length >> 8));
+            output.WriteByte((byte)length);
+            output.Write(packet);
+            output.Write(jpeg.AsSpan(2));
+            return output.ToArray();
+        }
+
+        private static ExifProfile SeattleExif()
+        {
+            ExifProfile exif = new ExifProfile();
+            exif.SetValue(ExifTag.GPSLatitude, [new Rational(47), new Rational(36), new Rational(0)]);
+            exif.SetValue(ExifTag.GPSLatitudeRef, "N");
+            exif.SetValue(ExifTag.GPSLongitude, [new Rational(122), new Rational(20), new Rational(0)]);
+            exif.SetValue(ExifTag.GPSLongitudeRef, "W");
+            return exif;
+        }
+
+        private static async Task<InitialPhotoUpload> UploadMetadataPhoto(Fixture fixture, byte[] jpeg)
+        {
+            var result = Assert.IsType<OkObjectResult>(await fixture.Controller.UploadPhoto(
+                                        [new FormFile(new MemoryStream(jpeg), 0, jpeg.Length, "files", "metadata.jpg")]));
+            return Assert.Single(Assert.IsType<InitialPhotoUpload[]>(result.Value));
+        }
+
+        private static void AssertCoordinate(double expected, string? actual)
+        {
+            Assert.Equal(expected, double.Parse(actual!, CultureInfo.InvariantCulture), precision: 7);
+        }
+
+        private static void AssertMetadataWarning(Fixture fixture, string format)
+        {
+            Assert.Contains(fixture.Log.Invocations, i => i.Method.Name == "Log" &&
+                                        i.Arguments[0].Equals(LogLevel.Warning) && i.Arguments[2].ToString()!.Contains(format));
+        }
+
+        private static void AssertError(IActionResult result, int status, string code)
+        {
+            var response = Assert.IsAssignableFrom<ObjectResult>(result);
+            Assert.Equal(status, response.StatusCode);
+            Assert.Equal(code, Assert.IsType<UploadError>(response.Value).Code);
+            Assert.DoesNotContain("sensitive", JsonSerializer.Serialize(response.Value));
+            Assert.DoesNotContain("private", JsonSerializer.Serialize(response.Value));
+        }
+
+        private sealed class Fixture : IDisposable
+        {
+            public Mock<BlobContainerClient> Blobs { get; } = new Mock<BlobContainerClient>(MockBehavior.Strict);
+            public Mock<ReportStore> Store { get; }
+            public Mock<BlockedDevicesDatabase> BlockedDevices { get; } = new Mock<BlockedDevicesDatabase>(
+                MockBehavior.Strict, NullLogger<BlockedDevicesDatabase>.Instance, Mock.Of<Cosmos.Container>());
+            public bool DeviceBlocked { get; set; }
+            public Mock<IAuthenticationService> Authentication { get; } = new Mock<IAuthenticationService>(MockBehavior.Strict);
+            public Mock<HttpMessageHandler> Provider { get; } = new Mock<HttpMessageHandler>(MockBehavior.Strict);
+            public Mock<HttpMessageHandler> SlackHandler { get; } = new Mock<HttpMessageHandler>(MockBehavior.Strict);
+            public Mock<ImageAnalysisClient> Analysis { get; } = new Mock<ImageAnalysisClient>(MockBehavior.Strict);
+            public Mock<ContentSafetyClient> Safety { get; } = new Mock<ContentSafetyClient>(MockBehavior.Strict);
+            public Mock<HttpMessageHandler> MapsHandler { get; } = new Mock<HttpMessageHandler>(MockBehavior.Strict);
+            public Mock<ILogger<UploadController>> Log { get; } = new Mock<ILogger<UploadController>>();
+            public List<InitialPhotoUploadMetadata> InitialMetadata { get; } = [];
+            public Dictionary<string, InitialPhotoUploadMetadata> Metadata { get; } = [];
+            public AuthenticateResult Cookie { get; set; } = AuthenticateResult.NoResult();
+            public AuthenticateResult Bearer { get; set; } = AuthenticateResult.NoResult();
+            public SubmissionReceipt Receipt { get; } = new SubmissionReceipt(Id, Id,
+                new DateTimeOffset(2026, 9, 7, 12, 0, 0, TimeSpan.Zero), new ReportAttribution());
+            public SubmissionReport? Existing { get; set; }
+            public IReadOnlyList<PreparedSubmissionPhoto>? Committed { get; private set; }
+            public ReportAttribution? CommittedAttribution { get; private set; }
+            public long SourceLength { get; set; } = 23;
+            public string? LastDeviceId { get; private set; }
+            public UploadController Controller { get; }
+            private readonly ServiceProvider services;
+            private readonly HttpClient providerClient;
+            private readonly HttpClient slackClient;
+            private readonly HttpClient mapsClient;
+            private readonly SlackbotProvider slack;
+
+            public Fixture()
+            {
+                BlockedDevices.Setup(d => d.IsBlockedAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                    .ReturnsAsync(() => DeviceBlocked);
+                Store = new Mock<ReportStore>(Blobs.Object, NullLogger<ReportStore>.Instance, TimeProvider.System);
+                Store.Setup(s => s.GetAsync(Id, It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+                    .Returns((string _, string? device, CancellationToken _) =>
+                    {
+                        LastDeviceId = device;
+                        return Task.FromResult(Existing);
+                    });
+                Store.Setup(s => s.CommitAsync(Id, It.IsAny<string?>(), It.IsAny<ReportAttribution>(),
+                    It.IsAny<IReadOnlyList<PreparedSubmissionPhoto>>(), It.IsAny<CancellationToken>()))
+                    .Returns((string _, string? device, ReportAttribution attribution,
+                        IReadOnlyList<PreparedSubmissionPhoto> photos, CancellationToken _) =>
+                    {
+                        LastDeviceId = device;
+                        Committed = photos;
+                        CommittedAttribution = attribution;
+                        return Task.FromResult(Receipt);
+                    });
+                Authentication.Setup(a => a.AuthenticateAsync(It.IsAny<HttpContext>(), It.IsAny<string>()))
+                    .Returns((HttpContext _, string scheme) => Task.FromResult(scheme == BlueskyAuthDefaults.BearerScheme ? Bearer : Cookie));
+                services = new ServiceCollection().AddSingleton(Authentication.Object).BuildServiceProvider();
+                Provider.Protected().Setup("Dispose", ItExpr.IsAny<bool>());
+                SlackHandler.Protected().Setup("Dispose", ItExpr.IsAny<bool>());
+                MapsHandler.Protected().Setup("Dispose", ItExpr.IsAny<bool>());
+                providerClient = new HttpClient(Provider.Object);
+                slackClient = new HttpClient(SlackHandler.Object);
+                mapsClient = new HttpClient(MapsHandler.Object);
+                SlackHandler.Protected().Setup<Task<HttpResponseMessage>>("SendAsync",
+                    ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
+                    .ReturnsAsync(() => new HttpResponseMessage(HttpStatusCode.OK));
+                Mock<SecretClient> secrets = new Mock<SecretClient>();
+                secrets.Setup(s => s.GetSecret(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                    .Returns((string name, string _, CancellationToken _) =>
+                        Response.FromValue(new KeyVaultSecret(name, "test-value"), Mock.Of<Response>()));
+                slack = new SlackbotProvider(NullLogger<SlackbotProvider>.Instance, slackClient, secrets.Object);
+                Controller = NewController();
+            }
+
+            public UploadController NewController()
+            {
+                UploadController controller = new UploadController(Log.Object,
+                                                    Analysis.Object, Safety.Object,
+                                                    new MapsSearchClient(new AzureKeyCredential("test-key"),
+                                                        new MapsSearchClientOptions() { Transport = new HttpClientTransport(mapsClient) }), Blobs.Object,
+                                                    new MastodonCredentialVerifier(providerClient), slack,
+                                                    new DeviceBlocklistProvider(NullLogger<DeviceBlocklistProvider>.Instance, BlockedDevices.Object),
+                                                    Store.Object, new HelperMethods())
+                {
+                    ControllerContext = new ControllerContext() { HttpContext = new DefaultHttpContext() { RequestServices = services } }
+                };
+                controller.Request.Headers[UploadController.ReportIdHeader] = Id;
+                return controller;
+            }
+
+            public void ConfigureInitial()
+            {
+                MapsHandler.Protected().Setup<Task<HttpResponseMessage>>("SendAsync",
+                                                        ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
+                                                    .ReturnsAsync(() => new HttpResponseMessage(HttpStatusCode.OK)
+                                                    {
+                                                        Content = new StringContent("""
+                        {"summary":{"queryType":"NEARBY","queryTime":1,"numResults":1},
+                         "addresses":[{"address":{"streetName":"Pike St"},"position":"47.60621,-122.33207"}]}
+                        """, Encoding.UTF8, "application/json")
+                                                    });
+                Analysis.Setup(a => a.AnalyzeAsync(It.IsAny<BinaryData>(), VisualFeatures.Tags,
+                        It.IsAny<ImageAnalysisOptions>(), It.IsAny<CancellationToken>()))
+                    .ReturnsAsync(Response.FromValue(AIVisionImageAnalysisModelFactory.ImageAnalysisResult(
+                        tags: AIVisionImageAnalysisModelFactory.TagsResult(
+                            [AIVisionImageAnalysisModelFactory.DetectedTag(.95f, "car")])), Mock.Of<Response>()));
+                Safety.Setup(s => s.AnalyzeImageAsync(It.IsAny<BinaryData>(), It.IsAny<CancellationToken>()))
+                    .ReturnsAsync(Response.FromValue(ContentSafetyModelFactory.AnalyzeImageResult(
+                        [ContentSafetyModelFactory.ImageCategoriesAnalysis(ImageCategory.Hate, 0)]), Mock.Of<Response>()));
+                Mock<BlobServiceClient> service = new Mock<BlobServiceClient>();
+                service.SetupGet(s => s.AccountName).Returns("account");
+                service.Setup(s => s.GetUserDelegationKeyAsync(It.IsAny<DateTimeOffset?>(),
+                        It.IsAny<DateTimeOffset>(), It.IsAny<CancellationToken>()))
+                    .ReturnsAsync(Response.FromValue(BlobsModelFactory.UserDelegationKey(
+                        Guid.Empty.ToString(), Guid.Empty.ToString(),
+                        DateTimeOffset.UtcNow.AddMinutes(-1), DateTimeOffset.UtcNow.AddHours(1),
+                        "b", "2023-11-03", Convert.ToBase64String(new byte[32])),
+                        Mock.Of<Response>()));
+                Blobs.Protected().Setup<BlobServiceClient>("GetParentBlobServiceClientCore").Returns(service.Object);
+                Blobs.Setup(b => b.GetBlobClient(It.Is<string>(name => name.StartsWith("initialupload/"))))
+                    .Returns((string name) =>
+                    {
+                        Mock<BlobClient> blob = new Mock<BlobClient>();
+                        blob.SetupGet(b => b.Uri).Returns(new Uri($"https://account.blob.core.windows.net/uploads/{name}"));
+                        blob.SetupGet(b => b.Name).Returns(name);
+                        blob.SetupGet(b => b.BlobContainerName).Returns("uploads");
+                        blob.Protected().Setup<BlobContainerClient>("GetParentBlobContainerClientCore").Returns(Blobs.Object);
+                        blob.Setup(b => b.UploadAsync(It.IsAny<BinaryData>(), It.IsAny<BlobUploadOptions>(), It.IsAny<CancellationToken>()))
+                            .Returns((BinaryData data, BlobUploadOptions options, CancellationToken _) =>
+                            {
+                                Assert.Equal(ETag.All, options.Conditions.IfNoneMatch);
+                                if (name.EndsWith(".json"))
+                                {
+                                    InitialMetadata.Add(data.ToObjectFromJson<InitialPhotoUploadMetadata>()!);
+                                    Assert.Equal("application/json", options.HttpHeaders.ContentType);
+                                }
+                                else
+                                {
+                                    Assert.Equal("image/jpeg", options.HttpHeaders.ContentType);
+                                    Assert.InRange(data.ToMemory().Length, 1, 8 * 1024 * 1024);
+                                    using MagickImage jpeg = new MagickImage(data.ToArray());
+                                    Assert.Equal(MagickFormat.Jpeg, jpeg.Format);
+                                }
+                                return Task.FromResult(Response.FromValue(BlobsModelFactory.BlobContentInfo(
+                                    new ETag("\"initial-version\""), DateTimeOffset.UtcNow, null!, null!, 0),
+                                    Mock.Of<Response>()));
+                            });
+                        return blob.Object;
+                    });
+            }
+
+            public FinalizeReportRequest Prepare(int count = 1)
+            {
+                List<FinalizedPhotoUpload> photos = [];
+                for (int i = 0; i < count; i++)
+                {
+                    string photoId = $"photo-{i}";
+                    InitialPhotoUploadMetadata metadata = new InitialPhotoUploadMetadata()
+                    {
+                        PhotoId = photoId,
+                        SubmissionId = "prepared-set",
+                        PhotoNumber = i,
+                        ReportId = Id,
+                        Tags = [new ImageTag() { Name = "car", Confidence = .95f }]
+                    };
+                    Metadata[photoId] = metadata;
+                    photos.Add(new FinalizedPhotoUpload()
+                    {
+                        PhotoId = photoId,
+                        SubmissionId = "prepared-set",
+                        PhotoNumber = i,
+                        PhotoDateTime = new DateTime(2026, 9, 7, 10, 0, 0),
+                        PhotoLatitude = "47.60621",
+                        PhotoLongitude = "-122.33207",
+                        PhotoCrossStreet = "Pike St",
+                        NumberOfCars = 2
+                    });
+                    Mock<BlobClient> json = new Mock<BlobClient>(MockBehavior.Strict);
+                    json.Setup(b => b.GetPropertiesAsync(It.IsAny<BlobRequestConditions>(), It.IsAny<CancellationToken>()))
+                        .ReturnsAsync(() => Response.FromValue(BlobsModelFactory.BlobProperties(
+                            contentLength: BinaryData.FromObjectAsJson(Metadata[photoId]).ToMemory().Length,
+                            eTag: new ETag("\"metadata-version\"")), Mock.Of<Response>()));
+                    json.Setup(b => b.DownloadStreamingAsync(It.IsAny<BlobDownloadOptions>(), It.IsAny<CancellationToken>()))
+                        .Returns((BlobDownloadOptions options, CancellationToken _) =>
+                        {
+                            Assert.Equal(new ETag("\"metadata-version\""), options.Conditions.IfMatch);
+                            return Task.FromResult(Response.FromValue(BlobsModelFactory.BlobDownloadStreamingResult(
+                                content: BinaryData.FromObjectAsJson(Metadata[photoId]).ToStream()), Mock.Of<Response>()));
+                        });
+                    Mock<BlobClient> jpeg = new Mock<BlobClient>(MockBehavior.Strict);
+                    jpeg.Setup(b => b.GetPropertiesAsync(It.IsAny<BlobRequestConditions>(), It.IsAny<CancellationToken>()))
+                        .ReturnsAsync(() => Response.FromValue(BlobsModelFactory.BlobProperties(contentLength: SourceLength,
+                            contentType: "image/jpeg", eTag: new ETag("\"photo-version\"")), Mock.Of<Response>()));
+                    Blobs.Setup(b => b.GetBlobClient($"initialupload/{photoId}.json")).Returns(json.Object);
+                    Blobs.Setup(b => b.GetBlobClient($"initialupload/{photoId}.jpeg")).Returns(jpeg.Object);
+                }
+                return new FinalizeReportRequest(photos, new ReportAttribution());
+            }
+
+            public void MastodonResponse(HttpStatusCode status, string json)
+            {
+                Provider.Protected().Setup<Task<HttpResponseMessage>>("SendAsync",
+                                                    ItExpr.Is<HttpRequestMessage>(m => m.RequestUri!.ToString() ==
+                                                        "https://mastodon.example/api/v1/accounts/verify_credentials" &&
+                                                        m.Headers.Authorization!.Parameter == "retained-token"),
+                                                    ItExpr.IsAny<CancellationToken>())
+                                                    .ReturnsAsync(() => new HttpResponseMessage(status) { Content = new StringContent(json) });
+            }
+
+            public static AuthenticateResult Auth(string did, string handle)
+            {
+                return AuthenticateResult.Success(new AuthenticationTicket(new ClaimsPrincipal(new ClaimsIdentity(
+                                                [
+                                                    new Claim(BlueskyAuthDefaults.DidClaim, did),
+                    new Claim(BlueskyAuthDefaults.HandleClaim, handle)
+                                                ], "test")), "test"));
+            }
+
+            public void Dispose()
+            {
+                services.Dispose();
+                providerClient.Dispose();
+                slackClient.Dispose();
+                mapsClient.Dispose();
+            }
+        }
+    }
+}

--- a/SeattleCarsInBikeLanes.slnx
+++ b/SeattleCarsInBikeLanes.slnx
@@ -3,9 +3,6 @@
   <Project Path="../atproto.net/golf1052.atproto.net/golf1052.atproto.net.csproj" />
   <Project Path="../MastodonAPI/golf1052.Mastodon/golf1052.Mastodon.csproj" />
   <Project Path="../ThreadsAPI/golf1052.ThreadsAPI/golf1052.ThreadsAPI.csproj" />
-  <Project Path="SeattleCarsInBikeLanes.Mobile/SeattleCarsInBikeLanes.Mobile.csproj">
-    <Deploy Solution="Debug|*" />
-  </Project>
   <Project Path="SeattleCarsInBikeLanes.Tests/SeattleCarsInBikeLanes.Tests.csproj" />
   <Project Path="SeattleCarsInBikeLanes/SeattleCarsInBikeLanes.csproj" />
 </Solution>

--- a/SeattleCarsInBikeLanes/Controllers/AdminDeviceBlocksController.cs
+++ b/SeattleCarsInBikeLanes/Controllers/AdminDeviceBlocksController.cs
@@ -1,0 +1,107 @@
+using Azure.Identity;
+using idunno.Authentication.Basic;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Azure.Cosmos;
+using Newtonsoft.Json;
+using SeattleCarsInBikeLanes.Database;
+using SeattleCarsInBikeLanes.Models;
+
+namespace SeattleCarsInBikeLanes.Controllers
+{
+    [ApiController]
+    [Route("api/AdminPage/BlockedDevices")]
+    [Authorize(AuthenticationSchemes = BasicAuthenticationDefaults.AuthenticationScheme)]
+    public class AdminDeviceBlocksController : ControllerBase
+    {
+        private readonly ILogger<AdminDeviceBlocksController> logger;
+        private readonly BlockedDevicesDatabase database;
+
+        public AdminDeviceBlocksController(ILogger<AdminDeviceBlocksController> logger, BlockedDevicesDatabase database)
+        {
+            this.logger = logger;
+            this.database = database;
+        }
+
+        [HttpGet]
+        [ResponseCache(NoStore = true, Location = ResponseCacheLocation.None)]
+        public async Task<IActionResult> Get(CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            try
+            {
+                var devices = await database.ListAsync(cancellationToken);
+                return Ok(devices.Select(device => new AdminBlockedDeviceResponse(device.DeviceId, device.Reason)).ToArray());
+            }
+            catch (Exception ex) when (IsStorageFailure(ex, cancellationToken))
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                logger.LogError(ex, "Could not load blocked devices.");
+                return StatusCode(StatusCodes.Status503ServiceUnavailable,
+                    "Blocked devices could not be loaded. Refresh the blocked-device list and try again. If this continues, check the storage configuration.");
+            }
+        }
+
+        [HttpPost]
+        [Consumes("application/json")]
+        public async Task<IActionResult> Block([FromBody] BlockDeviceRequest request, CancellationToken cancellationToken = default)
+        {
+            string? deviceId = DeviceIdRules.Normalize(request.DeviceId);
+            if (!DeviceIdRules.IsValid(deviceId))
+            {
+                return BadRequest("A device ID of 1-128 ASCII letters, digits, hyphens or underscores is required.");
+            }
+
+            string? reason = request.Reason?.Trim();
+            if (string.IsNullOrEmpty(reason) || reason.Length > BlockedDevicesDatabase.MaximumReasonLength)
+            {
+                return BadRequest($"A reason of 1-{BlockedDevicesDatabase.MaximumReasonLength} characters is required.");
+            }
+
+            cancellationToken.ThrowIfCancellationRequested();
+            try
+            {
+                await database.BlockAsync(deviceId!, reason, cancellationToken);
+                return NoContent();
+            }
+            catch (Exception ex) when (IsStorageFailure(ex, cancellationToken))
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                logger.LogError(ex, "Could not confirm blocking device {DeviceId}.", deviceId);
+                return StatusCode(StatusCodes.Status503ServiceUnavailable,
+                    "The device block could not be confirmed. Refresh the blocked-device list before retrying. If this continues, check the storage configuration.");
+            }
+        }
+
+        [HttpDelete]
+        [Consumes("application/json")]
+        public async Task<IActionResult> Unblock([FromBody] UnblockDeviceRequest request, CancellationToken cancellationToken = default)
+        {
+            string? deviceId = DeviceIdRules.Normalize(request.DeviceId);
+            if (!DeviceIdRules.IsValid(deviceId))
+            {
+                return BadRequest("A device ID of 1-128 ASCII letters, digits, hyphens or underscores is required.");
+            }
+
+            cancellationToken.ThrowIfCancellationRequested();
+            try
+            {
+                await database.UnblockAsync(deviceId!, cancellationToken);
+                return NoContent();
+            }
+            catch (Exception ex) when (IsStorageFailure(ex, cancellationToken))
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                logger.LogError(ex, "Could not confirm unblocking device {DeviceId}.", deviceId);
+                return StatusCode(StatusCodes.Status503ServiceUnavailable,
+                    "The device unblock could not be confirmed. Refresh the blocked-device list before retrying. If this continues, check the storage configuration.");
+            }
+        }
+
+        private static bool IsStorageFailure(Exception exception, CancellationToken cancellationToken)
+        {
+            return exception is CosmosException or HttpRequestException or TimeoutException or AuthenticationFailedException or JsonException ||
+                (exception is OperationCanceledException && !cancellationToken.IsCancellationRequested);
+        }
+    }
+}

--- a/SeattleCarsInBikeLanes/Controllers/AdminPageController.cs
+++ b/SeattleCarsInBikeLanes/Controllers/AdminPageController.cs
@@ -1,8 +1,14 @@
 ﻿using System.Net;
+using System.Globalization;
+using System.Security.Cryptography;
+using System.Text;
+using Azure;
 using Azure.Maps.Search;
 using Azure.Security.KeyVault.Secrets;
 using Azure.Storage.Blobs;
 using Azure.Storage.Blobs.Models;
+using Azure.Storage.Blobs.Specialized;
+using Azure.Storage.Sas;
 using FishyFlip;
 using FishyFlip.Lexicon.App.Bsky.Embed;
 using FishyFlip.Lexicon.App.Bsky.Feed;
@@ -27,6 +33,7 @@ using LinqToTwitter.OAuth;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Newtonsoft.Json;
+using SeattleCarsInBikeLanes.Core.Contracts;
 using SeattleCarsInBikeLanes.Database;
 using SeattleCarsInBikeLanes.Database.Models;
 using SeattleCarsInBikeLanes.Providers;
@@ -52,6 +59,9 @@ namespace SeattleCarsInBikeLanes.Controllers
         private readonly BlueskyClientProvider blueskyClientProvider;
         private readonly BlueskyOAuthProvider blueskyOAuthProvider;
         private readonly ThreadsClient threadsClient;
+        private readonly ReportStore reportStore;
+        private const string FinalizedUploadPrefix = ReportStore.FinalizedUploadPrefix;
+        private const string PartialPublicationWarning = "Some posts may already have been published. Check Bluesky, Mastodon and Threads, delete any successful posts, fix the cause shown in the logs, then click Upload again.";
 
         public AdminPageController(ILogger<AdminPageController> logger,
             HelperMethods helperMethods,
@@ -65,7 +75,8 @@ namespace SeattleCarsInBikeLanes.Controllers
             FeedProvider feedProvider,
             BlueskyClientProvider blueskyClientProvider,
             BlueskyOAuthProvider blueskyOAuthProvider,
-            ThreadsClient threadsClient)
+            ThreadsClient threadsClient,
+            ReportStore reportStore)
         {
             this.logger = logger;
             this.helperMethods = helperMethods;
@@ -79,6 +90,7 @@ namespace SeattleCarsInBikeLanes.Controllers
             this.blueskyClientProvider = blueskyClientProvider;
             this.blueskyOAuthProvider = blueskyOAuthProvider;
             this.threadsClient = threadsClient;
+            this.reportStore = reportStore;
 
             SingleUserAuthorizer auth = new SingleUserAuthorizer()
             {
@@ -111,63 +123,166 @@ namespace SeattleCarsInBikeLanes.Controllers
         }
 
         [HttpGet("/api/AdminPage/PendingPhotos")]
-        public async Task<Dictionary<string, List<FinalizedPhotoUploadWithSasUriMetadata>>> GetPendingPhotos()
+        [ResponseCache(NoStore = true, Location = ResponseCacheLocation.None)]
+        public async Task<Dictionary<string, List<FinalizedPhotoUploadWithSasUriMetadata>>> GetPendingPhotos(CancellationToken ct = default)
         {
             Dictionary<string, List<FinalizedPhotoUploadWithSasUriMetadata>> submissions = new Dictionary<string, List<FinalizedPhotoUploadWithSasUriMetadata>>();
-            var blobs = blobContainerClient.GetBlobsAsync(BlobTraits.None, BlobStates.None, UploadController.FinalizedUploadPrefix, CancellationToken.None);
-            await foreach (var blob in blobs)
+            await foreach (var report in reportStore.GetPendingAsync(ct))
             {
-                if (blob.Name.EndsWith(".jpeg"))
+                List<FinalizedPhotoUploadWithSasUriMetadata> photos = new List<FinalizedPhotoUploadWithSasUriMetadata>();
+                foreach (var photo in report.Photos)
                 {
-                    // Skip pictures because we'll load them once we have the JSON
-                    continue;
+                    var preview = ToPreview(photo.Metadata);
+                    preview.ReportId = report.Receipt.ReportId;
+                    preview.ReportVersion = report.Version;
+                    preview.DeviceId = report.DeviceId;
+                    preview.ModerationStatus = report.Moderation?.Kind ?? "pending";
+                    preview.ModerationOperationId = report.Moderation?.Id;
+                    preview.ModerationStartedAt = report.Moderation?.StartedAt;
+                    preview.Warning = report.Moderation is null ? null :
+                        report.Moderation.Kind == "deleting"
+                            ? "Deletion is in progress. Wait for the request to finish, then refresh."
+                            : "Publication is in progress. Wait for the request to finish before retrying.";
+                    preview.CanModerate = report.Moderation is null;
+                    await SetPreviewAsync(preview, photo, ct);
+                    photos.Add(preview);
                 }
-                BlobClient jsonBlobClient = blobContainerClient.GetBlobClient(blob.Name);
-                var downloadResponse = await jsonBlobClient.DownloadContentAsync();
-                var metadata = JsonConvert.DeserializeObject<FinalizedPhotoUploadWithSasUriMetadata>(downloadResponse.Value.Content.ToString());
-                if (metadata == null)
+                if (photos.Any(p => !p.CanModerate))
                 {
-                    logger.LogError($"Error when deserializing FinalizedPhotoUploadWithSasUriMetadata. Skipping.");
-                    continue;
+                    photos.ForEach(p => p.CanModerate = false);
                 }
-                if (!submissions.ContainsKey(metadata.SubmissionId))
-                {
-                    submissions.Add(metadata.SubmissionId, new List<FinalizedPhotoUploadWithSasUriMetadata>());
-                }
-                BlobClient photoBlobClient = blobContainerClient.GetBlobClient($"{UploadController.FinalizedUploadPrefix}{metadata!.PhotoId}.jpeg");
-                Uri photoUri = await photoBlobClient.GenerateUserDelegationReadOnlySasUri(DateTimeOffset.UtcNow.AddHours(1));
-                metadata.Uri = photoUri.ToString();
-                submissions[metadata.SubmissionId].Add(metadata);
+                submissions.Add(report.Receipt.ReportId, photos);
             }
 
-            foreach (var submission in submissions)
+            foreach (var group in await ReadLegacyGroupsAsync(ct))
             {
-                submission.Value.Sort((a, b) => a.PhotoNumber.CompareTo(b.PhotoNumber));
+                // Consult all states, including tombstones left behind after partial cleanup.
+                if (await reportStore.ExistsAsync(group.ReportId, ct))
+                {
+                    continue;
+                }
+                List<FinalizedPhotoUploadWithSasUriMetadata> photos = new List<FinalizedPhotoUploadWithSasUriMetadata>();
+                foreach (var metadata in group.Metadata.OrderBy(p => p.PhotoNumber))
+                {
+                    var preview = ToPreview(metadata);
+                    preview.ReportId = group.ReportId;
+                    preview.ReportVersion = group.Version;
+                    preview.LegacySubmissionId = group.SubmissionId;
+                    preview.Warning = group.Error;
+                    preview.CanModerate = group.Error is null;
+                    preview.ModerationStatus = group.Error is null ? "pending" : "needs-repair";
+                    var photo = group.Photos.FirstOrDefault(p => p.Metadata.PhotoId == metadata.PhotoId);
+                    if (photo is not null)
+                    {
+                        await SetPreviewAsync(preview, photo, ct);
+                    }
+                    photos.Add(preview);
+                }
+                if (photos.Any(p => !p.CanModerate))
+                {
+                    photos.ForEach(p => p.CanModerate = false);
+                }
+                submissions.TryAdd(group.ReportId, photos);
             }
             return submissions;
         }
 
         [HttpPost("/api/AdminPage/UploadTweet")]
-        public async Task<IActionResult> UploadTweet([FromBody] List<FinalizedPhotoUploadMetadata> data)
+        public async Task<IActionResult> UploadTweet([FromBody] ModerateReportRequest request, CancellationToken ct = default)
         {
-            string carsString;
-            if (data.Count == 0)
+            SubmissionReport report;
+            try
             {
-                string errorString = "Must pass at least 1 metadata object.";
-                logger.LogError(errorString);
-                return BadRequest(errorString);
+                report = await AcquireModerationAsync(request, "publishing", ct);
             }
-            FinalizedPhotoUploadMetadata metadata = data[0];
+            catch (Exception ex)
+            {
+                return ModerationError(ex);
+            }
 
+            bool effectsStarted = false;
+            string publicationStage = "preparation";
+            List<Stream> pictureStreams = new List<Stream>();
+            try
+            {
+                await PublishReportAsync(report, request, pictureStreams, stage =>
+                                                {
+                                                    effectsStarted = true;
+                                                    publicationStage = stage;
+                                                }, ct);
+                publicationStage = "report retirement";
+                await reportStore.RetireAsync(report.Receipt.ReportId, report.Moderation!.Id, ct);
+                await TryCleanupAsync();
+                return NoContent();
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Publication failed during {Stage} for report {ReportId}, operation {OperationId}, external work started: {EffectsStarted}",
+                                                    publicationStage, report.Receipt.ReportId, report.Moderation!.Id, effectsStarted);
+                try
+                {
+                    if (publicationStage == "report retirement")
+                    {
+                        var saved = await reportStore.GetAsync(report.Receipt.ReportId, report.DeviceId, CancellationToken.None);
+                        if (saved?.Retired == true && saved.Moderation?.Id == report.Moderation.Id)
+                        {
+                            return NoContent();
+                        }
+                    }
+                    // We check/delete partial social posts before retrying. A failed request
+                    // must leave the report pending with its photos.
+                    await reportStore.ReleaseModerationAsync(report.Receipt.ReportId, report.Moderation.Id, CancellationToken.None);
+                    var pending = await reportStore.GetForModerationAsync(report.Receipt.ReportId, CancellationToken.None);
+                    bool invalidPhoto = !effectsStarted &&
+                        (ex is InvalidDataException || ex is RequestFailedException { Status: 404 or 412 });
+                    var failure = new
+                    {
+                        message = effectsStarted
+                            ? $"Upload failed during {publicationStage}. The report and its photos are still pending. {PartialPublicationWarning}"
+                            : invalidPhoto
+                                ? "A saved photo is missing, changed or invalid. Nothing was posted. Repair the stored photo before retrying."
+                                : "Publication failed before external posting. The report is still pending; fix the cause shown in the logs, then click Upload again.",
+                        reportId = report.Receipt.ReportId,
+                        reportVersion = pending.Version,
+                        retryAllowed = pending.Moderation is null
+                    };
+                    return invalidPhoto ? Conflict(failure) : StatusCode(effectsStarted ? 502 : 503, failure);
+                }
+                catch (Exception releaseError)
+                {
+                    logger.LogError(releaseError, "Could not confirm pending state for failed report {ReportId}", report.Receipt.ReportId);
+                    return StatusCode(503, new
+                    {
+                        message = $"Upload failed during {publicationStage}, and the saved report state could not be refreshed. Fix the storage error shown in the logs and refresh before retrying.",
+                        reportId = report.Receipt.ReportId,
+                        operationId = report.Moderation.Id
+                    });
+                }
+            }
+            finally
+            {
+                foreach (var stream in pictureStreams)
+                {
+                    stream.Dispose();
+                }
+            }
+        }
+
+        private async Task PublishReportAsync(SubmissionReport report, ModerateReportRequest request,
+            List<Stream> pictureStreams, Action<string> externalEffectsStarting, CancellationToken ct)
+        {
+            var data = report.Photos.Select(p => p.Metadata).ToList();
+            FinalizedPhotoUploadMetadata metadata = data[0];
+            string carsString;
             MastodonClient mastodonClient = mastodonClientProvider.GetServerClient();
             AtProtoClient blueskyClient;
-            if (string.IsNullOrWhiteSpace(metadata.BlueskyAdminDid) || string.IsNullOrWhiteSpace(metadata.BlueskyAccessJwt))
+            if (string.IsNullOrWhiteSpace(request.BlueskyAdminDid) || string.IsNullOrWhiteSpace(request.BlueskyAccessJwt))
             {
                 blueskyClient = await blueskyClientProvider.GetClient();
             }
             else
             {
-                blueskyClient = blueskyClientProvider.GetClient(metadata.BlueskyAdminDid, metadata.BlueskyAccessJwt);
+                blueskyClient = blueskyClientProvider.GetClient(request.BlueskyAdminDid, request.BlueskyAccessJwt);
             }
 
             if (metadata.NumberOfCars == 1)
@@ -184,14 +299,26 @@ namespace SeattleCarsInBikeLanes.Controllers
             // it rather than attributing the post to a handle that may now belong to someone else.
             if (!string.IsNullOrWhiteSpace(metadata.BlueskyUserDid))
             {
+                foreach (var photo in data)
+                {
+                    if (!string.IsNullOrWhiteSpace(photo.BlueskyHandle) &&
+                                                                photo.BlueskySubmittedBy == $"Submitted by {photo.BlueskyHandle}")
+                    {
+                        photo.BlueskySubmittedBy = $"Submitted by @{photo.BlueskyHandle}";
+                    }
+                }
                 string? currentHandle = await blueskyOAuthProvider.ResolveHandleFromDid(metadata.BlueskyUserDid);
                 if (!string.IsNullOrWhiteSpace(currentHandle) && currentHandle != metadata.BlueskyHandle)
                 {
                     logger.LogInformation("Bluesky handle for {Did} changed from {OldHandle} to {NewHandle} since submission.",
-                        metadata.BlueskyUserDid, metadata.BlueskyHandle, currentHandle);
+                                                                metadata.BlueskyUserDid, metadata.BlueskyHandle, currentHandle);
 
                     foreach (var d in data)
                     {
+                        if (d.BlueskySubmittedBy == $"Submitted by @{d.BlueskyHandle}")
+                        {
+                            d.BlueskySubmittedBy = $"Submitted by @{currentHandle}";
+                        }
                         d.BlueskyHandle = currentHandle;
                     }
                 }
@@ -206,7 +333,7 @@ namespace SeattleCarsInBikeLanes.Controllers
             string tootBody = postBody;
             if (!string.IsNullOrWhiteSpace(metadata.MastodonSubmittedBy))
             {
-                if (metadata.MastodonSubmittedBy.StartsWith("Submitted by"))
+                if (metadata.MastodonSubmittedBy != "Submission")
                 {
                     tootBody += $"\n{metadata.MastodonSubmittedBy}";
                 }
@@ -242,7 +369,8 @@ namespace SeattleCarsInBikeLanes.Controllers
             List<BskyFacet> facets = new List<BskyFacet>();
             if (!string.IsNullOrWhiteSpace(metadata.BlueskySubmittedBy))
             {
-                if (metadata.BlueskySubmittedBy.StartsWith("Submitted by"))
+                if (!string.IsNullOrWhiteSpace(metadata.BlueskyHandle) && !string.IsNullOrWhiteSpace(metadata.BlueskyUserDid) &&
+                                                    metadata.BlueskySubmittedBy == $"Submitted by @{metadata.BlueskyHandle}")
                 {
                     string blueskyHandle = $"@{metadata.BlueskyHandle}";
                     skeetBody += $"\nSubmitted by {blueskyHandle}";
@@ -252,8 +380,8 @@ namespace SeattleCarsInBikeLanes.Controllers
                     {
                         Index = new BskyByteSlice()
                         {
-                            ByteStart = handleStartIndex,
-                            ByteEnd = handleStartIndex + blueskyHandle.Length
+                            ByteStart = Encoding.UTF8.GetByteCount(skeetBody[..handleStartIndex]),
+                            ByteEnd = Encoding.UTF8.GetByteCount(skeetBody[..(handleStartIndex + blueskyHandle.Length)])
                         },
                         Features = new List<BskyFeature>()
                         {
@@ -263,6 +391,10 @@ namespace SeattleCarsInBikeLanes.Controllers
                             }
                         }
                     });
+                }
+                else if (metadata.BlueskySubmittedBy != "Submission")
+                {
+                    skeetBody += $"\n{metadata.BlueskySubmittedBy}";
                 }
                 else if (!string.IsNullOrWhiteSpace(metadata.TwitterSubmittedBy) &&
                     metadata.TwitterSubmittedBy.StartsWith("Submitted by") &&
@@ -276,8 +408,8 @@ namespace SeattleCarsInBikeLanes.Controllers
                     {
                         Index = new BskyByteSlice()
                         {
-                            ByteStart = linkStartIndex,
-                            ByteEnd = linkStartIndex + twitterLink.Length
+                            ByteStart = Encoding.UTF8.GetByteCount(skeetBody[..linkStartIndex]),
+                            ByteEnd = Encoding.UTF8.GetByteCount(skeetBody[..(linkStartIndex + twitterLink.Length)])
                         },
                         Features = new List<BskyFeature>()
                         {
@@ -301,8 +433,8 @@ namespace SeattleCarsInBikeLanes.Controllers
                     {
                         Index = new BskyByteSlice()
                         {
-                            ByteStart = linkStartIndex,
-                            ByteEnd = linkStartIndex + mastodonLink.Length
+                            ByteStart = Encoding.UTF8.GetByteCount(skeetBody[..linkStartIndex]),
+                            ByteEnd = Encoding.UTF8.GetByteCount(skeetBody[..(linkStartIndex + mastodonLink.Length)])
                         },
                         Features = new List<BskyFeature>()
                         {
@@ -325,8 +457,8 @@ namespace SeattleCarsInBikeLanes.Controllers
                     {
                         Index = new BskyByteSlice()
                         {
-                            ByteStart = linkStartIndex,
-                            ByteEnd = linkStartIndex + threadsLink.Length
+                            ByteStart = Encoding.UTF8.GetByteCount(skeetBody[..linkStartIndex]),
+                            ByteEnd = Encoding.UTF8.GetByteCount(skeetBody[..(linkStartIndex + threadsLink.Length)])
                         },
                         Features = new List<BskyFeature>()
                         {
@@ -350,7 +482,7 @@ namespace SeattleCarsInBikeLanes.Controllers
             string threadsBody = postBody;
             if (!string.IsNullOrWhiteSpace(metadata.ThreadsSubmittedBy))
             {
-                if (metadata.ThreadsSubmittedBy.StartsWith("Submitted by"))
+                if (metadata.ThreadsSubmittedBy != "Submission")
                 {
                     threadsBody += $"\n{metadata.ThreadsSubmittedBy}";
                 }
@@ -379,89 +511,482 @@ namespace SeattleCarsInBikeLanes.Controllers
                 }
             }
 
-            List<BlobClient> photoBlobClients = new List<BlobClient>();
-            List<IImage> imgurUploads = new List<IImage>();
-            List<Stream> pictureStreams = new List<Stream>();
-
-            foreach (var d in data)
+            List<byte[]> photoBuffers = new List<byte[]>();
+            foreach (var photo in report.Photos)
             {
-                BlobClient photoBlobClient = blobContainerClient.GetBlobClient($"{UploadController.FinalizedUploadPrefix}{d.PhotoId}.jpeg");
-                photoBlobClients.Add(photoBlobClient);
-                var photoDownload = await photoBlobClient.DownloadContentAsync();
+                ValidatePhotoReference(photo);
+                BlobClient photoBlobClient = blobContainerClient.GetBlobClient(photo.BlobName);
+                var photoDownload = await photoBlobClient.DownloadContentAsync(new BlobDownloadOptions()
+                {
+                    Conditions = new BlobRequestConditions() { IfMatch = new ETag(photo.ETag) }
+                }, ct);
                 var photoBytes = photoDownload.Value.Content.ToArray();
-                pictureStreams.Add(new MemoryStream(photoBytes));
+                if (photoBytes.LongLength != photo.Length)
+                {
+                    throw new InvalidDataException("A stored photo has changed. Repair the report before publishing.");
+                }
+                photoBuffers.Add(photoBytes);
+                pictureStreams.Add(new MemoryStream(photoBytes, writable: false));
             }
 
             ReportedItem newReportedItem = new ReportedItem()
             {
-                TweetId = $"{Guid.NewGuid()}.0",
+                TweetId = $"{report.Receipt.ReportId}.0",
                 CreatedAt = DateTime.UtcNow,
                 NumberOfCars = metadata.NumberOfCars!.Value,
                 Date = DateOnly.FromDateTime(metadata.PhotoDateTime.Value),
                 Time = TimeOnly.FromDateTime(metadata.PhotoDateTime.Value),
                 LocationString = metadata.PhotoCrossStreet!,
-                Location = new Microsoft.Azure.Cosmos.Spatial.Point(double.Parse(metadata.PhotoLongitude!), double.Parse(metadata.PhotoLatitude!)),
+                Location = new Microsoft.Azure.Cosmos.Spatial.Point(double.Parse(metadata.PhotoLongitude!, CultureInfo.InvariantCulture), double.Parse(metadata.PhotoLatitude!, CultureInfo.InvariantCulture)),
                 TwitterLink = metadata.TwitterLink,
                 Latest = true
             };
 
             List<ReportedItem> reportedItems = new List<ReportedItem>() { newReportedItem };
 
-            List<string> imgurLinks = await UploadImagesToImgur(reportedItems, pictureStreams);
-            newReportedItem.ImgurUrls.AddRange(imgurUploads.Select(i => i.Link));
+            List<string> imgurLinks = await UploadImagesToImgur(reportedItems, pictureStreams,
+                () => externalEffectsStarting("Imgur upload"));
 
-            Task mastodonUploadTask = UploadPostToMastodon(mastodonClient, reportedItems, pictureStreams, tootBody, postBody);
-            Task blueskyUploadTask = UploadPostToBluesky(blueskyClient, reportedItems, pictureStreams, skeetBody, facets, postBody);
-            Task threadsUploadTask = UploadPostToThreads(threadsClient, reportedItems, imgurLinks, threadsBody);
-            await Task.WhenAll(mastodonUploadTask, blueskyUploadTask, threadsUploadTask);
-
-            bool addedToDatabase = await reportedItemsDatabase.AddReportedItem(newReportedItem);
-            if (!addedToDatabase)
+            // Independent cursors/lifetimes share the same immutable photo bytes.
+            List<Stream> mastodonStreams = new List<Stream>();
+            List<Stream> blueskyStreams = new List<Stream>();
+            foreach (byte[] bytes in photoBuffers)
             {
-                logger.LogError($"Failed to add tweet to database: {newReportedItem.TweetId}");
+                MemoryStream mastodonStream = new MemoryStream(bytes, writable: false);
+                MemoryStream blueskyStream = new MemoryStream(bytes, writable: false);
+                mastodonStreams.Add(mastodonStream);
+                blueskyStreams.Add(blueskyStream);
+                pictureStreams.Add(mastodonStream);
+                pictureStreams.Add(blueskyStream);
             }
+            externalEffectsStarting("social publication");
+            await Task.WhenAll(
+                UploadPostToMastodon(mastodonClient, reportedItems, mastodonStreams, tootBody, postBody, failOnError: true),
+                UploadPostToBluesky(blueskyClient, reportedItems, blueskyStreams, skeetBody, facets, postBody, failOnError: true),
+                UploadPostToThreads(threadsClient, reportedItems, imgurLinks, threadsBody, failOnError: true));
+            if (string.IsNullOrWhiteSpace(newReportedItem.MastodonLink) ||
+                string.IsNullOrWhiteSpace(newReportedItem.BlueskyLink) ||
+                string.IsNullOrWhiteSpace(newReportedItem.ThreadsLink))
+            {
+                throw new InvalidOperationException("One or more social publications were not confirmed.");
+            }
+            externalEffectsStarting("database persistence");
+            await reportedItemsDatabase.SavePublishedReportAsync(newReportedItem, ct);
 
+            externalEffectsStarting("feed persistence");
             await feedProvider.AddReportedItemToFeed(newReportedItem);
 
-            foreach (var d in data)
-            {
-                BlobClient metadataBlobClient = blobContainerClient.GetBlobClient($"{UploadController.FinalizedUploadPrefix}{d.PhotoId}.json");
-                await metadataBlobClient.DeleteAsync();
-            }
-
-            foreach (var photoBlobClient in photoBlobClients)
-            {
-                await photoBlobClient.DeleteAsync();
-            }
-
-            helperMethods.DisposePictureStreams(pictureStreams);
-
-            return NoContent();
         }
 
         [HttpDelete("/api/AdminPage/DeletePendingPhoto")]
-        public async Task DeletePendingPhoto([FromBody] List<FinalizedPhotoUploadMetadata> data)
+        public async Task<IActionResult> DeletePendingPhoto([FromBody] ModerateReportRequest request, CancellationToken ct = default)
         {
-            if (data.Count == 0)
+            SubmissionReport report;
+            try
             {
-                throw new Exception("Must pass at least 1 metadata object.");
+                report = await AcquireModerationAsync(request, "deleting", ct);
+            }
+            catch (Exception ex)
+            {
+                return ModerationError(ex);
+            }
+            try
+            {
+                await reportStore.RetireAsync(report.Receipt.ReportId, report.Moderation!.Id, ct);
+                await TryCleanupAsync();
+                return NoContent();
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Deletion could not be confirmed for {ReportId}, operation {OperationId}",
+                                                    report.Receipt.ReportId, report.Moderation!.Id);
+                return StatusCode(503, new
+                {
+                    message = "Deletion could not be confirmed. Fix the storage error shown in the logs, then refresh to check the saved report state.",
+                    reportId = report.Receipt.ReportId,
+                    operationId = report.Moderation.Id
+                });
+            }
+        }
+
+        private async Task<SubmissionReport> AcquireModerationAsync(ModerateReportRequest request, string kind, CancellationToken ct)
+        {
+            if (!ReportStore.IsValidReportId(request.ReportId) || string.IsNullOrWhiteSpace(request.ReportVersion))
+            {
+                throw new ArgumentException("A report ID and version are required. Refresh pending reports.");
+            }
+            if (request.PhotoIds is null || request.PhotoIds.Count == 0)
+            {
+                throw new ArgumentException("The complete ordered photo set is required.");
+            }
+            if (kind == "publishing" && request.Edits is null)
+            {
+                throw new ArgumentException("Publication corrections are required.");
+            }
+            if (kind == "publishing")
+            {
+                ValidateEdits(request.Edits!);
+            }
+            SubmissionReport report;
+            string? expectedVersion = request.ReportVersion;
+            if (request.ReportVersion.StartsWith("legacy:", StringComparison.Ordinal))
+            {
+                if (string.IsNullOrWhiteSpace(request.LegacySubmissionId) ||
+                                                    ReportStore.LegacyReportId(request.LegacySubmissionId) != request.ReportId)
+                {
+                    throw new ArgumentException("The saved submission does not match this report.");
+                }
+                if (await reportStore.ExistsAsync(request.ReportId, ct))
+                {
+                    throw new ModerationConflictException();
+                }
+                var group = (await ReadLegacyGroupsAsync(ct)).SingleOrDefault(g => g.ReportId == request.ReportId);
+                if (group is null || group.Version != request.ReportVersion)
+                {
+                    throw new ModerationConflictException();
+                }
+                if (group.Error is not null)
+                {
+                    throw new InvalidDataException(group.Error);
+                }
+                RequireWholePhotoSet(request.PhotoIds, group.Photos);
+                report = await reportStore.AdoptLegacyAsync(group.SubmissionId, group.Photos, ct);
+                expectedVersion = report.Version;
+            }
+            else
+            {
+                report = await reportStore.GetForModerationAsync(request.ReportId, ct);
             }
 
-            foreach (var metadata in data)
+            RequireWholePhotoSet(request.PhotoIds, report.Photos);
+            var overrides = kind == "publishing"
+                ? report.Photos.Select(p => ApplyEdits(p.Metadata, request.Edits!)).ToList()
+                : null;
+            return await reportStore.BeginModerationAsync(request.ReportId, kind, overrides, expectedVersion, ct);
+        }
+
+        private static void RequireWholePhotoSet(IReadOnlyList<string> ids, IReadOnlyList<SubmissionPhoto> photos)
+        {
+            if (!ids.SequenceEqual(photos.Select(p => p.Metadata.PhotoId), StringComparer.Ordinal))
             {
-                BlobClient photoBlobClient = blobContainerClient.GetBlobClient($"{UploadController.FinalizedUploadPrefix}{metadata.PhotoId}.jpeg");
-                BlobClient metadataBlobClient = blobContainerClient.GetBlobClient($"{UploadController.FinalizedUploadPrefix}{metadata.PhotoId}.json");
-                await photoBlobClient.DeleteAsync();
-                await metadataBlobClient.DeleteAsync();
+                throw new ArgumentException("The complete ordered photo set must match the saved report. Refresh pending reports.");
             }
-            Response.StatusCode = (int)HttpStatusCode.NoContent;
+        }
+
+        private static void ValidateEdits(AdminPublicationEdits edits)
+        {
+            UploadLimits limits = new UploadLimits();
+            if (edits.NumberOfCars < 1 || edits.PhotoDateTime == default ||
+                string.IsNullOrWhiteSpace(edits.PhotoCrossStreet) || edits.PhotoCrossStreet.Length > 500 ||
+                !double.TryParse(edits.PhotoLatitude, NumberStyles.Float, CultureInfo.InvariantCulture, out var latitude) ||
+                !double.TryParse(edits.PhotoLongitude, NumberStyles.Float, CultureInfo.InvariantCulture, out var longitude) ||
+                !double.IsFinite(latitude) || !double.IsFinite(longitude) ||
+                latitude < limits.SouthLatitude || latitude > limits.NorthLatitude ||
+                longitude < limits.WestLongitude || longitude > limits.EastLongitude)
+            {
+                throw new ArgumentException("Enter a positive car count, date/time, location and valid Seattle GPS coordinates.");
+            }
+            if (new[] { edits.TwitterSubmittedBy, edits.MastodonSubmittedBy, edits.BlueskySubmittedBy, edits.ThreadsSubmittedBy }
+                            .Any(value => value?.Length > 1000))
+            {
+                throw new ArgumentException("Attribution text must be at most 1,000 characters.");
+            }
+            if (!string.IsNullOrWhiteSpace(edits.TwitterLink) &&
+                            (edits.TwitterLink.Length > 2048 || !System.Uri.TryCreate(edits.TwitterLink, UriKind.Absolute, out var link) ||
+                             (link.Scheme != "https" && link.Scheme != "http")))
+            {
+                throw new ArgumentException("Twitter link must be an HTTP or HTTPS URL.");
+            }
+        }
+
+        private static FinalizedPhotoUploadMetadata ApplyEdits(FinalizedPhotoUploadMetadata source, AdminPublicationEdits edits)
+        {
+            var metadata = SanitizedCopy(source);
+            metadata.NumberOfCars = edits.NumberOfCars;
+            metadata.PhotoDateTime = edits.PhotoDateTime;
+            metadata.PhotoCrossStreet = edits.PhotoCrossStreet.Trim();
+            metadata.PhotoLatitude = edits.PhotoLatitude.Trim();
+            metadata.PhotoLongitude = edits.PhotoLongitude.Trim();
+            metadata.TwitterSubmittedBy = edits.TwitterSubmittedBy?.Trim() ?? "Submission";
+            metadata.MastodonSubmittedBy = edits.MastodonSubmittedBy?.Trim() ?? "Submission";
+            metadata.BlueskySubmittedBy = edits.BlueskySubmittedBy?.Trim() ?? "Submission";
+            metadata.ThreadsSubmittedBy = edits.ThreadsSubmittedBy?.Trim() ?? "Submission";
+            metadata.TwitterLink = edits.TwitterLink?.Trim();
+            return metadata;
+        }
+
+        private static FinalizedPhotoUploadMetadata SanitizedCopy(FinalizedPhotoUploadMetadata source)
+        {
+            return new FinalizedPhotoUploadMetadata()
+            {
+                PhotoId = source.PhotoId,
+                SubmissionId = source.SubmissionId,
+                PhotoNumber = source.PhotoNumber,
+                ReportId = source.ReportId,
+                DeviceId = source.DeviceId,
+                PhotoDateTime = source.PhotoDateTime,
+                PhotoLatitude = source.PhotoLatitude,
+                PhotoLongitude = source.PhotoLongitude,
+                PhotoCrossStreet = source.PhotoCrossStreet,
+                Tags = source.Tags?.Where(t => t is not null).Select(t => new ImageTag() { Name = t.Name, Confidence = t.Confidence }).ToList() ?? [],
+                NumberOfCars = source.NumberOfCars,
+                UserSpecifiedDateTime = source.UserSpecifiedDateTime,
+                UserSpecifiedLocation = source.UserSpecifiedLocation,
+                Attribute = source.Attribute,
+                TwitterSubmittedBy = source.TwitterSubmittedBy,
+                MastodonSubmittedBy = source.MastodonSubmittedBy,
+                BlueskySubmittedBy = source.BlueskySubmittedBy,
+                ThreadsSubmittedBy = source.ThreadsSubmittedBy,
+                TwitterUsername = source.TwitterUsername,
+                TwitterLink = source.TwitterLink,
+                MastodonEndpoint = source.MastodonEndpoint,
+                MastodonUsername = source.MastodonUsername,
+                MastodonFullUsername = source.MastodonFullUsername,
+                BlueskyHandle = source.BlueskyHandle,
+                BlueskyUserDid = source.BlueskyUserDid,
+                ThreadsUsername = source.ThreadsUsername
+            };
+        }
+
+        private static FinalizedPhotoUploadWithSasUriMetadata ToPreview(FinalizedPhotoUploadMetadata metadata)
+        {
+            return JsonConvert.DeserializeObject<FinalizedPhotoUploadWithSasUriMetadata>(JsonConvert.SerializeObject(SanitizedCopy(metadata)))!;
+        }
+
+        private async Task SetPreviewAsync(FinalizedPhotoUploadWithSasUriMetadata preview, SubmissionPhoto photo, CancellationToken ct)
+        {
+            try
+            {
+                ValidatePhotoReference(photo);
+                var blob = blobContainerClient.GetBlobClient(photo.BlobName);
+                var properties = await blob.GetPropertiesAsync(new BlobRequestConditions() { IfMatch = new ETag(photo.ETag) }, ct);
+                if (properties.Value.ContentLength != photo.Length)
+                {
+                    throw new InvalidDataException("The saved photo length has changed.");
+                }
+                var expiresOn = DateTimeOffset.UtcNow.AddHours(1);
+                if (string.IsNullOrEmpty(properties.Value.VersionId))
+                {
+                    preview.Uri = (blob.CanGenerateSasUri
+                                                                ? blob.GenerateSasUri(BlobSasPermissions.Read, expiresOn)
+                                                                : await blob.GenerateUserDelegationReadOnlySasUri(expiresOn)).ToString();
+                }
+                else
+                {
+                    BlobSasBuilder sas = new BlobSasBuilder(BlobSasPermissions.Read, expiresOn)
+                    {
+                        BlobContainerName = blob.BlobContainerName,
+                        BlobName = blob.Name,
+                        BlobVersionId = properties.Value.VersionId,
+                        Resource = "bv"
+                    };
+                    if (blob.CanGenerateSasUri)
+                    {
+                        preview.Uri = blob.WithVersion(properties.Value.VersionId).GenerateSasUri(sas).ToString();
+                    }
+                    else
+                    {
+                        var service = blob.GetParentBlobContainerClient().GetParentBlobServiceClient();
+                        var key = await service.GetUserDelegationKeyAsync(null, expiresOn, ct);
+                        preview.Uri = new BlobUriBuilder(blob.Uri)
+                        {
+                            VersionId = properties.Value.VersionId,
+                            Sas = sas.ToSasQueryParameters(key.Value, service.AccountName)
+                        }.ToUri().ToString();
+                    }
+                }
+            }
+            catch (Exception ex) when (ex is InvalidDataException || ex is RequestFailedException { Status: 404 or 412 })
+            {
+                preview.CanModerate = false;
+                preview.Warning = string.Join(" ", new[] { preview.Warning, $"Photo {photo.Metadata.PhotoNumber + 1} is missing, changed or invalid. Repair the stored report before moderation." }.Where(s => s is not null));
+                logger.LogWarning(ex, "Unavailable preview for {PhotoId}", photo.Metadata.PhotoId);
+            }
+        }
+
+        private static bool SafeSegment(string? value)
+        {
+            return !string.IsNullOrWhiteSpace(value) &&
+                                    value.Length <= 256 && value is not "." and not ".." &&
+                                    value.All(c => char.IsAsciiLetterOrDigit(c) || c is '-' or '_' or '.');
+        }
+
+        private static void ValidatePhotoReference(SubmissionPhoto photo)
+        {
+            if (!photo.BlobName.StartsWith(FinalizedUploadPrefix, StringComparison.Ordinal))
+            {
+                throw new InvalidDataException("Invalid stored JPEG reference.");
+            }
+            var parts = photo.BlobName[FinalizedUploadPrefix.Length..].Split('/');
+            if (string.IsNullOrWhiteSpace(photo.ETag) || photo.Length <= 0 ||
+                !photo.BlobName.EndsWith(".jpeg", StringComparison.Ordinal) || !parts.All(SafeSegment) ||
+                !(parts.Length == 1 || parts.Length == 4 &&
+                    photo.BlobName.StartsWith(ReportStore.PhotoPrefix, StringComparison.Ordinal)))
+            {
+                throw new InvalidDataException("Invalid stored JPEG reference.");
+            }
+        }
+
+        private async Task<List<LegacyGroup>> ReadLegacyGroupsAsync(CancellationToken ct)
+        {
+            Dictionary<string, LegacyGroup> groups = new Dictionary<string, LegacyGroup>(StringComparer.Ordinal);
+            bool unidentifiedCorruption = false;
+            await foreach (var blob in blobContainerClient.GetBlobsAsync(BlobTraits.None, BlobStates.None, FinalizedUploadPrefix, ct))
+            {
+                // Only flat per-photo sidecars use the original format, not nested report records.
+                if (!blob.Name.StartsWith(FinalizedUploadPrefix, StringComparison.Ordinal) ||
+                    blob.Name[FinalizedUploadPrefix.Length..].Contains('/') ||
+                    !blob.Name.EndsWith(".json", StringComparison.Ordinal))
+                {
+                    continue;
+                }
+                FinalizedPhotoUploadMetadata? metadata = null;
+                string? submissionId = null;
+                string? error = null;
+                string version = blob.Properties?.ETag?.ToString() ?? "";
+                try
+                {
+                    var content = await blobContainerClient.GetBlobClient(blob.Name).DownloadContentAsync(ct);
+                    version = content.Value.Details.ETag.ToString();
+                    var json = Newtonsoft.Json.Linq.JObject.Parse(content.Value.Content.ToString());
+                    var submissionToken = json.GetValue("SubmissionId", StringComparison.OrdinalIgnoreCase);
+                    submissionId = submissionToken?.Type == Newtonsoft.Json.Linq.JTokenType.String ? (string?)submissionToken : null;
+                    metadata = json.ToObject<FinalizedPhotoUploadMetadata>();
+                    if (metadata is null || string.IsNullOrWhiteSpace(submissionId) || !SafeSegment(metadata.PhotoId) ||
+                        blob.Name != $"{FinalizedUploadPrefix}{metadata.PhotoId}.json")
+                    {
+                        throw new InvalidDataException("Invalid legacy photo metadata or path.");
+                    }
+                }
+                catch (Exception ex) when (ex is JsonException or InvalidDataException || ex is RequestFailedException { Status: 404 })
+                {
+                    error = $"Saved metadata {blob.Name} is missing or corrupt. Repair the original JSON/JPEG pair before moderation.";
+                    logger.LogWarning(ex, "Invalid legacy sidecar {BlobName}", blob.Name);
+                    unidentifiedCorruption |= string.IsNullOrWhiteSpace(submissionId);
+                }
+
+                submissionId = string.IsNullOrWhiteSpace(submissionId) ? $"unreadable:{blob.Name}" : submissionId;
+                if (!groups.TryGetValue(submissionId, out var group))
+                {
+                    group = new LegacyGroup() { SubmissionId = submissionId };
+                    groups.Add(submissionId, group);
+                }
+                group.Versions.Add($"{blob.Name}:{version}");
+                group.Error ??= error;
+                group.Metadata.Add(SanitizedCopy(metadata ?? new FinalizedPhotoUploadMetadata()
+                {
+                    SubmissionId = submissionId,
+                    PhotoId = blob.Name,
+                    PhotoNumber = group.Metadata.Count,
+                    Tags = []
+                }));
+            }
+
+            List<LegacyGroup> result = new List<LegacyGroup>();
+            foreach (var group in groups.Values)
+            {
+                if (await reportStore.ExistsAsync(group.ReportId, ct))
+                {
+                    continue;
+                }
+                if (unidentifiedCorruption)
+                {
+                    group.Error ??= "Some saved JSON is unreadable and its report cannot be identified. Repair the flagged metadata before adopting legacy reports, so no photos are omitted.";
+                }
+                group.Metadata.Sort((a, b) => a.PhotoNumber.CompareTo(b.PhotoNumber));
+                if (group.Metadata.Count > 4 || group.Metadata.Select(p => p.PhotoId).Distinct().Count() != group.Metadata.Count ||
+                    !group.Metadata.Select(p => p.PhotoNumber).SequenceEqual(Enumerable.Range(0, group.Metadata.Count)))
+                {
+                    group.Error ??= "Saved photo numbering is incomplete or duplicated. Repair the original report before moderation.";
+                }
+                foreach (var metadata in group.Metadata)
+                {
+                    if (!SafeSegment(metadata.PhotoId))
+                    {
+                        continue;
+                    }
+                    try
+                    {
+                        string name = $"{FinalizedUploadPrefix}{metadata.PhotoId}.jpeg";
+                        var properties = await blobContainerClient.GetBlobClient(name).GetPropertiesAsync(cancellationToken: ct);
+                        SubmissionPhoto photo = new SubmissionPhoto(metadata, name, properties.Value.ETag.ToString(), properties.Value.ContentLength);
+                        ValidatePhotoReference(photo);
+                        group.Photos.Add(photo);
+                        group.Versions.Add($"{name}:{photo.ETag}:{photo.Length}");
+                    }
+                    catch (Exception ex) when (ex is InvalidDataException || ex is RequestFailedException { Status: 404 })
+                    {
+                        group.Error ??= $"Saved photo {metadata.PhotoId} is missing or invalid. Restore the original JPEG before moderation.";
+                        logger.LogWarning(ex, "Invalid legacy JPEG {PhotoId}", metadata.PhotoId);
+                    }
+                }
+                result.Add(group);
+            }
+            return result;
+        }
+
+        private async Task TryCleanupAsync()
+        {
+            try
+            {
+                await reportStore.CleanupAsync(CancellationToken.None);
+            }
+            catch (Exception ex)
+            {
+                logger.LogWarning(ex, "Retired report cleanup will be retried.");
+            }
+        }
+
+        private IActionResult ModerationError(Exception ex)
+        {
+            if (ex is ModerationConflictException or ReportConflictException or ReportInProgressException || ex is RequestFailedException { Status: 409 or 412 })
+            {
+                return Conflict(new
+                {
+                    message = "This report changed or has an operation in progress. Refresh pending reports before taking action."
+                });
+            }
+            if (ex is ArgumentException or InvalidDataException)
+            {
+                return BadRequest(new
+                {
+                    message = ex.Message
+                });
+            }
+            if (ex is KeyNotFoundException || ex is RequestFailedException { Status: 404 })
+            {
+                return NotFound(new
+                {
+                    message = "This pending report is no longer available. Refresh pending reports."
+                });
+            }
+            logger.LogError(ex, "Could not acquire report moderation");
+            return StatusCode(503, new
+            {
+                message = "Report storage is unavailable or moderation could not be confirmed. Refresh before retrying."
+            });
+        }
+
+        private sealed class LegacyGroup
+        {
+            public required string SubmissionId { get; init; }
+            public string ReportId => ReportStore.LegacyReportId(SubmissionId);
+            public string Version => "legacy:" + Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(string.Join("\n", Versions.Order(StringComparer.Ordinal))))).ToLowerInvariant();
+            public List<string> Versions { get; } = [];
+            public List<FinalizedPhotoUploadMetadata> Metadata { get; } = [];
+            public List<SubmissionPhoto> Photos { get; } = [];
+            public string? Error { get; set; }
+        }
+
+        private sealed class ModerationConflictException : Exception
+        {
         }
 
         [HttpPost("/api/AdminPage/PostTweet")]
         public async Task<IActionResult> PostTweet([FromBody] PostTweetRequest request)
         {
             if (string.IsNullOrWhiteSpace(request.PostUrl) &&
-                string.IsNullOrWhiteSpace(request.TweetBody) && string.IsNullOrWhiteSpace(request.TweetImages) && string.IsNullOrWhiteSpace(request.TweetLink))
+                                        string.IsNullOrWhiteSpace(request.TweetBody) && string.IsNullOrWhiteSpace(request.TweetImages) && string.IsNullOrWhiteSpace(request.TweetLink))
             {
                 return BadRequest("Post URL or tweet body, tweet images, and tweet link is required.");
             }
@@ -706,59 +1231,59 @@ namespace SeattleCarsInBikeLanes.Controllers
                 switch (success.Posts[0].Embed)
                 {
                     case ViewRecordDef viewRecordDef:
-                    {
-                        switch (viewRecordDef.Record)
                         {
-                            case ViewRecord viewRecord:
+                            switch (viewRecordDef.Record)
                             {
-                                if (viewRecord.Embeds is null || viewRecord.Embeds.Count == 0)
-                                {
-                                    return BadRequest("No embeds found in skeet.");
-                                }
-                                switch (viewRecord.Embeds[0])
-                                {
-                                    case ViewImages viewImages:
+                                case ViewRecord viewRecord:
                                     {
-                                        imageLinks = viewImages.Images.Select(i => i.Fullsize).ToList();
-                                        break;
-                                    }
-                                    case ViewRecordWithMedia viewRecordWithMedia:
-                                    {
-                                        ViewImages? recordMediaImages = viewRecordWithMedia.Media as ViewImages;
-                                        if (recordMediaImages == null)
+                                        if (viewRecord.Embeds is null || viewRecord.Embeds.Count == 0)
                                         {
-                                            logger.LogError($"Media embedded in record is not a type ViewImages for post {request.PostUrl}");
-                                            return BadRequest("Media embedded in record is not a type ViewImages");
+                                            return BadRequest("No embeds found in skeet.");
                                         }
-                                        imageLinks = recordMediaImages.Images.Select(i => i.Fullsize).ToList();
+                                        switch (viewRecord.Embeds[0])
+                                        {
+                                            case ViewImages viewImages:
+                                                {
+                                                    imageLinks = viewImages.Images.Select(i => i.Fullsize).ToList();
+                                                    break;
+                                                }
+                                            case ViewRecordWithMedia viewRecordWithMedia:
+                                                {
+                                                    ViewImages? recordMediaImages = viewRecordWithMedia.Media as ViewImages;
+                                                    if (recordMediaImages == null)
+                                                    {
+                                                        logger.LogError($"Media embedded in record is not a type ViewImages for post {request.PostUrl}");
+                                                        return BadRequest("Media embedded in record is not a type ViewImages");
+                                                    }
+                                                    imageLinks = recordMediaImages.Images.Select(i => i.Fullsize).ToList();
+                                                    break;
+                                                }
+                                            default:
+                                                break;
+                                        }
                                         break;
                                     }
-                                    default:
-                                        break;
-                                }
-                                break;
+                                default:
+                                    break;
                             }
-                            default:
-                                break;
+                            break;
                         }
-                        break;
-                    }
                     case ViewImages viewImages:
-                    {
-                        imageLinks = viewImages.Images.Select(i => i.Fullsize).ToList();
-                        break;
-                    }
-                    case ViewRecordWithMedia viewRecordWithMedia:
-                    {
-                        ViewImages? recordMediaImages = viewRecordWithMedia.Media as ViewImages;
-                        if (recordMediaImages == null)
                         {
-                            logger.LogError($"Media embedded in record is not a type ViewImages for post {request.PostUrl}");
-                            return BadRequest("Media embedded in record is not a type ViewImages");
+                            imageLinks = viewImages.Images.Select(i => i.Fullsize).ToList();
+                            break;
                         }
-                        imageLinks = recordMediaImages.Images.Select(i => i.Fullsize).ToList();
-                        break;
-                    }
+                    case ViewRecordWithMedia viewRecordWithMedia:
+                        {
+                            ViewImages? recordMediaImages = viewRecordWithMedia.Media as ViewImages;
+                            if (recordMediaImages == null)
+                            {
+                                logger.LogError($"Media embedded in record is not a type ViewImages for post {request.PostUrl}");
+                                return BadRequest("Media embedded in record is not a type ViewImages");
+                            }
+                            imageLinks = recordMediaImages.Images.Select(i => i.Fullsize).ToList();
+                            break;
+                        }
                     default:
                         logger.LogError($"Unexpected Bluesky embed type {success.Posts[0].Embed!.Type} on post {request.PostUrl}");
                         break;
@@ -809,7 +1334,8 @@ namespace SeattleCarsInBikeLanes.Controllers
             List<ReportedItem> reportedItems,
             List<Stream> pictureStreams,
             string mastodonText,
-            string originalPostBody)
+            string originalPostBody,
+            bool failOnError = false)
         {
             List<string> attachmentIds = new List<string>();
 
@@ -821,9 +1347,14 @@ namespace SeattleCarsInBikeLanes.Controllers
                     MastodonAttachment? attachment = await mastodonClient.UploadMedia(stream);
                     attachmentIds.Add(attachment.Id);
                     string attachmentId = attachment.Id;
+                    DateTimeOffset processingDeadline = DateTimeOffset.UtcNow.AddMinutes(2);
                     do
                     {
                         attachment = await mastodonClient.GetAttachment(attachmentId);
+                        if (failOnError && attachment is null && DateTimeOffset.UtcNow >= processingDeadline)
+                        {
+                            throw new TimeoutException("Mastodon media processing was not confirmed.");
+                        }
                         await Task.Delay(500);
                     }
                     while (attachment == null);
@@ -831,6 +1362,10 @@ namespace SeattleCarsInBikeLanes.Controllers
                 catch (Exception ex)
                 {
                     logger.LogError(ex, $"Failed to upload image to Mastodon. Imgur links: {string.Join(' ', reportedItems[0].ImgurUrls)} Text {originalPostBody}");
+                    if (failOnError)
+                    {
+                        throw;
+                    }
                     return;
                 }
             }
@@ -847,6 +1382,10 @@ namespace SeattleCarsInBikeLanes.Controllers
             catch (Exception ex)
             {
                 logger.LogError(ex, $"Failed to publish Mastodon status. Imgur links: {string.Join(' ', reportedItems[0].ImgurUrls)} Attachment ids: {string.Join(' ', attachmentIds)} Text {originalPostBody}");
+                if (failOnError)
+                {
+                    throw;
+                }
                 return;
             }
         }
@@ -856,7 +1395,8 @@ namespace SeattleCarsInBikeLanes.Controllers
             List<Stream> pictureStreams,
             string skeetBody,
             List<BskyFacet> facets,
-            string originalPostBody)
+            string originalPostBody,
+            bool failOnError = false)
         {
             List<AtProtoBlob> blobs = new List<AtProtoBlob>();
             foreach (var stream in pictureStreams)
@@ -874,6 +1414,10 @@ namespace SeattleCarsInBikeLanes.Controllers
                 catch (Exception ex)
                 {
                     logger.LogError(ex, $"Failed to upload image to Bluesky. Imgur links: {string.Join(' ', reportedItems[0].ImgurUrls)} Text {originalPostBody}");
+                    if (failOnError)
+                    {
+                        throw;
+                    }
                     return;
                 }
             }
@@ -915,6 +1459,10 @@ namespace SeattleCarsInBikeLanes.Controllers
             catch (Exception ex)
             {
                 logger.LogError(ex, $"Failed to publish Bluesky status. Imgur links: {string.Join(' ', reportedItems[0].ImgurUrls)} Blob ids: {string.Join(' ', blobs.Select(b => b.Ref.Link))} Text {originalPostBody}");
+                if (failOnError)
+                {
+                    throw;
+                }
                 return;
             }
         }
@@ -922,15 +1470,16 @@ namespace SeattleCarsInBikeLanes.Controllers
         private async Task UploadPostToThreads(ThreadsClient threadsClient,
             List<ReportedItem> reportedItems,
             List<string> tweetImageLinks,
-            string threadsBody)
+            string threadsBody,
+            bool failOnError = false)
         {
             try
             {
                 if (tweetImageLinks.Count == 1)
                 {
                     string threadsMediaContainerId = await threadsClient.CreateThreadsMediaContainer("IMAGE",
-                        threadsBody,
-                        tweetImageLinks[0]);
+                                                                threadsBody,
+                                                                tweetImageLinks[0]);
                     // Threads API recommends waiting 30 seconds between creating the media container and publishing it
                     // but we'll check the container status API instead.
                     var containerStatus = await helperMethods.WaitForThreadsMediaContainer(threadsClient, threadsMediaContainerId);
@@ -952,11 +1501,11 @@ namespace SeattleCarsInBikeLanes.Controllers
                     foreach (var imageLink in tweetImageLinks)
                     {
                         string threadsMediaContainerId = await threadsClient.CreateThreadsMediaContainer("IMAGE",
-                            null,
-                            imageLink,
-                            null,
-                            null,
-                            true);
+                                                                            null,
+                                                                            imageLink,
+                                                                            null,
+                                                                            null,
+                                                                            true);
                         containerIds.Add(threadsMediaContainerId);
                     }
 
@@ -968,6 +1517,10 @@ namespace SeattleCarsInBikeLanes.Controllers
                         if (itemContainerStatus.Status != "FINISHED")
                         {
                             logger.LogError($"Failed to publish Threads status. Carousel item container {containerId} was in status {itemContainerStatus.Status} instead of FINISHED. Imgur links: {string.Join(' ', reportedItems[0].ImgurUrls)} Text {threadsBody}");
+                            if (failOnError)
+                            {
+                                throw new InvalidOperationException("Threads carousel processing was not confirmed.");
+                            }
                             return;
                         }
                     }
@@ -996,6 +1549,10 @@ namespace SeattleCarsInBikeLanes.Controllers
             catch (Exception ex)
             {
                 logger.LogError(ex, $"Failed to publish Threads status. Imgur links: {string.Join(' ', reportedItems[0].ImgurUrls)} Text {threadsBody}");
+                if (failOnError)
+                {
+                    throw;
+                }
                 return;
             }
         }
@@ -1300,7 +1857,7 @@ namespace SeattleCarsInBikeLanes.Controllers
                     string firstSkeetAtUri = GetAtUriLinkFromBlueskyLink(firstSkeetLink);
                     GetFeedPostsResponse mostCarsBlueskySkeetList = await blueskyClient.GetFeedPosts(new List<string>() { firstSkeetAtUri });
                     BskyPostView<BskyPost> mostCarsBlueskySkeet = mostCarsBlueskySkeetList.Posts[0];
-                    BskyFacet firstSkeetFacet = new BskyFacet
+                    BskyFacet firstSkeetFacet = new BskyFacet()
                     {
                         Index = new BskyByteSlice()
                         {
@@ -1366,7 +1923,7 @@ namespace SeattleCarsInBikeLanes.Controllers
                             string latestSkeetAtUri = GetAtUriLinkFromBlueskyLink(latestSkeetLink);
                             GetFeedPostsResponse latestSkeetBlueskySkeetList = await blueskyClient.GetFeedPosts(new List<string>() { latestSkeetAtUri });
                             BskyPostView<BskyPost> latestSkeetBlueskySkeet = latestSkeetBlueskySkeetList.Posts[0];
-                            BskyFacet latestSkeetFacet = new BskyFacet
+                            BskyFacet latestSkeetFacet = new BskyFacet()
                             {
                                 Index = new BskyByteSlice()
                                 {
@@ -1425,7 +1982,7 @@ namespace SeattleCarsInBikeLanes.Controllers
                 string secondSkeetAtUri = GetAtUriLinkFromBlueskyLink(secondSkeetLink);
                 GetFeedPostsResponse secondSkeetList = await blueskyClient.GetFeedPosts(new List<string>() { secondSkeetAtUri });
                 BskyPostView<BskyPost> secondSkeetPost = secondSkeetList.Posts[0];
-                BskyFacet secondSkeetFacet = new BskyFacet
+                BskyFacet secondSkeetFacet = new BskyFacet()
                 {
                     Index = new BskyByteSlice()
                     {
@@ -1518,7 +2075,7 @@ namespace SeattleCarsInBikeLanes.Controllers
                 if (!skipMostCars)
                 {
                     string firstCreationId = await threadsClient.CreateThreadsMediaContainer("TEXT",
-                        $"{introText}{mostCarsText} {GetSocialLinkForThreads(mostCars[0])}");
+                                                                $"{introText}{mostCarsText} {GetSocialLinkForThreads(mostCars[0])}");
                     var firstContainerStatus = await helperMethods.WaitForThreadsMediaContainer(threadsClient, firstCreationId);
                     if (firstContainerStatus.Status == "FINISHED")
                     {
@@ -1528,7 +2085,7 @@ namespace SeattleCarsInBikeLanes.Controllers
                 else
                 {
                     string firstCreationId = await threadsClient.CreateThreadsMediaContainer("TEXT",
-                        $"{introText}");
+                                                                $"{introText}");
                     var firstContainerStatus = await helperMethods.WaitForThreadsMediaContainer(threadsClient, firstCreationId);
                     if (firstContainerStatus.Status == "FINISHED")
                     {
@@ -1569,8 +2126,8 @@ namespace SeattleCarsInBikeLanes.Controllers
                 if (!skipWorstIntersection)
                 {
                     string thirdCreationId = await threadsClient.CreateThreadsMediaContainer("TEXT",
-                    $"{worstIntersectionText}",
-                    replyToId: secondThreadsPostId);
+                                                            $"{worstIntersectionText}",
+                                                            replyToId: secondThreadsPostId);
                     var thirdContainerStatus = await helperMethods.WaitForThreadsMediaContainer(threadsClient, thirdCreationId);
                     if (thirdContainerStatus.Status == "FINISHED")
                     {
@@ -1694,7 +2251,8 @@ namespace SeattleCarsInBikeLanes.Controllers
             return pictureStreams;
         }
 
-        private async Task<List<string>> UploadImagesToImgur(List<ReportedItem> reportedItems, List<Stream> pictureStreams)
+        private async Task<List<string>> UploadImagesToImgur(List<ReportedItem> reportedItems, List<Stream> pictureStreams,
+            Action? externalEffectsStarting = null)
         {
             List<string> imgurLinks = new List<string>();
             int currentImageCount = 0;
@@ -1718,7 +2276,7 @@ namespace SeattleCarsInBikeLanes.Controllers
                 }
 
                 // Create specific imgur stream because imgur upload disposes our stream
-                MemoryStream imgurStream = new MemoryStream();
+                using MemoryStream imgurStream = new MemoryStream();
                 await stream.CopyToAsync(imgurStream);
                 imgurStream.Position = 0;
                 stream.Position = 0;
@@ -1727,6 +2285,8 @@ namespace SeattleCarsInBikeLanes.Controllers
                 {
                     // Note there is a bug in the ImgurAPI package where when a rate limit is hit an exception
                     // will be thrown because the package doesn't process rate limits correctly.
+                    // A timeout after this boundary can still mean the upload was accepted.
+                    externalEffectsStarting?.Invoke();
                     imgurUpload = await imgurImageEndpoint.UploadImageAsync(imgurStream);
                 }
                 catch (Exception ex)
@@ -1824,6 +2384,13 @@ namespace SeattleCarsInBikeLanes.Controllers
         public class FinalizedPhotoUploadWithSasUriMetadata : FinalizedPhotoUploadMetadata
         {
             public string? Uri { get; set; }
+            public string? ReportVersion { get; set; }
+            public string? LegacySubmissionId { get; set; }
+            public string ModerationStatus { get; set; } = "pending";
+            public string? ModerationOperationId { get; set; }
+            public DateTimeOffset? ModerationStartedAt { get; set; }
+            public string? Warning { get; set; }
+            public bool CanModerate { get; set; } = true;
 
             // Here because of bug when trying to deserialize values types to nullable value type properties
             // See https://github.com/dotnet/runtime/issues/44428
@@ -1891,6 +2458,31 @@ namespace SeattleCarsInBikeLanes.Controllers
                     blueskyAccessJwt)
             {
             }
+        }
+
+        public sealed class ModerateReportRequest
+        {
+            public string ReportId { get; set; } = "";
+            public string ReportVersion { get; set; } = "";
+            public string? LegacySubmissionId { get; set; }
+            public List<string> PhotoIds { get; set; } = [];
+            public AdminPublicationEdits? Edits { get; set; }
+            public string? BlueskyAdminDid { get; set; }
+            public string? BlueskyAccessJwt { get; set; }
+        }
+
+        public sealed class AdminPublicationEdits
+        {
+            public int NumberOfCars { get; set; }
+            public DateTime PhotoDateTime { get; set; }
+            public string PhotoCrossStreet { get; set; } = "";
+            public string PhotoLatitude { get; set; } = "";
+            public string PhotoLongitude { get; set; } = "";
+            public string? TwitterSubmittedBy { get; set; }
+            public string? MastodonSubmittedBy { get; set; }
+            public string? BlueskySubmittedBy { get; set; }
+            public string? ThreadsSubmittedBy { get; set; }
+            public string? TwitterLink { get; set; }
         }
 
         public class PostTweetRequest

--- a/SeattleCarsInBikeLanes/Controllers/BlueskyAuthController.cs
+++ b/SeattleCarsInBikeLanes/Controllers/BlueskyAuthController.cs
@@ -196,7 +196,7 @@ namespace SeattleCarsInBikeLanes.Controllers
                 if (!string.Equals(did, loginState.ExpectedDid, StringComparison.Ordinal))
                 {
                     logger.LogError("Bluesky returned DID {ReturnedDid} but we requested {ExpectedDid}.",
-                        did, loginState.ExpectedDid);
+                                                                did, loginState.ExpectedDid);
                     await TryRevoke(agent, cancellationToken);
                     return LoginFailed("Bluesky authenticated a different account than the one requested.");
                 }
@@ -252,6 +252,20 @@ namespace SeattleCarsInBikeLanes.Controllers
                 result.Principal.FindFirstValue(BlueskyAuthDefaults.HandleClaim)));
         }
 
+        [HttpGet("/api/BlueskyAuth/native-me")]
+        [AllowAnonymous]
+        public async Task<IActionResult> NativeMe()
+        {
+            AuthenticateResult result = await HttpContext.AuthenticateAsync(BlueskyAuthDefaults.BearerScheme);
+            string? did = result.Principal?.FindFirstValue(BlueskyAuthDefaults.DidClaim);
+            string? handle = result.Principal?.FindFirstValue(BlueskyAuthDefaults.HandleClaim);
+            if (!result.Succeeded || string.IsNullOrWhiteSpace(did) || string.IsNullOrWhiteSpace(handle))
+            {
+                return Unauthorized();
+            }
+            return Ok(new Core.Contracts.CredentialIdentity(did, handle, result.Properties?.ExpiresUtc));
+        }
+
         /// <summary>
         /// Issues a bearer token for the signed in identity, for clients that cannot use cookies.
         /// </summary>
@@ -287,7 +301,7 @@ namespace SeattleCarsInBikeLanes.Controllers
         private static ClaimsPrincipal BuildPrincipal(string did, string handle, string authenticationScheme)
         {
             Claim[] claims = new[]
-            {
+                                    {
                 new Claim(BlueskyAuthDefaults.DidClaim, did),
                 new Claim(BlueskyAuthDefaults.HandleClaim, handle),
                 new Claim(ClaimTypes.NameIdentifier, did),

--- a/SeattleCarsInBikeLanes/Controllers/MastodonController.cs
+++ b/SeattleCarsInBikeLanes/Controllers/MastodonController.cs
@@ -89,8 +89,30 @@ namespace SeattleCarsInBikeLanes.Controllers
             return new MastodonUsernameResponse()
             {
                 Username = mastodonAccount.Username,
-                FullUsername = $"@{mastodonAccount.Username}@{endpoint.Host}"
+                FullUsername = $"@{mastodonAccount.Username}@{endpoint.Host}",
+                AccountId = mastodonAccount.Id
             };
+        }
+
+        [HttpPost("NativeIdentity")]
+        public async Task<IActionResult> NativeIdentity([FromBody] MastodonUsernameRequest request,
+            [FromServices] MastodonCredentialVerifier verifier, CancellationToken cancellationToken)
+        {
+            try
+            {
+                VerifiedMastodonAccount account = await verifier.VerifyAsync(request.ServerUrl,
+                                                    request.AccessToken, cancellationToken);
+                return Ok(account);
+            }
+            catch (CredentialRejectedException)
+            {
+                return Unauthorized();
+            }
+            catch (Exception ex) when (ex is ProviderUnavailableException or HttpRequestException or System.Text.Json.JsonException ||
+                ex is OperationCanceledException && !cancellationToken.IsCancellationRequested)
+            {
+                return StatusCode(StatusCodes.Status503ServiceUnavailable);
+            }
         }
 
         [HttpPost("redirect")]
@@ -119,6 +141,7 @@ namespace SeattleCarsInBikeLanes.Controllers
 
         public class MastodonUsernameResponse
         {
+            public string AccountId { get; set; } = string.Empty;
             public string Username { get; set; } = string.Empty;
             public string FullUsername { get; set; } = string.Empty;
         }

--- a/SeattleCarsInBikeLanes/Controllers/UploadController.cs
+++ b/SeattleCarsInBikeLanes/Controllers/UploadController.cs
@@ -1,19 +1,20 @@
-﻿using System.Diagnostics;
+using System.Globalization;
 using System.Security.Claims;
-using System.Text;
+using System.Text.Json;
+using System.Xml;
+using Azure;
 using Azure.AI.ContentSafety;
 using Azure.AI.Vision.ImageAnalysis;
 using Azure.Maps.Search;
 using Azure.Maps.Search.Models;
 using Azure.Storage.Blobs;
-using golf1052.Mastodon;
-using golf1052.Mastodon.Models.Accounts;
+using Azure.Storage.Blobs.Models;
 using ImageMagick;
-using LinqToTwitter;
-using LinqToTwitter.OAuth;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.Azure.Cosmos.Spatial;
+using SeattleCarsInBikeLanes.Core.Contracts;
 using SeattleCarsInBikeLanes.Models;
 using SeattleCarsInBikeLanes.Providers;
 using SeattleCarsInBikeLanes.Storage.Models;
@@ -26,17 +27,23 @@ namespace SeattleCarsInBikeLanes.Controllers
     {
         public const string InitialUploadPrefix = "initialupload/";
         public const string FinalizedUploadPrefix = "finalizedupload/";
+        public const string DeviceIdHeader = "X-Device-Id";
+        public const string ReportIdHeader = "X-Report-Id";
+        public const int MaxPhotosPerReport = 4;
+        // Preserve the existing request ceiling; original photos can exceed the prepared-JPEG limit.
+        private const long MaxInitialRequestBytes = 30_000_000;
 
         private readonly BoundingBox SeattleBoundingBox = new BoundingBox(
-            new Position(-122.436522, 47.495082),
-            new Position(-122.235787, 47.735525));
+            new Position(-122.436522, 47.495082), new Position(-122.235787, 47.735525));
         private readonly ILogger<UploadController> logger;
         private readonly ImageAnalysisClient imageAnalysisClient;
         private readonly ContentSafetyClient contentSafetyClient;
         private readonly MapsSearchClient mapsSearchClient;
         private readonly BlobContainerClient blobContainerClient;
-        private readonly MastodonClientProvider mastodonClientProvider;
+        private readonly MastodonCredentialVerifier mastodonVerifier;
         private readonly SlackbotProvider slackbotProvider;
+        private readonly DeviceBlocklistProvider deviceBlocklistProvider;
+        private readonly ReportStore reportStore;
         private readonly HelperMethods helperMethods;
 
         public UploadController(ILogger<UploadController> logger,
@@ -44,8 +51,10 @@ namespace SeattleCarsInBikeLanes.Controllers
             ContentSafetyClient contentSafetyClient,
             MapsSearchClient mapsSearchClient,
             BlobContainerClient blobContainerClient,
-            MastodonClientProvider mastodonClientProvider,
+            MastodonCredentialVerifier mastodonVerifier,
             SlackbotProvider slackbotProvider,
+            DeviceBlocklistProvider deviceBlocklistProvider,
+            ReportStore reportStore,
             HelperMethods helperMethods)
         {
             this.logger = logger;
@@ -53,621 +62,886 @@ namespace SeattleCarsInBikeLanes.Controllers
             this.contentSafetyClient = contentSafetyClient;
             this.mapsSearchClient = mapsSearchClient;
             this.blobContainerClient = blobContainerClient;
-            this.mastodonClientProvider = mastodonClientProvider;
+            this.mastodonVerifier = mastodonVerifier;
             this.slackbotProvider = slackbotProvider;
+            this.deviceBlocklistProvider = deviceBlocklistProvider;
+            this.reportStore = reportStore;
             this.helperMethods = helperMethods;
         }
 
-        [HttpPost("Initial")]
-        public async Task<IActionResult> UploadPhoto([FromForm]List<IFormFile> files)
+        private string? DeviceId => DeviceIdRules.Normalize(Request.Headers[DeviceIdHeader].ToString());
+
+        private string? ReportId => Request.Headers[ReportIdHeader].Count == 1 &&
+            ReportStore.IsValidReportId(Request.Headers[ReportIdHeader].ToString())
+                ? Request.Headers[ReportIdHeader].ToString() : null;
+
+        private bool ValidDeviceContext => !Request.Headers.ContainsKey(DeviceIdHeader) ||
+            Request.Headers[DeviceIdHeader].Count == 1 && DeviceIdRules.IsValid(DeviceId);
+
+        [HttpGet("Limits")]
+        public IActionResult GetLimits()
         {
-            if (Request.ContentLength == 0 || files == null || files.Count == 0)
+            return Ok(new UploadLimits()
             {
-                string error = "Error: No photo uploaded.";
-                logger.LogError(error);
-                return BadRequest(error);
-            }
-
-            if (files.Count > 4)
-            {
-                string error = "Cannot upload more than 4 images on a report";
-                logger.LogError(error);
-                return BadRequest(error);
-            }
-
-            string submissionId = helperMethods.GetRandomFileName();
-
-            List<Task<InitialPhotoUploadWithSasUriMetadata>> metadataTasks = new List<Task<InitialPhotoUploadWithSasUriMetadata>>();
-            List<InitialPhotoUploadWithSasUriMetadata> metadata = new List<InitialPhotoUploadWithSasUriMetadata>();
-            Dictionary<int, string> exceptions = new Dictionary<int, string>();
-            for (int i = 0; i < files.Count; i++)
-            {
-                IFormFile? file = files[i];
-                try
-                {
-                    metadataTasks.Add(ProcessInitialUpload(file, submissionId, i));
-                }
-                catch (Exception ex)
-                {
-                    exceptions.Add(i, ex.Message);
-                }
-            }
-
-            await Task.WhenAll(metadataTasks);
-
-            for (int i = 0; i < metadataTasks.Count; i++)
-            {
-                var metadataTask = metadataTasks[i];
-                if (metadataTask.IsFaulted)
-                {
-                    if (metadataTask.Exception != null)
-                    {
-                        if (exceptions.ContainsKey(i))
-                        {
-                            exceptions[i] += $"\n{metadataTask.Exception.Message}";
-                        }
-                        else
-                        {
-                            exceptions.Add(i, metadataTask.Exception.Message);
-                        }
-                    }
-                }
-                else
-                {
-                    metadata.Add(metadataTask.Result);
-                }
-            }
-
-            if (exceptions.Count > 0)
-            {
-                // return a bad request with a string containing each exception and the photo number on a new line
-                StringBuilder requestBuilder = new StringBuilder();
-                foreach (var exception in exceptions)
-                {
-                    requestBuilder.AppendLine($"Photo {exception.Key + 1}: {exception.Value}");
-                }
-                string requestString = requestBuilder.ToString();
-                logger.LogError(requestString);
-                return BadRequest(requestString);
-            }
-
-            return Ok(metadata);
+                MaxPhotosPerReport = MaxPhotosPerReport,
+                MaxPhotoBytes = ReportStore.MaxPhotoBytes,
+                MaxReportBytes = ReportStore.MaxReportBytes,
+                SouthLatitude = SeattleBoundingBox.Min.Latitude,
+                WestLongitude = SeattleBoundingBox.Min.Longitude,
+                NorthLatitude = SeattleBoundingBox.Max.Latitude,
+                EastLongitude = SeattleBoundingBox.Max.Longitude
+            });
         }
 
-        private async Task<InitialPhotoUploadWithSasUriMetadata> ProcessInitialUpload(IFormFile file, string submissionId, int index)
+        [HttpPost("Initial")]
+        [RequestSizeLimit(MaxInitialRequestBytes)]
+        [RequestFormLimits(MultipartBodyLengthLimit = MaxInitialRequestBytes)]
+        public async Task<IActionResult> UploadPhoto([FromForm] List<IFormFile> files,
+            CancellationToken cancellationToken = default)
         {
-            string tempFile = Path.GetTempFileName();
+            if (ReportId is not { } id || !ValidDeviceContext)
+            {
+                return BadRequest("A valid report ID and, when supplied, device ID are required.");
+            }
+            if (files is not { Count: > 0 and <= MaxPhotosPerReport })
+            {
+                return BadRequest("Upload one to four photos.");
+            }
+            if (files.Any(f => f is null || f.Length is <= 0 or > MaxInitialRequestBytes) ||
+                        files.Sum(f => f.Length) > MaxInitialRequestBytes)
+            {
+                return BadRequest("Upload nonempty photos within the 30 MB request limit.");
+            }
             try
             {
-                using var fileStream1 = System.IO.File.OpenWrite(tempFile);
-                await file.CopyToAsync(fileStream1);
-                fileStream1.Dispose();
-                DateTime? photoDate = GetPhotoDate(tempFile);
-                Position? photoLocation = GetPhotoLocation(tempFile);
-                if (photoLocation != null && !SeattleBoundingBox.Contains(photoLocation))
+                // Reusing an ID must never rebind an existing report to another installation.
+                await reportStore.GetAsync(id, DeviceId, cancellationToken);
+                if (await deviceBlocklistProvider.IsBlocked(DeviceId, cancellationToken))
                 {
-                    string lat = photoLocation.Latitude.ToString("#.#####");
-                    string lon = photoLocation.Longitude.ToString("#.#####");
-                    throw new BikeLaneException($"Error: Photo not taken in Seattle. The location on the photo is " +
-                        $"<a href=\"https://bing.com/maps?cp={photoLocation.Latitude}~{photoLocation.Longitude}&lvl=13&sp=point.{photoLocation.Latitude}_{photoLocation.Longitude}_Photo%20location___\" target=\"_blank\">{lat}, {lon}</a>");
+                    return StatusCode(StatusCodes.Status403Forbidden, "This device can't submit reports.");
                 }
-
-                // Ensure image is jpeg and is small enough to upload to Computer Vision
-                string tempFile2 = Path.GetTempFileName();
-                using var jpeg = new MagickImage(tempFile);
-                jpeg.Format = MagickFormat.Jpeg;
-                if (jpeg.Width > jpeg.Height && jpeg.Width > 1920)
+                string submissionId = helperMethods.GetRandomFileName();
+                async Task<(InitialPhotoUpload? Photo, string? Error)> Prepare(IFormFile file, int index)
                 {
-                    jpeg.Resize(1920, 1080);
-                }
-                else if (jpeg.Height > jpeg.Width && jpeg.Height > 1920)
-                {
-                    jpeg.Resize(1080, 1920);
-                }
-                await jpeg.WriteAsync(tempFile2);
-                jpeg.Dispose();
-                System.IO.File.Delete(tempFile);
-                tempFile = tempFile2;
-                using var fileStream2 = System.IO.File.OpenRead(tempFile);
-
-                Task<Azure.Response<AnalyzeImageResult>> contentSafetyAnalyzeImageTask = contentSafetyClient.AnalyzeImageAsync(BinaryData.FromStream(fileStream2));
-                fileStream2.Seek(0, SeekOrigin.Begin);
-                Task<Azure.Response<ImageAnalysisResult>> analyzeImageTask = imageAnalysisClient.AnalyzeAsync(BinaryData.FromStream(fileStream2), VisualFeatures.Tags);
-
-                Task<ReverseSearchCrossStreetAddressResultItem?>? crossStreetItemTask = null;
-                if (photoLocation != null)
-                {
-                    crossStreetItemTask = helperMethods.ReverseSearchCrossStreet(photoLocation, mapsSearchClient);
-                }
-
-                // No idea why this is not detected as null free since we're doing the filter
-                await Task.WhenAll(new List<Task?>() { crossStreetItemTask, contentSafetyAnalyzeImageTask, analyzeImageTask }.Where(t => t != null)!);
-
-                fileStream2.Dispose();
-
-                AnalyzeImageResult contentSafetyAnalyzeImageResult = contentSafetyAnalyzeImageTask.Result.Value;
-                ImageCategoriesAnalysis? hateCategory = contentSafetyAnalyzeImageResult.CategoriesAnalysis.FirstOrDefault(c => c.Category == ImageCategory.Hate);
-                ImageCategoriesAnalysis? selfHarmCategory = contentSafetyAnalyzeImageResult.CategoriesAnalysis.FirstOrDefault(c => c.Category == ImageCategory.SelfHarm);
-                ImageCategoriesAnalysis? sexualCategory = contentSafetyAnalyzeImageResult.CategoriesAnalysis.FirstOrDefault(c => c.Category == ImageCategory.Sexual);
-                ImageCategoriesAnalysis? violenceCategory = contentSafetyAnalyzeImageResult.CategoriesAnalysis.FirstOrDefault(c => c.Category == ImageCategory.Violence);
-                if ((hateCategory != null && hateCategory.Severity > 2) ||
-                    (selfHarmCategory != null && selfHarmCategory.Severity > 2) ||
-                    (sexualCategory != null && sexualCategory.Severity > 2) ||
-                    (violenceCategory != null && violenceCategory.Severity > 2))
-                {
-                    logger.LogWarning($"Photo does not pass content check. Analysis results: " +
-                    $"Hate: {hateCategory?.Severity}, Self Harm: {selfHarmCategory?.Severity}, Sexual: {sexualCategory?.Severity}, Violence: {violenceCategory?.Severity}");
-                    throw new BikeLaneException("Error: Photo does not pass content check.");
-                }
-
-                ImageAnalysisResult analyzeImageResult = analyzeImageTask.Result.Value;
-                static List<ImageTag> AzureTagToImageTag(IReadOnlyList<DetectedTag> tags)
-                {
-                    List<ImageTag> imageTags = new List<ImageTag>();
-                    foreach (var tag in tags)
+                    try
                     {
-                        imageTags.Add(new ImageTag()
-                        {
-                            Name = tag.Name,
-                            Confidence = tag.Confidence
-                        });
+                        return (await ProcessInitialUpload(file, submissionId, id, DeviceId, index, cancellationToken), null);
                     }
-                    return imageTags;
+                    catch (BikeLaneException ex)
+                    {
+                        return (null, $"Photo {index + 1}: {ex.Message}");
+                    }
+                    catch (MagickException)
+                    {
+                        return (null, $"Photo {index + 1}: The file could not be read as an image.");
+                    }
                 }
 
-                ReverseSearchCrossStreetAddressResultItem? crossStreetItem = null;
-                string? crossStreet = null;
-                if (crossStreetItemTask != null)
+                // Catch validation in each task, but let cancellation and infrastructure failures escape.
+                var prepared = await Task.WhenAll(files.Select(Prepare));
+                string[] errors = prepared.Where(p => p.Error is not null).Select(p => p.Error!).ToArray();
+                return errors.Length > 0
+                    ? BadRequest(string.Join("\n", errors))
+                    : Ok(prepared.Select(p => p.Photo!).ToArray());
+            }
+            catch (UnauthorizedAccessException)
+            {
+                return StatusCode(StatusCodes.Status403Forbidden);
+            }
+            catch (ReportInProgressException ex)
+            {
+                return InProgress(ex);
+            }
+            catch (Exception ex) when (IsUnavailable(ex, cancellationToken))
+            {
+                return Unavailable("Photo preparation is temporarily unavailable. Please retry.");
+            }
+        }
+
+        private async Task<InitialPhotoUpload> ProcessInitialUpload(IFormFile file, string submissionId,
+            string reportId, string? deviceId, int index, CancellationToken cancellationToken)
+        {
+            using Stream input = file.OpenReadStream();
+            using var original = await ReadBoundedAsync(input, MaxInitialRequestBytes, cancellationToken);
+            if (original.Length != file.Length)
+            {
+                throw new BikeLaneException("The uploaded image length changed.");
+            }
+            using var image = new MagickImage(original);
+            (DateTime? photoDate, Position? photoLocation) = GetPhotoMetadata(image);
+            if (photoLocation is not null && (!double.IsFinite(photoLocation.Latitude) ||
+                !double.IsFinite(photoLocation.Longitude)))
+            {
+                throw new BikeLaneException("The photo's location metadata is invalid.");
+            }
+            if (photoLocation is not null && !SeattleBoundingBox.Contains(photoLocation))
+            {
+                string latitude = photoLocation.Latitude.ToString("G", CultureInfo.InvariantCulture);
+                string longitude = photoLocation.Longitude.ToString("G", CultureInfo.InvariantCulture);
+                string label = $"{photoLocation.Latitude.ToString("0.#####", CultureInfo.InvariantCulture)}, " +
+                    photoLocation.Longitude.ToString("0.#####", CultureInfo.InvariantCulture);
+                throw new BikeLaneException("Photo not taken in Seattle. The location on the photo is " +
+                    $"<a href=\"https://bing.com/maps?cp={latitude}~{longitude}&amp;lvl=13&amp;sp=point.{latitude}_{longitude}_Photo%20location___\" " +
+                    $"target=\"_blank\" rel=\"noopener noreferrer\">{label}</a>");
+            }
+
+            image.Format = MagickFormat.Jpeg;
+            if (image.Width >= image.Height && image.Width > 1920)
+            {
+                image.Resize(1920, 1080);
+            }
+            else if (image.Height > image.Width && image.Height > 1920)
+            {
+                image.Resize(1080, 1920);
+            }
+            using var jpeg = new MemoryStream();
+            await image.WriteAsync(jpeg, cancellationToken);
+            if (jpeg.Length is <= 0 or > ReportStore.MaxPhotoBytes)
+            {
+                throw new BikeLaneException("The prepared image must be no larger than 8 MiB.");
+            }
+            BinaryData bytes = new BinaryData(jpeg.GetBuffer().AsMemory(0, checked((int)jpeg.Length)));
+
+            Task<Response<AnalyzeImageResult>> safetyTask =
+                contentSafetyClient.AnalyzeImageAsync(bytes, cancellationToken: cancellationToken);
+            Task<Response<ImageAnalysisResult>> analysisTask =
+                imageAnalysisClient.AnalyzeAsync(bytes, VisualFeatures.Tags, cancellationToken: cancellationToken);
+            Task<ReverseSearchCrossStreetAddressResultItem?> crossStreetTask = photoLocation is null
+                ? Task.FromResult<ReverseSearchCrossStreetAddressResultItem?>(null)
+                : helperMethods.ReverseSearchCrossStreet(photoLocation, mapsSearchClient).WaitAsync(cancellationToken);
+            await Task.WhenAll(safetyTask, analysisTask, crossStreetTask);
+            if (safetyTask.Result.Value.CategoriesAnalysis.Any(c => c.Severity > 2))
+            {
+                throw new BikeLaneException("Photo does not pass content check.");
+            }
+            if (photoLocation is not null && crossStreetTask.Result is null)
+            {
+                throw new BikeLaneException("Could not determine cross street.");
+            }
+            string photoId = helperMethods.GetRandomFileName();
+            InitialPhotoUploadMetadata metadata = new InitialPhotoUploadMetadata()
+            {
+                PhotoId = photoId,
+                SubmissionId = submissionId,
+                ReportId = reportId,
+                DeviceId = deviceId,
+                PhotoNumber = index,
+                PhotoDateTime = photoDate,
+                PhotoLatitude = photoLocation?.Latitude.ToString("G", CultureInfo.InvariantCulture),
+                PhotoLongitude = photoLocation?.Longitude.ToString("G", CultureInfo.InvariantCulture),
+                PhotoCrossStreet = crossStreetTask.Result?.Address.StreetName,
+                Tags = analysisTask.Result.Value.Tags.Values.Select(t => new ImageTag()
                 {
-                    crossStreetItem = crossStreetItemTask.Result;
-                    if (crossStreetItem == null)
+                    Name = t.Name,
+                    Confidence = t.Confidence
+                }).ToList()
+            };
+            BlobClient photo = blobContainerClient.GetBlobClient($"{InitialUploadPrefix}{photoId}.jpeg");
+            BlobClient storedMetadata = blobContainerClient.GetBlobClient($"{InitialUploadPrefix}{photoId}.json");
+            await Task.WhenAll(
+                photo.UploadAsync(bytes, new BlobUploadOptions()
+                {
+                    Conditions = new BlobRequestConditions() { IfNoneMatch = ETag.All },
+                    HttpHeaders = new BlobHttpHeaders() { ContentType = "image/jpeg" }
+                }, cancellationToken),
+                storedMetadata.UploadAsync(new BinaryData(metadata), new BlobUploadOptions()
+                {
+                    Conditions = new BlobRequestConditions() { IfNoneMatch = ETag.All },
+                    HttpHeaders = new BlobHttpHeaders() { ContentType = "application/json" }
+                }, cancellationToken));
+            Uri preview = await photo.GenerateUserDelegationReadOnlySasUri(DateTimeOffset.UtcNow.AddMinutes(10));
+            return metadata.ToContract(preview.ToString());
+        }
+
+        private static async Task<MemoryStream> ReadBoundedAsync(Stream source, long maximum,
+            CancellationToken cancellationToken)
+        {
+            MemoryStream result = new MemoryStream();
+            try
+            {
+                byte[] buffer = new byte[8192];
+                int count;
+                while ((count = await source.ReadAsync(buffer, cancellationToken)) != 0)
+                {
+                    if (result.Length + count > maximum)
                     {
-                        throw new BikeLaneException("Error: Could not determine cross street.");
+                        throw new BikeLaneException("The uploaded data exceeds the size limit.");
+                    }
+                    result.Write(buffer, 0, count);
+                }
+                result.Position = 0;
+                return result;
+            }
+            catch
+            {
+                result.Dispose();
+                throw;
+            }
+        }
+
+        private (DateTime? Date, Position? Location) GetPhotoMetadata(MagickImage image)
+        {
+            DateTime? date = null;
+            double? latitude = null;
+            double? longitude = null;
+            try
+            {
+                IExifProfile? exif = image.GetExifProfile();
+                date = ReadExifDate(exif?.GetValue(ExifTag.DateTimeDigitized)?.Value) ??
+                    ReadExifDate(exif?.GetValue(ExifTag.DateTimeOriginal)?.Value);
+                latitude = ReadExifCoordinate(exif?.GetValue(ExifTag.GPSLatitude)?.Value,
+                    exif?.GetValue(ExifTag.GPSLatitudeRef)?.Value, latitude: true);
+                longitude = ReadExifCoordinate(exif?.GetValue(ExifTag.GPSLongitude)?.Value,
+                    exif?.GetValue(ExifTag.GPSLongitudeRef)?.Value, latitude: false);
+            }
+            catch (Exception ex) when (ex is MagickException or ArgumentException or FormatException)
+            {
+                logger.LogWarning("Malformed EXIF metadata could not be read; trying XMP for missing fields.");
+            }
+
+            if (date is null || latitude is null || longitude is null)
+            {
+                Dictionary<string, string> xmp = ReadXmp(image);
+                foreach (string field in new[] { "CreateDate", "DateTimeDigitized", "DateTimeOriginal" })
+                {
+                    if (date is not null)
+                    {
+                        break;
+                    }
+                    if (!xmp.TryGetValue(field, out string? text))
+                    {
+                        continue;
+                    }
+                    if (TryXmpDate(text, out DateTime value))
+                    {
+                        date = value;
                     }
                     else
                     {
-                        crossStreet = crossStreetItem.Address.StreetName;
+                        logger.LogWarning("Malformed XMP capture date in {Field} was ignored.", field);
                     }
                 }
+                latitude ??= ReadXmpCoordinate(xmp, latitude: true);
+                longitude ??= ReadXmpCoordinate(xmp, latitude: false);
+            }
+            return (date, latitude is { } lat && longitude is { } lon ? new Position(lon, lat) : null);
+        }
 
-                string randomFileName = helperMethods.GetRandomFileName();
-                InitialPhotoUploadMetadata metadata;
-                if (photoDate != null && photoLocation != null && crossStreet != null)
+        private DateTime? ReadExifDate(string? text)
+        {
+            if (string.IsNullOrWhiteSpace(text))
+            {
+                return null;
+            }
+            if (DateTime.TryParseExact(text.Trim(), "yyyy:MM:dd HH:mm:ss", CultureInfo.InvariantCulture,
+                        DateTimeStyles.None, out DateTime date))
+            {
+                return date;
+            }
+            logger.LogWarning("Malformed EXIF capture date was ignored.");
+            return null;
+        }
+
+        private double? ReadExifCoordinate(Rational[]? values, string? reference, bool latitude)
+        {
+            if (values is null && string.IsNullOrWhiteSpace(reference))
+            {
+                return null;
+            }
+            if (values?.Length == 3 && TryHemisphere(reference, latitude, out int sign) &&
+                        TryDegrees(values.Select(v => v.ToDouble()).ToArray(), latitude, out double degrees))
+            {
+                return sign * degrees;
+            }
+            logger.LogWarning("Malformed EXIF GPS {Coordinate} was ignored.", latitude ? "latitude" : "longitude");
+            return null;
+        }
+
+        private Dictionary<string, string> ReadXmp(MagickImage image)
+        {
+            const int maxXmpBytes = 256 * 1024;
+            try
+            {
+                IXmpProfile? profile = image.GetXmpProfile();
+                if (profile is null)
                 {
-                    metadata = new InitialPhotoUploadMetadata(randomFileName,
-                        submissionId,
-                        index,
-                        photoDate.Value,
-                        photoLocation.Latitude.ToString("#.#####"),
-                        photoLocation.Longitude.ToString("#.#####"),
-                        crossStreet,
-                        AzureTagToImageTag(analyzeImageResult.Tags.Values));
+                    return [];
                 }
-                else
+                if (profile.ToReadOnlySpan().Length > maxXmpBytes)
                 {
-                    metadata = new InitialPhotoUploadMetadata(randomFileName,
-                        submissionId,
-                        index,
-                        AzureTagToImageTag(analyzeImageResult.Tags.Values));
+                    logger.LogWarning("Oversized XMP metadata was ignored.");
+                    return [];
                 }
-
-                BlobClient photoBlobClient = blobContainerClient.GetBlobClient($"{InitialUploadPrefix}{randomFileName}.jpeg");
-                using var fileStream3 = System.IO.File.OpenRead(tempFile);
-                Task uploadPhotoTask = photoBlobClient.UploadAsync(fileStream3);
-
-                BlobClient metadataBlobClient = blobContainerClient.GetBlobClient($"{InitialUploadPrefix}{randomFileName}.json");
-                Task uploadMetadataTask = metadataBlobClient.UploadAsync(new BinaryData(metadata));
-
-                await Task.WhenAll(uploadPhotoTask, uploadMetadataTask);
-                fileStream3.Dispose();
-
-                Uri sasUri = await photoBlobClient.GenerateUserDelegationReadOnlySasUri(DateTimeOffset.UtcNow.AddMinutes(10));
-                return InitialPhotoUploadWithSasUriMetadata.FromMetadata(sasUri.ToString(), metadata);
+                using var stream = new MemoryStream(profile.ToByteArray());
+                using var reader = XmlReader.Create(stream, new XmlReaderSettings()
+                {
+                    DtdProcessing = DtdProcessing.Prohibit,
+                    XmlResolver = null,
+                    MaxCharactersInDocument = maxXmpBytes,
+                    MaxCharactersFromEntities = 1024,
+                    IgnoreComments = true,
+                    IgnoreProcessingInstructions = true
+                });
+                Dictionary<string, string> fields = new Dictionary<string, string>(StringComparer.Ordinal);
+                while (!reader.EOF)
+                {
+                    if (reader.Depth > 32)
+                    {
+                        throw new XmlException("XMP nesting exceeds the limit.");
+                    }
+                    if (reader.NodeType == XmlNodeType.Element)
+                    {
+                        if (IsCaptureXmpField(reader.NamespaceURI, reader.LocalName))
+                        {
+                            string name = reader.LocalName;
+                            fields.TryAdd(name, reader.ReadElementContentAsString().Trim());
+                            continue;
+                        }
+                        while (reader.MoveToNextAttribute())
+                        {
+                            if (IsCaptureXmpField(reader.NamespaceURI, reader.LocalName))
+                            {
+                                fields.TryAdd(reader.LocalName, reader.Value.Trim());
+                            }
+                        }
+                        reader.MoveToElement();
+                    }
+                    reader.Read();
+                }
+                return fields;
             }
-            catch (BikeLaneException ex)
+            catch (Exception ex) when (ex is XmlException or MagickException or ArgumentException)
             {
-                logger.LogError(ex, "Failure during photo upload.");
-                throw;
+                // XML exceptions can contain uploaded text or entity locations; never log their payload.
+                logger.LogWarning("Malformed or unsafe XMP metadata was ignored.");
+                return [];
             }
-            catch (Exception ex)
+        }
+
+        private static bool IsCaptureXmpField(string ns, string name)
+        {
+            return ns == "http://ns.adobe.com/xap/1.0/" && name == "CreateDate" ||
+                                    ns == "http://ns.adobe.com/exif/1.0/" && name is
+                                        "DateTimeDigitized" or "DateTimeOriginal" or "GPSLatitude" or "GPSLongitude" or
+                                        "GPSLatitudeRef" or "GPSLongitudeRef";
+        }
+
+        private static bool TryXmpDate(string text, out DateTime date)
+        {
+            date = default;
+            if (text.Length > 128)
             {
-                logger.LogError(ex, "Failure during photo upload");
-                throw new Exception("Failure during photo upload.");
+                return false;
             }
-            finally
+            string[] localFormats = ["yyyy-MM-dd'T'HH:mm:ss", "yyyy-MM-dd'T'HH:mm:ss.FFFFFFF",
+            "yyyy:MM:dd HH:mm:ss"];
+            if (DateTime.TryParseExact(text, localFormats, CultureInfo.InvariantCulture, DateTimeStyles.None, out date))
             {
-                System.IO.File.Delete(tempFile);
+                return true;
+            }
+            string withOffset = text.EndsWith('Z') ? text[..^1] + "+00:00" : text;
+            if (!DateTimeOffset.TryParseExact(withOffset,
+                ["yyyy-MM-dd'T'HH:mm:sszzz", "yyyy-MM-dd'T'HH:mm:ss.FFFFFFFzzz"],
+                CultureInfo.InvariantCulture, DateTimeStyles.None, out DateTimeOffset capture))
+            {
+                return false;
+            }        // The report form edits the camera's wall-clock date, not a date converted to server time.
+            date = capture.DateTime;
+            return true;
+        }
+
+        private double? ReadXmpCoordinate(Dictionary<string, string> fields, bool latitude)
+        {
+            string name = latitude ? "GPSLatitude" : "GPSLongitude";
+            if (!fields.TryGetValue(name, out string? text))
+            {
+                return null;
+            }
+            fields.TryGetValue(name + "Ref", out string? reference);
+            if (TryXmpCoordinate(text, reference, latitude, out double value))
+            {
+                return value;
+            }
+            logger.LogWarning("Malformed XMP GPS {Coordinate} was ignored.", latitude ? "latitude" : "longitude");
+            return null;
+        }
+
+        private static bool TryXmpCoordinate(string text, string? reference, bool latitude, out double coordinate)
+        {
+            coordinate = 0;
+            if (text.Length is 0 or > 128)
+            {
+                return false;
+            }
+            text = text.Trim();
+            if (text.Length == 0)
+            {
+                return false;
+            }
+            char suffix = char.ToUpperInvariant(text[^1]);
+            if (suffix is 'N' or 'S' or 'E' or 'W')
+            {
+                if (!string.IsNullOrWhiteSpace(reference) &&
+                                                    !string.Equals(reference.Trim(), suffix.ToString(), StringComparison.OrdinalIgnoreCase))
+                {
+                    return false;
+                }
+                reference = suffix.ToString();
+                text = text[..^1].Trim();
+            }
+            string[] parts = text.Replace("degrees", " ", StringComparison.OrdinalIgnoreCase)
+                .Replace("deg", " ", StringComparison.OrdinalIgnoreCase)
+                .Split([',', ' ', '\t', '\r', '\n', ':', '°', '\'', '"', '′', '″'],
+                    StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+            if (parts.Length is < 1 or > 3)
+            {
+                return false;
+            }
+            double[] values = new double[parts.Length];
+            for (int i = 0; i < parts.Length; i++)
+            {
+                string[] fraction = parts[i].Split('/');
+                if (fraction.Length is < 1 or > 2 ||
+                    !double.TryParse(fraction[0], NumberStyles.Float, CultureInfo.InvariantCulture, out values[i]))
+                {
+                    return false;
+                }
+                if (fraction.Length == 2)
+                {
+                    if (!double.TryParse(fraction[1], NumberStyles.Float, CultureInfo.InvariantCulture,
+                                                                out double denominator) || !double.IsFinite(denominator) || denominator <= 0)
+                    {
+                        return false;
+                    }
+                    values[i] /= denominator;
+                }
+            }
+            int sign = values[0] < 0 ? -1 : 1;
+            if (!string.IsNullOrWhiteSpace(reference))
+            {
+                if (!TryHemisphere(reference, latitude, out int hemisphere) || sign < 0 && hemisphere > 0)
+                {
+                    return false;
+                }
+                sign = hemisphere;
+            }
+            values[0] = Math.Abs(values[0]);
+            if (!TryDegrees(values, latitude, out double degrees))
+            {
+                return false;
+            }
+            coordinate = sign * degrees;
+            return true;
+        }
+
+        private static bool TryHemisphere(string? reference, bool latitude, out int sign)
+        {
+            string? hemisphere = reference?.Trim().ToUpperInvariant();
+            sign = hemisphere is "S" or "W" ? -1 : 1;
+            return latitude ? hemisphere is "N" or "S" : hemisphere is "E" or "W";
+        }
+
+        private static bool TryDegrees(double[] values, bool latitude, out double degrees)
+        {
+            degrees = 0;
+            if (values.Any(v => !double.IsFinite(v) || v < 0) ||
+                values.Skip(1).Any(v => v >= 60))
+            {
+                return false;
+            }
+            degrees = values[0] + (values.Length > 1 ? values[1] / 60 : 0) +
+                        (values.Length > 2 ? values[2] / 3600 : 0);
+            return degrees <= (latitude ? 90 : 180);
+        }
+
+        // Kept for existing callers; finalization uses the explicit attribution resolver instead.
+        [NonAction]
+        public async Task<bool?> ApplyBlueskyIdentity(List<FinalizedPhotoUploadMetadata> data)
+        {
+            AuthenticateResult auth = await HttpContext.AuthenticateAsync(BlueskyAuthDefaults.AnyScheme);
+            string? did = auth.Succeeded ? auth.Principal.FindFirstValue(BlueskyAuthDefaults.DidClaim) : null;
+            string? handle = auth.Succeeded ? auth.Principal.FindFirstValue(BlueskyAuthDefaults.HandleClaim) : null;
+            bool signedIn = !string.IsNullOrWhiteSpace(did) && !string.IsNullOrWhiteSpace(handle);
+            bool requested = data.Any(d => d.BlueskySubmittedBy?.StartsWith("Submitted by", StringComparison.Ordinal) == true);
+            foreach (var photo in data)
+            {
+                photo.BlueskyUserDid = signedIn ? did : null;
+                photo.BlueskyHandle = signedIn ? handle : null;
+                if (!signedIn && requested)
+                {
+                    photo.BlueskySubmittedBy = "Submission";
+                }
+            }
+            return requested && !signedIn ? false : signedIn ? true : null;
+        }
+
+        [HttpGet("Reports/{id}")]
+        public async Task<IActionResult> ReportStatus(string id, CancellationToken cancellationToken = default)
+        {
+            if (!ReportStore.IsValidReportId(id) || !ValidDeviceContext)
+            {
+                return BadRequest("A valid report ID and, when supplied, device ID are required.");
+            }
+            try
+            {
+                SubmissionReport? report = await reportStore.GetAsync(id, DeviceId, cancellationToken);
+                return report is null ? NotFound() : Ok(report.Receipt);
+            }
+            catch (UnauthorizedAccessException)
+            {
+                return StatusCode(StatusCodes.Status403Forbidden);
+            }
+            catch (ReportInProgressException ex)
+            {
+                return InProgress(ex);
+            }
+            catch (Exception ex) when (IsUnavailable(ex, cancellationToken))
+            {
+                return Unavailable("Report recovery is temporarily unavailable. Please retry.");
             }
         }
 
         [HttpPost("Finalize")]
-        public async Task<IActionResult> FinalizeUpload([FromBody] List<FinalizedPhotoUploadMetadata> data)
+        [RequestSizeLimit(256 * 1024)]
+        [ValidateFinalizationAfterReceipt]
+        public async Task<IActionResult> FinalizeUpload([FromBody] FinalizeReportRequest request,
+            CancellationToken cancellationToken = default)
         {
-            if (data.Count == 0)
+            if (ReportId is not { } id || !ValidDeviceContext)
             {
-                string error = "Expected at least 1 metadata object";
-                logger.LogError(error);
-                return BadRequest(error);
+                return BadRequest("A valid report ID and, when supplied, device ID are required.");
             }
-
-            FinalizedPhotoUploadMetadata metadata = data[0];
-            if (!metadata.PhotoDateTime.HasValue)
+            try
             {
-                string error = "Please select the date and time the report happened.";
-                logger.LogError(error);
-                return BadRequest(error);
-            }
-            if (string.IsNullOrWhiteSpace(metadata.PhotoLatitude) || string.IsNullOrEmpty(metadata.PhotoLongitude))
-            {
-                string error = "Please select the location the report happened.";
-                logger.LogError(error);
-                return BadRequest(error);
-            }
-            Position photoLocation = new Position(double.Parse(metadata.PhotoLongitude!), double.Parse(metadata.PhotoLatitude!));
-            if (!SeattleBoundingBox.Contains(photoLocation))
-            {
-                string error = "Photo not taken in Seattle.";
-                logger.LogError(error);
-                return BadRequest(error);
-            }
-
-            if (string.IsNullOrWhiteSpace(metadata.PhotoCrossStreet))
-            {
-                ReverseSearchCrossStreetAddressResultItem? crossStreetItem = null;
-                crossStreetItem = await helperMethods.ReverseSearchCrossStreet(photoLocation, mapsSearchClient);
-                if (crossStreetItem == null)
+                // The first receipt remains authoritative after credential expiry, cleanup and moderation.
+                SubmissionReport? existing = await reportStore.GetAsync(id, DeviceId, cancellationToken);
+                if (existing is not null)
                 {
-                    logger.LogWarning($"Couldn't find cross street for {metadata.PhotoLatitude}, {metadata.PhotoLongitude}");
+                    return Ok(existing.Receipt);
                 }
-                else
+                if (await deviceBlocklistProvider.IsBlocked(DeviceId, cancellationToken))
                 {
-                    foreach (var d in data)
+                    return StatusCode(StatusCodes.Status403Forbidden, "This device can't submit reports.");
+                }
+                if (request?.Photos is not { Count: > 0 and <= MaxPhotosPerReport } ||
+                    request.Attribution is null || request.Photos.Any(p => p is null))
+                {
+                    return BadRequest("A report needs one to four photos and explicit attribution.");
+                }
+                FinalizedPhotoUpload first = request.Photos[0];
+                if (!ValidReportFields(first, out double latitude, out double longitude) ||
+                    request.Photos.Any(p => !SameReportFields(first, p)))
+                {
+                    return BadRequest("All photos need the same date, Seattle location, positive car count and report fields.");
+                }
+                HashSet<string> ids = new HashSet<string>(StringComparer.Ordinal);
+                for (int i = 0; i < request.Photos.Count; i++)
+                {
+                    FinalizedPhotoUpload photo = request.Photos[i];
+                    if (!ValidPreparationId(photo.PhotoId) || !ValidPreparationId(photo.SubmissionId) ||
+                        !ids.Add(photo.PhotoId) || photo.PhotoNumber != i || photo.SubmissionId != first.SubmissionId)
                     {
-                        d.PhotoCrossStreet = crossStreetItem.Address.StreetName;
+                        return BadRequest("Invalid ordered prepared photo set.");
                     }
                 }
-            }
 
-            if (metadata.NumberOfCars == null || metadata.NumberOfCars < 1)
-            {
-                string error = "Number of cars must be at least 1.";
-                logger.LogError(error);
-                return BadRequest(error);
-            }
-
-            if (metadata.Attribute != null && metadata.Attribute.Value)
-            {
-                if (!string.IsNullOrWhiteSpace(metadata.TwitterAccessToken))
+                ReportAttribution intent;
+                try
                 {
-                    OAuth2Authorizer userAuth = new OAuth2Authorizer()
+                    intent = NormalizeAttribution(request.Attribution);
+                }
+                catch (ArgumentException)
+                {
+                    return BadRequest("Invalid report attribution.");
+                }
+                string? blueskyHandle = null;
+                if (intent.BlueskyDid is { } intendedDid)
+                {
+                    // An explicitly supplied bearer must never fall through to a different website account.
+                    bool bearerSupplied = Request.Headers.Authorization.Any(value =>
+                        value?.TrimStart() is { } header &&
+                        header.StartsWith("Bearer", StringComparison.OrdinalIgnoreCase) &&
+                        (header.Length == 6 || char.IsWhiteSpace(header[6])));
+                    AuthenticateResult auth = await HttpContext.AuthenticateAsync(bearerSupplied
+                        ? BlueskyAuthDefaults.BearerScheme : BlueskyAuthDefaults.CookieScheme);
+                    if (!auth.Succeeded)
                     {
-                        CredentialStore = new OAuth2CredentialStore()
+                        if (auth.Failure is not null && IsUnavailable(auth.Failure, cancellationToken))
                         {
-                            AccessToken = metadata.TwitterAccessToken
+                            return Unavailable("Bluesky could not verify the account. Please retry.");
                         }
-                    };
-                    TwitterContext twitterContext = new TwitterContext(userAuth);
+                        return RejectedCredential("The Bluesky credential is no longer valid.");
+                    }
+                    string? actualDid = auth.Principal.FindFirstValue(BlueskyAuthDefaults.DidClaim);
+                    blueskyHandle = auth.Principal.FindFirstValue(BlueskyAuthDefaults.HandleClaim);
+                    if (string.IsNullOrWhiteSpace(actualDid) || string.IsNullOrWhiteSpace(blueskyHandle))
+                    {
+                        return RejectedCredential("The Bluesky credential has no verified identity.");
+                    }
+                    if (!string.Equals(actualDid, intendedDid, StringComparison.Ordinal))
+                    {
+                        return Conflict(new UploadError(UploadErrors.IdentityMismatch,
+                            "The Bluesky credential does not match the selected account."));
+                    }
+                }
+
+                VerifiedMastodonAccount? mastodon = null;
+                if (intent.MastodonServer is { } server)
+                {
+                    if (string.IsNullOrWhiteSpace(first.MastodonAccessToken))
+                    {
+                        return RejectedCredential("The selected Mastodon account requires its credential.");
+                    }
+                    if (first.MastodonAccessToken.Length > 8192 || first.MastodonAccessToken.Any(char.IsControl) ||
+                        request.Photos.Any(p => p.MastodonAccessToken != first.MastodonAccessToken))
+                    {
+                        return BadRequest("Invalid report credentials.");
+                    }
+                    mastodon = await mastodonVerifier.VerifyAsync(server, first.MastodonAccessToken, cancellationToken);
+                    if (!string.Equals(mastodon.Id, intent.MastodonAccountId, StringComparison.Ordinal))
+                    {
+                        return Conflict(new UploadError(UploadErrors.IdentityMismatch,
+                            "The Mastodon credential does not match the selected account."));
+                    }
+                }
+
+                List<PreparedSubmissionPhoto> prepared = [];
+                long totalBytes = 0;
+                for (int i = 0; i < request.Photos.Count; i++)
+                {
+                    FinalizedPhotoUpload supplied = request.Photos[i];
+                    InitialPhotoUploadMetadata stored;
+                    BlobProperties properties;
+                    string sourceName = $"{InitialUploadPrefix}{supplied.PhotoId}.jpeg";
                     try
                     {
-                        TwitterUserQuery? response = await (from user in twitterContext.TwitterUser
-                                                            where user.Type == UserType.Me
-                                                            select user).SingleOrDefaultAsync();
-                        TwitterUser? twitterUser = response?.Users?.SingleOrDefault();
-                        if (twitterUser != null)
-                        {
-                            if (twitterUser.Username != null && metadata.TwitterUsername != null &&
-                                twitterUser.Username != metadata.TwitterUsername)
-                            {
-                                logger.LogWarning($"Metadata Twitter username dosen't match authenticated user." +
-                                    $"Metadata username: {metadata.TwitterUsername}. Auth username: {twitterUser.Username}.");
-
-                                foreach (var d in data)
-                                {
-                                    d.TwitterSubmittedBy = "Submission";
-                                    d.Attribute = false;
-                                    d.TwitterUsername = null;
-                                }
-                            }
-                        }
+                        stored = await ReadPreparationAsync(supplied.PhotoId, cancellationToken);
+                        properties = (await blobContainerClient.GetBlobClient(sourceName)
+                            .GetPropertiesAsync(cancellationToken: cancellationToken)).Value;
                     }
-                    catch (Exception ex)
+                    catch (RequestFailedException ex) when (IsMissingOrChangedPreparation(ex))
                     {
-                        logger.LogError(ex, "Failed to verify authenticated Twitter user.");
-                        foreach (var d in data)
-                        {
-                            d.TwitterSubmittedBy = "Submission";
-                            d.Attribute = false;
-                            d.TwitterUsername = null;
-                        }
+                        return PreparationExpired();
                     }
-                }
-
-                if (!string.IsNullOrWhiteSpace(metadata.MastodonEndpoint) && !string.IsNullOrWhiteSpace(metadata.MastodonAccessToken))
-                {
-                    Uri endpoint = new Uri(metadata.MastodonEndpoint);
-                    MastodonClient mastodonClient = await mastodonClientProvider.GetUserClient(endpoint, metadata.MastodonAccessToken);
-                    MastodonAccount mastodonAccount = await mastodonClient.VerifyCredentials();
-                    string mastodonUsername = $"@{mastodonAccount.Username}@{endpoint.Host}";
-                    if (mastodonUsername != metadata.MastodonFullUsername)
+                    if (stored.PhotoId != supplied.PhotoId || stored.PhotoNumber != i ||
+                        stored.SubmissionId != first.SubmissionId || stored.ReportId != id ||
+                        !string.Equals(stored.DeviceId, DeviceId, StringComparison.Ordinal))
                     {
-                        logger.LogWarning($"Metadata Mastodon username doesn't match authenticated user." +
-                            $"Metadata username: {metadata.MastodonFullUsername}. Auth username: {mastodonUsername}.");
-                        foreach (var d in data)
-                        {
-                            d.MastodonSubmittedBy = "Submission";
-                            d.Attribute = false;
-                            d.MastodonUsername = null;
-                            d.MastodonFullUsername = null;
-                        }
+                        return BadRequest("The prepared photos do not belong to this report and submitting context.");
                     }
-                }
-
-                bool? verifiedBlueskyUser = await ApplyBlueskyIdentity(data);
-                if (verifiedBlueskyUser.HasValue && !verifiedBlueskyUser.Value)
-                {
-                    foreach (var d in data)
+                    if (properties.ContentLength is <= 0 or > ReportStore.MaxPhotoBytes ||
+                        (totalBytes += properties.ContentLength) > ReportStore.MaxReportBytes)
                     {
-                        d.Attribute = false;
+                        return BadRequest("Prepared photos exceed the upload size limits.");
                     }
-                }
-            }
-            else
-            {
-                // Not attributing, so make sure nothing the client sent survives.
-                foreach (var d in data)
-                {
-                    d.BlueskyHandle = null;
-                    d.BlueskyUserDid = null;
-                }
-            }
-
-            foreach (var d in data)
-            {
-                // Clear all tokens and other sensitive info before saving to Azure
-                d.TwitterAccessToken = null;
-                d.MastodonAccessToken = null;
-                d.ThreadsAccessToken = null;
-
-                string randomFileName = d.PhotoId;
-                BlobClient photoBlobClient = blobContainerClient.GetBlobClient($"{InitialUploadPrefix}{randomFileName}.jpeg");
-                await photoBlobClient.Move($"{FinalizedUploadPrefix}{randomFileName}.jpeg");
-
-                BlobClient newMetadataBlobClient = blobContainerClient.GetBlobClient($"{FinalizedUploadPrefix}{randomFileName}.json");
-                await newMetadataBlobClient.UploadAsync(new BinaryData(d));
-
-                BlobClient metadataBlobClient = blobContainerClient.GetBlobClient($"{InitialUploadPrefix}{randomFileName}.json");
-                await metadataBlobClient.DeleteAsync();
-            }
-
-            // Ping me on Slack about the new submission
-            await slackbotProvider.SendSlackMessage($"New submission. {metadata.NumberOfCars} {helperMethods.GetCarsString(metadata.NumberOfCars.Value)} " +
-                $"@ {metadata.PhotoCrossStreet} submitted {DateTime.Now:s}");
-
-            return NoContent();
-        }
-
-        /// <summary>
-        /// Applies the signed in Bluesky identity to the submission.
-        /// </summary>
-        /// <remarks>
-        /// The identity comes from the authenticated principal, established when the user signed in
-        /// with Bluesky, and never from the request body.
-        /// </remarks>
-        public async Task<bool?> ApplyBlueskyIdentity(List<FinalizedPhotoUploadMetadata> data)
-        {
-            AuthenticateResult authentication =
-                await HttpContext.AuthenticateAsync(BlueskyAuthDefaults.AnyScheme);
-
-            string? did = authentication.Succeeded
-                ? authentication.Principal.FindFirstValue(BlueskyAuthDefaults.DidClaim)
-                : null;
-            string? handle = authentication.Succeeded
-                ? authentication.Principal.FindFirstValue(BlueskyAuthDefaults.HandleClaim)
-                : null;
-
-            bool signedIn = !string.IsNullOrWhiteSpace(did) && !string.IsNullOrWhiteSpace(handle);
-
-            // Whether or not the submission asked for Bluesky attribution, only a signed in user
-            // can receive it.
-            bool attributionRequested = data.Any(d =>
-                !string.IsNullOrWhiteSpace(d.BlueskySubmittedBy) &&
-                d.BlueskySubmittedBy.StartsWith("Submitted by", StringComparison.Ordinal));
-
-            foreach (var d in data)
-            {
-                if (signedIn)
-                {
-                    d.BlueskyHandle = handle;
-                    d.BlueskyUserDid = did;
-                }
-                else
-                {
-                    d.BlueskyHandle = null;
-                    d.BlueskyUserDid = null;
-
-                    if (attributionRequested)
+                    if (!string.Equals(properties.ContentType, "image/jpeg", StringComparison.OrdinalIgnoreCase) ||
+                        string.IsNullOrEmpty(properties.ETag.ToString()))
                     {
-                        d.BlueskySubmittedBy = "Submission";
+                        return BadRequest("The prepared source is not a versioned JPEG image.");
+                    }
+                    if (stored.Tags is null || stored.Tags.Count > 1024 ||
+                        stored.Tags.Any(t => t is null || t.Name is null || t.Name.Length > 1024 ||
+                            !float.IsFinite(t.Confidence)))
+                    {
+                        throw new InvalidDataException("Invalid stored analysis.");
+                    }
+                    // Construct an allowlist rather than copying client identity, tokens or admin fields.
+                    FinalizedPhotoUploadMetadata metadata = new FinalizedPhotoUploadMetadata()
+                    {
+                        PhotoId = $"{id}-{i}",
+                        SubmissionId = id,
+                        ReportId = id,
+                        DeviceId = DeviceId,
+                        PhotoNumber = i,
+                        PhotoDateTime = first.PhotoDateTime,
+                        PhotoLatitude = latitude.ToString("G", CultureInfo.InvariantCulture),
+                        PhotoLongitude = longitude.ToString("G", CultureInfo.InvariantCulture),
+                        PhotoCrossStreet = first.PhotoCrossStreet?.Trim(),
+                        NumberOfCars = first.NumberOfCars,
+                        UserSpecifiedDateTime = first.UserSpecifiedDateTime,
+                        UserSpecifiedLocation = first.UserSpecifiedLocation,
+                        Tags = stored.Tags,
+                        Attribute = !intent.IsAnonymous,
+                        TwitterSubmittedBy = "Submission",
+                        ThreadsSubmittedBy = "Submission",
+                        BlueskyUserDid = intent.BlueskyDid,
+                        BlueskyHandle = blueskyHandle,
+                        BlueskySubmittedBy = blueskyHandle is null ? "Submission" : $"Submitted by @{blueskyHandle}",
+                        MastodonEndpoint = mastodon?.Server,
+                        MastodonUsername = mastodon?.Username,
+                        MastodonFullUsername = mastodon?.FullUsername,
+                        MastodonSubmittedBy = mastodon is null ? "Submission" : $"Submitted by {mastodon.FullUsername}"
+                    };
+                    prepared.Add(new PreparedSubmissionPhoto(metadata, sourceName, properties.ETag.ToString(),
+                        properties.ContentLength));
+                }
+
+                if (string.IsNullOrWhiteSpace(first.PhotoCrossStreet))
+                {
+                    string? crossStreet = (await helperMethods.ReverseSearchCrossStreet(
+                        new Position(longitude, latitude), mapsSearchClient).WaitAsync(cancellationToken))?.Address.StreetName;
+                    foreach (PreparedSubmissionPhoto photo in prepared)
+                    {
+                        photo.Metadata.PhotoCrossStreet = crossStreet;
                     }
                 }
+                SubmissionReceipt receipt =
+                    await reportStore.CommitAsync(id, DeviceId, intent, prepared, cancellationToken);
+                try
+                {
+                    await slackbotProvider.SendSlackMessage(
+                        $"New submission. {first.NumberOfCars} car(s) @ {prepared[0].Metadata.PhotoCrossStreet}");
+                }
+                catch (Exception)
+                {
+                    logger.LogWarning("A report was accepted but its Slack notification failed.");
+                }
+                return Ok(receipt);
             }
-
-            if (attributionRequested && !signedIn)
+            catch (CredentialRejectedException)
             {
-                logger.LogWarning("Bluesky attribution was requested without a signed in Bluesky user.");
-                return false;
+                return RejectedCredential("The Mastodon credential is no longer valid.");
             }
-
-            return signedIn ? true : null;
-        }
-
-        private DateTime? GetPhotoDate(string path)
-        {
-            try
+            catch (PreparationExpiredException)
             {
-                string output = CallExifTool(path, "-s -s -s -createdate");
-                if (string.IsNullOrWhiteSpace(output))
-                {
-                    return null;
-                }
-
-                string[] splitOutput = output.Split(' ');
-                if (splitOutput.Length != 2)
-                {
-                    logger.LogWarning($"GetPhotoDate() split output was {splitOutput.Length}. Expected 2. Output: {output}");
-                    return null;
-                }
-
-                bool parsedDate = DateOnly.TryParse(splitOutput[0].Replace(":", "-"), out DateOnly date);
-                if (!parsedDate)
-                {
-                    logger.LogWarning($"GetPhotoDate() could not parse date. Output: {output}");
-                    return null;
-                }
-
-                bool parsedTime = TimeOnly.TryParse(splitOutput[1], out TimeOnly time);
-                if (!parsedTime)
-                {
-                    logger.LogWarning($"GetPhotoDate() could not parse time. Output: {output}");
-                    return null;
-                }
-
-                return date.ToDateTime(time);
+                return PreparationExpired();
             }
-            catch
+            catch (UnauthorizedAccessException)
             {
-                return null;
+                return StatusCode(StatusCodes.Status403Forbidden);
+            }
+            catch (ReportInProgressException ex)
+            {
+                return InProgress(ex);
+            }
+            catch (BikeLaneException)
+            {
+                return BadRequest("Prepared photo metadata exceeds the size limit.");
+            }
+            catch (Exception ex) when (IsUnavailable(ex, cancellationToken))
+            {
+                return Unavailable("Report submission is temporarily unavailable. Please retry with the same report ID.");
             }
         }
 
-        private Position? GetPhotoLocation(string path)
+        private async Task<InitialPhotoUploadMetadata> ReadPreparationAsync(string photoId, CancellationToken cancellationToken)
         {
-            try
+            const int maxMetadataBytes = 64 * 1024;
+            BlobClient blob = blobContainerClient.GetBlobClient($"{InitialUploadPrefix}{photoId}.json");
+            BlobProperties properties = (await blob.GetPropertiesAsync(cancellationToken: cancellationToken)).Value;
+            if (properties.ContentLength is <= 0 or > maxMetadataBytes)
             {
-                string output = CallExifTool(path, "-n -s -s -s -gpsposition");
-                if (string.IsNullOrWhiteSpace(output))
-                {
-                    return null;
-                }
-
-                string[] splitOutput = output.Split(' ');
-                if (splitOutput.Length != 2)
-                {
-                    logger.LogWarning($"GetPhotoLocation() split output was {splitOutput.Length}. Expected 2. Output: {output}");
-                    return null;
-                }
-
-                bool parsedLatitude = double.TryParse(splitOutput[0], out double latitude);
-                if (!parsedLatitude)
-                {
-                    logger.LogWarning($"GetPhotoLocation() could not parse latitude. Output: {output}");
-                    return null;
-                }
-
-                bool parsedLongitude = double.TryParse(splitOutput[1], out double longitude);
-                if (!parsedLongitude)
-                {
-                    logger.LogWarning($"GetPhotoLocation() could not parse longitude. Output: {output}");
-                    return null;
-                }
-
-                return new Position(longitude, latitude);
+                throw new InvalidDataException("Invalid stored metadata size.");
             }
-            catch
+            var download = await blob.DownloadStreamingAsync(new BlobDownloadOptions()
             {
-                return null;
+                Conditions = new BlobRequestConditions() { IfMatch = properties.ETag }
+            }, cancellationToken);
+            using var source = download.Value.Content;
+            using var content = await ReadBoundedAsync(source, maxMetadataBytes, cancellationToken);
+            if (content.Length != properties.ContentLength)
+            {
+                throw new InvalidDataException("Incomplete stored metadata.");
             }
+            return await JsonSerializer.DeserializeAsync<InitialPhotoUploadMetadata>(content,
+                cancellationToken: cancellationToken) ?? throw new InvalidDataException("Missing stored metadata.");
         }
 
-        private string CallExifTool(string path, string arguments)
+        private bool ValidReportFields(FinalizedPhotoUpload photo, out double latitude, out double longitude)
         {
-            ProcessStartInfo info = new ProcessStartInfo("exiftool/exiftool.exe", $"{arguments} {path}");
-            info.UseShellExecute = false;
-            info.RedirectStandardOutput = true;
-            info.RedirectStandardError = true;
-            using Process? process = Process.Start(info);
-            if (process == null)
-            {
-                logger.LogError("exiftool.exe didn't start for some reason.");
-                return string.Empty;
-            }
-            string output = process.StandardOutput.ReadToEnd();
-            string errorOutput = process.StandardError.ReadToEnd();
-            process.WaitForExit(TimeSpan.FromSeconds(5));
-            if (process.ExitCode != 0)
-            {
-                // error
-                logger.LogError($"Could not get EXIF data for photo. Error: {errorOutput}");
-                throw new Exception(errorOutput);
-            }
-            else
-            {
-                return output.Replace("\r\n", "");
-            }
+            latitude = longitude = 0;
+            return photo.PhotoDateTime is { } date && date != DateTime.MinValue &&
+                photo.NumberOfCars is >= 1 && photo.PhotoCrossStreet?.Length is not > 1024 &&
+                double.TryParse(photo.PhotoLatitude, NumberStyles.Float, CultureInfo.InvariantCulture, out latitude) &&
+                double.TryParse(photo.PhotoLongitude, NumberStyles.Float, CultureInfo.InvariantCulture, out longitude) &&
+                double.IsFinite(latitude) && double.IsFinite(longitude) &&
+                SeattleBoundingBox.Contains(new Position(longitude, latitude));
         }
 
-        public class InitialPhotoUploadWithSasUriMetadata : InitialPhotoUploadMetadata
+        private static bool SameReportFields(FinalizedPhotoUpload first, FinalizedPhotoUpload next)
         {
-            public string Uri { get; set; }
-            
-            public InitialPhotoUploadWithSasUriMetadata(string uri,
-                string photoId,
-                string submissionId,
-                int photoNumber,
-                DateTime photoDateTime,
-                string photoLatitude,
-                string photoLongitude,
-                string photoCrossStreet,
-                List<ImageTag> tags) :
-                base(photoId,
-                    submissionId,
-                    photoNumber,
-                    photoDateTime,
-                    photoLatitude,
-                    photoLongitude,
-                    photoCrossStreet,
-                    tags)
+            return next.PhotoDateTime == first.PhotoDateTime && next.PhotoLatitude == first.PhotoLatitude &&
+                next.PhotoLongitude == first.PhotoLongitude && next.NumberOfCars == first.NumberOfCars &&
+                next.PhotoCrossStreet == first.PhotoCrossStreet &&
+                next.UserSpecifiedDateTime == first.UserSpecifiedDateTime &&
+                next.UserSpecifiedLocation == first.UserSpecifiedLocation;
+        }
+
+        private static bool ValidPreparationId(string? id)
+        {
+            return id is { Length: > 0 and <= 100 } &&
+                id.All(c => char.IsAsciiLetterOrDigit(c) || c is '-' or '_');
+        }
+
+        private static ReportAttribution NormalizeAttribution(ReportAttribution value)
+        {
+            string? did = value.BlueskyDid?.Trim();
+            string? account = value.MastodonAccountId?.Trim();
+            if (did is not null && (did.Length is 0 or > 512 ||
+                    !did.StartsWith("did:", StringComparison.Ordinal) || did.Any(char.IsWhiteSpace)) ||
+                account is { Length: 0 or > 128 } ||
+                (value.MastodonServer is null) != (account is null))
             {
-                Uri = uri;
+                throw new ArgumentException("Invalid attribution.");
+            }
+            return new ReportAttribution(did, value.MastodonServer is null ? null :
+                MastodonCredentialVerifier.NormalizeServer(value.MastodonServer.Trim()), account);
+        }
+
+        private IActionResult PreparationExpired()
+        {
+            return StatusCode(StatusCodes.Status410Gone, new UploadError(UploadErrors.PreparationExpired,
+                "The prepared photos expired or changed. Upload the photos again using the same report ID."));
+        }
+
+        private static bool IsMissingOrChangedPreparation(RequestFailedException exception)
+        {
+            return exception.Status == 404 && exception.ErrorCode is null or "BlobNotFound" ||
+                exception.Status == 412 && exception.ErrorCode is null or "ConditionNotMet";
+        }
+
+        private IActionResult RejectedCredential(string message)
+        {
+            return Unauthorized(new UploadError(UploadErrors.CredentialRejected, message));
+        }
+
+        private IActionResult InProgress(ReportInProgressException exception)
+        {
+            Response.Headers.RetryAfter = Math.Max(1, (int)Math.Ceiling(exception.RetryAfter.TotalSeconds))
+                .ToString(CultureInfo.InvariantCulture);
+            return Conflict(new UploadError(UploadErrors.ReportInProgress,
+                "This report is being accepted. Check its receipt and retry shortly."));
+        }
+
+        private IActionResult Unavailable(string message)
+        {
+            logger.LogWarning("An upload dependency is temporarily unavailable.");
+            return StatusCode(StatusCodes.Status503ServiceUnavailable,
+                new UploadError(UploadErrors.ProviderUnavailable, message));
+        }
+
+        private static bool IsUnavailable(Exception exception, CancellationToken cancellationToken)
+        {
+            return exception is RequestFailedException or IOException or InvalidDataException or JsonException or HttpRequestException or
+                    ProviderUnavailableException or TimeoutException ||
+                exception is OperationCanceledException && !cancellationToken.IsCancellationRequested;
+        }
+
+        private sealed class ValidateFinalizationAfterReceiptAttribute : ActionFilterAttribute
+        {
+            public ValidateFinalizationAfterReceiptAttribute()
+            {
+                Order = -3000;
             }
 
-            public InitialPhotoUploadWithSasUriMetadata(string uri,
-                string photoId,
-                string submissionId,
-                int photoNumber,
-                List<ImageTag> tags) :
-                base(photoId,
-                    submissionId,
-                    photoNumber,
-                    tags)
+            public override void OnActionExecuting(ActionExecutingContext context)
             {
-                Uri = uri;
-            }
-
-            public static InitialPhotoUploadWithSasUriMetadata FromMetadata(string uri, InitialPhotoUploadMetadata metadata)
-            {
-                if (metadata.PhotoDateTime.HasValue &&
-                    !string.IsNullOrWhiteSpace(metadata.PhotoLatitude) &&
-                    !string.IsNullOrWhiteSpace(metadata.PhotoLongitude) &&
-                    !string.IsNullOrWhiteSpace(metadata.PhotoCrossStreet))
+                // Keep JSON binding errors (including legacy arrays), but defer field validation until
+                // after receipt recovery. The action validates every client-writable report field.
+                if (context.ActionArguments.TryGetValue("request", out object? request) &&
+                    request is FinalizeReportRequest)
                 {
-                    return new InitialPhotoUploadWithSasUriMetadata(uri,
-                        metadata.PhotoId,
-                        metadata.SubmissionId,
-                        metadata.PhotoNumber,
-                        metadata.PhotoDateTime.Value,
-                        metadata.PhotoLatitude,
-                        metadata.PhotoLongitude,
-                        metadata.PhotoCrossStreet,
-                        metadata.Tags);
-                }
-                else
-                {
-                    return new InitialPhotoUploadWithSasUriMetadata(uri,
-                        metadata.PhotoId,
-                        metadata.SubmissionId,
-                        metadata.PhotoNumber,
-                        metadata.Tags);
+                    context.ModelState.Clear();
                 }
             }
         }

--- a/SeattleCarsInBikeLanes/Database/BlockedDevicesDatabase.cs
+++ b/SeattleCarsInBikeLanes/Database/BlockedDevicesDatabase.cs
@@ -1,0 +1,96 @@
+using System.Net;
+using Microsoft.Azure.Cosmos;
+using SeattleCarsInBikeLanes.Database.Models;
+using SeattleCarsInBikeLanes.Models;
+
+namespace SeattleCarsInBikeLanes.Database
+{
+    public class BlockedDevicesDatabase
+    {
+        public const int MaximumReasonLength = 1000;
+        private readonly Container container;
+
+        public BlockedDevicesDatabase(ILogger<BlockedDevicesDatabase> logger, Container container)
+        {
+            ArgumentNullException.ThrowIfNull(logger);
+            ArgumentNullException.ThrowIfNull(container);
+            this.container = container;
+        }
+
+        public virtual async Task<bool> IsBlockedAsync(string deviceId, CancellationToken cancellationToken = default)
+        {
+            deviceId = ValidateDeviceId(deviceId);
+            cancellationToken.ThrowIfCancellationRequested();
+            try
+            {
+                await container.ReadItemAsync<BlockedDevice>(deviceId, new PartitionKey(deviceId),
+                    cancellationToken: cancellationToken);
+                return true;
+            }
+            catch (CosmosException ex) when (ex.StatusCode == HttpStatusCode.NotFound)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                return false;
+            }
+        }
+
+        public virtual async Task BlockAsync(string deviceId, string reason, CancellationToken cancellationToken = default)
+        {
+            deviceId = ValidateDeviceId(deviceId);
+            string? normalizedReason = reason?.Trim();
+            if (string.IsNullOrEmpty(normalizedReason) || normalizedReason.Length > MaximumReasonLength)
+            {
+                throw new ArgumentException($"A reason of 1-{MaximumReasonLength} characters is required.", nameof(reason));
+            }
+
+            cancellationToken.ThrowIfCancellationRequested();
+            await container.UpsertItemAsync(new BlockedDevice { DeviceId = deviceId, Reason = normalizedReason },
+                new PartitionKey(deviceId), cancellationToken: cancellationToken);
+        }
+
+        public virtual async Task UnblockAsync(string deviceId, CancellationToken cancellationToken = default)
+        {
+            deviceId = ValidateDeviceId(deviceId);
+            cancellationToken.ThrowIfCancellationRequested();
+            try
+            {
+                await container.DeleteItemAsync<BlockedDevice>(deviceId, new PartitionKey(deviceId),
+                    cancellationToken: cancellationToken);
+            }
+            catch (CosmosException ex) when (ex.StatusCode == HttpStatusCode.NotFound)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                // A delete 404 can also mean the container itself is unavailable.
+                await container.ReadContainerAsync(cancellationToken: cancellationToken);
+            }
+        }
+
+        public virtual async Task<IReadOnlyList<BlockedDevice>> ListAsync(CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            using FeedIterator<BlockedDevice> iterator = container.GetItemQueryIterator<BlockedDevice>(
+                new QueryDefinition("SELECT c.id, c.reason FROM c"));
+            List<BlockedDevice> blockedDevices = new List<BlockedDevice>();
+            while (iterator.HasMoreResults)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                FeedResponse<BlockedDevice> page = await iterator.ReadNextAsync(cancellationToken);
+                blockedDevices.AddRange(page);
+            }
+
+            return blockedDevices;
+        }
+
+        private static string ValidateDeviceId(string deviceId)
+        {
+            string? normalizedId = DeviceIdRules.Normalize(deviceId);
+            if (!DeviceIdRules.IsValid(normalizedId))
+            {
+                throw new ArgumentException("A device ID of 1-128 ASCII letters, digits, hyphens or underscores is required.",
+                    nameof(deviceId));
+            }
+
+            return normalizedId!;
+        }
+    }
+}

--- a/SeattleCarsInBikeLanes/Database/Models/BlockedDevice.cs
+++ b/SeattleCarsInBikeLanes/Database/Models/BlockedDevice.cs
@@ -1,0 +1,13 @@
+using Newtonsoft.Json;
+
+namespace SeattleCarsInBikeLanes.Database.Models
+{
+    public class BlockedDevice
+    {
+        [JsonProperty("id")]
+        public string DeviceId { get; set; } = string.Empty;
+
+        [JsonProperty("reason")]
+        public string Reason { get; set; } = string.Empty;
+    }
+}

--- a/SeattleCarsInBikeLanes/Database/ReportedItemsDatabase.cs
+++ b/SeattleCarsInBikeLanes/Database/ReportedItemsDatabase.cs
@@ -19,6 +19,14 @@ namespace SeattleCarsInBikeLanes.Database
             return await base.AddItem(item, item.TweetId);
         }
 
+        public virtual async Task SavePublishedReportAsync(ReportedItem item, CancellationToken cancellationToken = default)
+        {
+            ArgumentNullException.ThrowIfNull(item);
+            ArgumentException.ThrowIfNullOrWhiteSpace(item.TweetId);
+
+            await container.UpsertItemAsync(item, new PartitionKey(item.TweetId), cancellationToken: cancellationToken);
+        }
+
         public async Task<bool> UpdateReportedItem(ReportedItem item)
         {
             return await base.UpdateItem(item, item.TweetId);
@@ -88,8 +96,8 @@ namespace SeattleCarsInBikeLanes.Database
             if (request.Location != null && request.DistanceFromLocationInMiles != null)
             {
                 query = query.Where(i => i.Location != null)
-                    .Where(i => i.Location!.Distance(new Point(request.Location)) <=
-                    request.DistanceFromLocationInMiles * 1609.344);
+                                                    .Where(i => i.Location!.Distance(new Point(request.Location)) <=
+                                                    request.DistanceFromLocationInMiles * 1609.344);
             }
 
             using FeedIterator<ReportedItem> iterator = query.ToFeedIterator();
@@ -139,11 +147,11 @@ namespace SeattleCarsInBikeLanes.Database
         public async Task<List<ReportedItem>?> GetItemUsingIdentifier(string identifier)
         {
             IQueryable<ReportedItem> query = container.GetItemLinqQueryable<ReportedItem>()
-                .Where(i => i.TweetId.Contains(identifier) ||
-                    (i.TwitterLink != null && i.TwitterLink.Contains(identifier)) ||
-                    (i.MastodonLink != null && i.MastodonLink.Contains(identifier)) ||
-                    (i.BlueskyLink != null && i.BlueskyLink.Contains(identifier)) ||
-                    (i.ThreadsLink != null && i.ThreadsLink.Contains(identifier)));
+                                        .Where(i => i.TweetId.Contains(identifier) ||
+                                            (i.TwitterLink != null && i.TwitterLink.Contains(identifier)) ||
+                                            (i.MastodonLink != null && i.MastodonLink.Contains(identifier)) ||
+                                            (i.BlueskyLink != null && i.BlueskyLink.Contains(identifier)) ||
+                                            (i.ThreadsLink != null && i.ThreadsLink.Contains(identifier)));
 
             using FeedIterator<ReportedItem> iterator = query.ToFeedIterator();
             return await ProcessIterator(iterator);
@@ -193,8 +201,8 @@ namespace SeattleCarsInBikeLanes.Database
         public async Task<List<ReportedItem>> GetMostCars(DateOnly startDate, DateOnly endDate)
         {
             IQueryable<ReportedItem> query = container.GetItemLinqQueryable<ReportedItem>()
-                .Where(i => i.Date >= startDate && i.Date <= endDate)
-                .OrderByDescending(i => i.NumberOfCars);
+                                        .Where(i => i.Date >= startDate && i.Date <= endDate)
+                                        .OrderByDescending(i => i.NumberOfCars);
 
             using FeedIterator<ReportedItem> iterator = query.ToFeedIterator();
             List<ReportedItem>? items = await ProcessIterator(iterator);

--- a/SeattleCarsInBikeLanes/Models/AdminDeviceBlockRequests.cs
+++ b/SeattleCarsInBikeLanes/Models/AdminDeviceBlockRequests.cs
@@ -1,0 +1,15 @@
+namespace SeattleCarsInBikeLanes.Models
+{
+    public sealed class BlockDeviceRequest
+    {
+        public string? DeviceId { get; set; }
+        public string? Reason { get; set; }
+    }
+
+    public sealed class UnblockDeviceRequest
+    {
+        public string? DeviceId { get; set; }
+    }
+
+    public sealed record AdminBlockedDeviceResponse(string DeviceId, string Reason);
+}

--- a/SeattleCarsInBikeLanes/Models/DeviceIdRules.cs
+++ b/SeattleCarsInBikeLanes/Models/DeviceIdRules.cs
@@ -1,0 +1,17 @@
+namespace SeattleCarsInBikeLanes.Models
+{
+    public static class DeviceIdRules
+    {
+        public static string? Normalize(string? deviceId)
+        {
+            return string.IsNullOrWhiteSpace(deviceId) ? null : deviceId.Trim();
+        }
+
+        public static bool IsValid(string? normalizedId)
+        {
+            return normalizedId is { Length: >= 1 and <= 128 } &&
+                normalizedId.All(character => character is >= 'A' and <= 'Z' or
+                    >= 'a' and <= 'z' or >= '0' and <= '9' or '-' or '_');
+        }
+    }
+}

--- a/SeattleCarsInBikeLanes/Program.cs
+++ b/SeattleCarsInBikeLanes/Program.cs
@@ -51,14 +51,14 @@ namespace SeattleCarsInBikeLanes
             builder.Services.AddCors(options =>
             {
                 options.AddDefaultPolicy(policy =>
-                {
-                    policy.WithOrigins("https://localhost:7152",
-                        "http://localhost:5152",
-                        // Bluesky OAuth development uses the atproto localhost exception, which
-                        // requires a 127.0.0.1 loopback callback, so the dev site is browsed there.
-                        "http://127.0.0.1:5152",
-                        "https://seattle.carinbikelane.com");
-                });
+                                                {
+                                                    policy.WithOrigins("https://localhost:7152",
+                                                                                "http://localhost:5152",
+                                                                                // Bluesky OAuth development uses the atproto localhost exception, which
+                                                                                // requires a 127.0.0.1 loopback callback, so the dev site is browsed there.
+                                                                                "http://127.0.0.1:5152",
+                                                                                "https://seattle.carinbikelane.com");
+                                                });
             });
 
             builder.Services.AddControllers();
@@ -99,7 +99,7 @@ namespace SeattleCarsInBikeLanes
                             if (usernameMatch && passwordMatch)
                             {
                                 var claims = new[]
-                                {
+                                                                                                {
                                     new Claim(ClaimTypes.NameIdentifier,
                                         context.Username,
                                         ClaimValueTypes.String,
@@ -145,7 +145,9 @@ namespace SeattleCarsInBikeLanes
                     };
                 })
                 .AddScheme<AuthenticationSchemeOptions, BlueskyBearerAuthenticationHandler>(
-                    BlueskyAuthDefaults.BearerScheme, _ => { })
+                    BlueskyAuthDefaults.BearerScheme, _ =>
+                    {
+                    })
                 .AddPolicyScheme(BlueskyAuthDefaults.AnyScheme, BlueskyAuthDefaults.AnyScheme, policyOptions =>
                 {
                     // Browsers send a cookie, the mobile app sends a bearer token.
@@ -164,6 +166,14 @@ namespace SeattleCarsInBikeLanes
             // Setup services
             var services = builder.Services;
             services.AddSingleton<HttpClient>();
+            services.AddSingleton(_ => new MastodonCredentialVerifier(new HttpClient(new HttpClientHandler()
+            {
+                AllowAutoRedirect = false,
+                UseCookies = false
+            })));
+            services.AddSingleton<DeviceBlocklistProvider>();
+            services.AddSingleton<ReportStore>();
+            services.AddHostedService<ReportCleanupService>();
             services.AddSingleton<HelperMethods>();
             services.AddSingleton<StatusResponse>();
             services.AddSingleton<DefaultAzureCredential>(c =>
@@ -179,14 +189,14 @@ namespace SeattleCarsInBikeLanes
             services.AddSingleton(c =>
             {
                 return new SecretClient(new Uri("https://seattle-carsinbikelanes.vault.azure.net/"),
-                    c.GetRequiredService<DefaultAzureCredential>());
+                                                    c.GetRequiredService<DefaultAzureCredential>());
             });
             services.AddSingleton(c =>
             {
                 SecretClient client = c.GetRequiredService<SecretClient>();
                 KeyVaultSecret twitterBearerTokenSecret = client.GetSecret("twitter-bearer-token");
                 string twitterBearerToken = twitterBearerTokenSecret.Value;
-                var twitterAuth = new ApplicationOnlyAuthorizer()
+                ApplicationOnlyAuthorizer twitterAuth = new ApplicationOnlyAuthorizer()
                 {
                     BearerToken = twitterBearerToken
                 };
@@ -195,12 +205,12 @@ namespace SeattleCarsInBikeLanes
             services.AddSingleton(c =>
             {
                 return new MapsSearchClient(c.GetRequiredService<DefaultAzureCredential>(),
-                    "df857d2c-3805-4793-90e4-63e84a499756");
+                                                    "df857d2c-3805-4793-90e4-63e84a499756");
             });
             services.AddSingleton(c =>
             {
                 return new CosmosClient("https://seattle-carsinbikelanes-db.documents.azure.com:443/",
-                    c.GetRequiredService<DefaultAzureCredential>());
+                                                    c.GetRequiredService<DefaultAzureCredential>());
             });
             services.AddSingleton(c =>
             {
@@ -212,6 +222,12 @@ namespace SeattleCarsInBikeLanes
                 ILogger<ReportedItemsDatabase> logger = c.GetRequiredService<ILogger<ReportedItemsDatabase>>();
                 Container container = c.GetRequiredService<Microsoft.Azure.Cosmos.Database>().GetContainer("items");
                 return new ReportedItemsDatabase(logger, container);
+            });
+            services.AddSingleton(c =>
+            {
+                ILogger<BlockedDevicesDatabase> logger = c.GetRequiredService<ILogger<BlockedDevicesDatabase>>();
+                Container container = c.GetRequiredService<Microsoft.Azure.Cosmos.Database>().GetContainer("blocked-devices");
+                return new BlockedDevicesDatabase(logger, container);
             });
             services.AddSingleton(c =>
             {
@@ -240,7 +256,7 @@ namespace SeattleCarsInBikeLanes
             services.AddSingleton(c =>
             {
                 return new BlobServiceClient(new Uri("https://seacarsinbikelanesfiles.blob.core.windows.net/"),
-                    c.GetRequiredService<DefaultAzureCredential>());
+                                                    c.GetRequiredService<DefaultAzureCredential>());
             });
             services.AddSingleton(c =>
             {
@@ -266,7 +282,7 @@ namespace SeattleCarsInBikeLanes
             services.AddSingleton<IImageEndpoint>(c =>
             {
                 return new ImageEndpoint(c.GetRequiredService<ApiClient>(),
-                    new HttpClient());
+                                                    new HttpClient());
             });
             services.AddSingleton(c =>
             {
@@ -275,29 +291,29 @@ namespace SeattleCarsInBikeLanes
             services.AddSingleton(c =>
             {
                 return new MastodonClientProvider(c.GetRequiredService<ILogger<MastodonClientProvider>>(),
-                    c.GetRequiredService<IWebHostEnvironment>(),
-                    c.GetRequiredService<MastodonOAuthMappingDatabase>(),
-                    c.GetRequiredService<SecretClient>(),
-                    c.GetRequiredService<ILogger<MastodonClient>>(),
-                    c.GetRequiredService<HttpClient>());
+                                                    c.GetRequiredService<IWebHostEnvironment>(),
+                                                    c.GetRequiredService<MastodonOAuthMappingDatabase>(),
+                                                    c.GetRequiredService<SecretClient>(),
+                                                    c.GetRequiredService<ILogger<MastodonClient>>(),
+                                                    c.GetRequiredService<HttpClient>());
             });
             services.AddSingleton(c =>
             {
                 return new FeedProvider(c.GetRequiredService<ILogger<FeedProvider>>(),
-                    c.GetRequiredService<ReportedItemsDatabase>(),
-                    c.GetRequiredService<BlobContainerClient>());
+                                                    c.GetRequiredService<ReportedItemsDatabase>(),
+                                                    c.GetRequiredService<BlobContainerClient>());
             });
             services.AddSingleton(c =>
             {
                 return new SlackbotProvider(c.GetRequiredService<ILogger<SlackbotProvider>>(),
-                    c.GetRequiredService<HttpClient>(),
-                    c.GetRequiredService<SecretClient>());
+                                                    c.GetRequiredService<HttpClient>(),
+                                                    c.GetRequiredService<SecretClient>());
             });
             services.AddSingleton(c =>
             {
                 return new BlueskyClientProvider(c.GetRequiredService<ILogger<BlueskyClientProvider>>(),
-                    c.GetRequiredService<SecretClient>(),
-                    c.GetRequiredService<HttpClient>());
+                                                    c.GetRequiredService<SecretClient>(),
+                                                    c.GetRequiredService<HttpClient>());
             });
             services.AddSingleton<GuessGameManager>();
             services.AddSingleton<BlueskyOAuthProvider>();
@@ -356,5 +372,3 @@ namespace SeattleCarsInBikeLanes
         }
     }
 }
-
-

--- a/SeattleCarsInBikeLanes/Providers/DeviceBlocklistProvider.cs
+++ b/SeattleCarsInBikeLanes/Providers/DeviceBlocklistProvider.cs
@@ -1,0 +1,47 @@
+using Azure.Identity;
+using Microsoft.Azure.Cosmos;
+using Newtonsoft.Json;
+using SeattleCarsInBikeLanes.Database;
+
+namespace SeattleCarsInBikeLanes.Providers
+{
+    /// <summary>
+    /// The set of devices that are not allowed to submit reports.
+    /// </summary>
+    public class DeviceBlocklistProvider
+    {
+        private readonly ILogger<DeviceBlocklistProvider> logger;
+        private readonly BlockedDevicesDatabase database;
+
+        public DeviceBlocklistProvider(ILogger<DeviceBlocklistProvider> logger,
+            BlockedDevicesDatabase database)
+        {
+            this.logger = logger;
+            this.database = database;
+        }
+
+        public async Task<bool> IsBlocked(string? deviceId, CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            if (string.IsNullOrWhiteSpace(deviceId))
+            {
+                // Website uploads have no installation identity.
+                return false;
+            }
+
+            try
+            {
+                return await database.IsBlockedAsync(deviceId, cancellationToken);
+            }
+            catch (Exception ex) when (ex is CosmosException or HttpRequestException or TimeoutException or
+                AuthenticationFailedException or JsonException ||
+                ex is OperationCanceledException && !cancellationToken.IsCancellationRequested)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                // Submission checks fail open; administrative operations must surface failures.
+                logger.LogError(ex, "Could not check the device blocklist. Allowing this submission.");
+                return false;
+            }
+        }
+    }
+}

--- a/SeattleCarsInBikeLanes/Providers/FeedProvider.cs
+++ b/SeattleCarsInBikeLanes/Providers/FeedProvider.cs
@@ -1,4 +1,5 @@
-﻿using System.ServiceModel.Syndication;
+﻿using System.Globalization;
+using System.ServiceModel.Syndication;
 using System.Text;
 using System.Xml;
 using Azure.Storage.Blobs;
@@ -229,10 +230,14 @@ namespace SeattleCarsInBikeLanes.Providers
             {
                 contentBuilder.Append($"<p><a href=\"{reportedItem.TwitterLink}\">Twitter post</a></p>");
             }
-            else if (reportedItem.TweetId.Length < 36)
+            else
             {
                 string tweetId = reportedItem.TweetId.Split('.')[0];
-                contentBuilder.Append($"<p><a href=\"https://twitter.com/carbikelanesea/status/{tweetId}\">Twitter post</a></p>");
+                if (tweetId.Length <= 20 &&
+                    ulong.TryParse(tweetId, NumberStyles.None, CultureInfo.InvariantCulture, out _))
+                {
+                    contentBuilder.Append($"<p><a href=\"https://twitter.com/carbikelanesea/status/{tweetId}\">Twitter post</a></p>");
+                }
             }
 
             if (!string.IsNullOrWhiteSpace(reportedItem.MastodonLink))
@@ -255,9 +260,10 @@ namespace SeattleCarsInBikeLanes.Providers
             SyndicationItem item = new SyndicationItem(titleBuilder.ToString(), content, null, reportedItem.TweetId, pubDate);
             item.PublishDate = pubDate;
 
+            feedItems.RemoveAll(existingItem => existingItem.Id == reportedItem.TweetId);
             if (feedItems.Count >= 100)
             {
-                feedItems.RemoveAt(feedItems.Count - 1);
+                feedItems.RemoveRange(99, feedItems.Count - 99);
             }
 
             if (beginning)

--- a/SeattleCarsInBikeLanes/Providers/MastodonCredentialVerifier.cs
+++ b/SeattleCarsInBikeLanes/Providers/MastodonCredentialVerifier.cs
@@ -1,0 +1,106 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text.Json.Serialization;
+using System.Text.Json;
+
+namespace SeattleCarsInBikeLanes.Providers
+{
+    public sealed record VerifiedMastodonAccount(string Server, string Id, string Username)
+    {
+        public string FullUsername => $"@{Username}@{new Uri(Server).Host}";
+    }
+
+    public sealed class CredentialRejectedException : Exception
+    {
+    }
+
+    public sealed class ProviderUnavailableException : Exception
+    {
+        public ProviderUnavailableException(string message) : base(message)
+        {
+        }
+    }
+
+    public sealed class MastodonCredentialVerifier
+    {
+        private const int MaxIdentityBytes = 64 * 1024;
+        private readonly HttpClient client;
+        private readonly TimeSpan verificationTimeout;
+
+        public MastodonCredentialVerifier(HttpClient client, TimeSpan? verificationTimeout = null)
+        {
+            this.client = client;
+            this.verificationTimeout = verificationTimeout ?? TimeSpan.FromSeconds(15);
+            if (this.verificationTimeout <= TimeSpan.Zero)
+            {
+                throw new ArgumentOutOfRangeException(nameof(verificationTimeout));
+            }
+        }
+
+        public static string NormalizeServer(string server)
+        {
+            if (!Uri.TryCreate(server, UriKind.Absolute, out Uri? uri) ||
+                                        uri.Scheme != Uri.UriSchemeHttps || !string.IsNullOrEmpty(uri.UserInfo) ||
+                                        uri.AbsolutePath != "/" || !string.IsNullOrEmpty(uri.Query) || !string.IsNullOrEmpty(uri.Fragment))
+            {
+                throw new ArgumentException("Invalid Mastodon server.");
+            }
+            return uri.GetLeftPart(UriPartial.Authority);
+        }
+
+        public async Task<VerifiedMastodonAccount> VerifyAsync(string server, string token, CancellationToken cancellationToken)
+        {
+            string canonical = NormalizeServer(server);
+            using HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get,
+                $"{canonical}/api/v1/accounts/verify_credentials");
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+            // HttpClient.Timeout only covers headers with ResponseHeadersRead.
+            using CancellationTokenSource deadline = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            deadline.CancelAfter(verificationTimeout);
+            try
+            {
+                using HttpResponseMessage response = await client.SendAsync(request,
+                                                    HttpCompletionOption.ResponseHeadersRead, deadline.Token);
+                if (response.StatusCode is HttpStatusCode.Unauthorized or HttpStatusCode.Forbidden)
+                {
+                    throw new CredentialRejectedException();
+                }
+                if (!response.IsSuccessStatusCode)
+                {
+                    throw new ProviderUnavailableException("Mastodon could not verify the account. Try again shortly.");
+                }
+                if (response.Content.Headers.ContentLength > MaxIdentityBytes)
+                {
+                    throw new ProviderUnavailableException("Mastodon returned an oversized account response.");
+                }
+                using Stream input = await response.Content.ReadAsStreamAsync(deadline.Token);
+                using MemoryStream body = new MemoryStream();
+                byte[] buffer = new byte[8192];
+                int count;
+                while ((count = await input.ReadAsync(buffer, deadline.Token)) != 0)
+                {
+                    if (body.Length + count > MaxIdentityBytes)
+                    {
+                        throw new ProviderUnavailableException("Mastodon returned an oversized account response.");
+                    }
+                    body.Write(buffer, 0, count);
+                }
+                Account? account = JsonSerializer.Deserialize<Account>(body.ToArray());
+                if (string.IsNullOrWhiteSpace(account?.Id) || string.IsNullOrWhiteSpace(account.Username))
+                {
+                    throw new ProviderUnavailableException("Mastodon returned an incomplete account.");
+                }
+                return new VerifiedMastodonAccount(canonical, account.Id, account.Username);
+            }
+            catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested && deadline.IsCancellationRequested)
+            {
+                throw new ProviderUnavailableException("Mastodon verification timed out. Please retry.");
+            }
+        }
+
+        private sealed record Account(
+            [property: JsonPropertyName("id")] string Id,
+            [property: JsonPropertyName("username")] string Username);
+    }
+}

--- a/SeattleCarsInBikeLanes/Providers/ReportStore.cs
+++ b/SeattleCarsInBikeLanes/Providers/ReportStore.cs
@@ -1,0 +1,1248 @@
+using System.Globalization;
+using System.Runtime.CompilerServices;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Azure;
+using Azure.Storage;
+using Azure.Storage.Blobs;
+using Azure.Storage.Blobs.Models;
+using SeattleCarsInBikeLanes.Core.Contracts;
+using SeattleCarsInBikeLanes.Storage.Models;
+
+namespace SeattleCarsInBikeLanes.Providers
+{
+    public sealed record PreparedSubmissionPhoto(FinalizedPhotoUploadMetadata Metadata, string BlobName, string ETag, long Length);
+
+    public sealed record SubmissionPhoto(FinalizedPhotoUploadMetadata Metadata, string BlobName, string ETag, long Length);
+
+    public sealed record ModerationOperation(string Id, string Kind, DateTimeOffset StartedAt);
+
+    public sealed record SubmissionReport(SubmissionReceipt Receipt, string? DeviceId, List<SubmissionPhoto> Photos,
+        bool Retired = false, ModerationOperation? Moderation = null)
+    {
+        [JsonIgnore]
+        public string? Version { get; init; }
+    }
+
+    public sealed class ReportInProgressException : Exception
+    {
+        public TimeSpan RetryAfter { get; }
+
+        public ReportInProgressException(TimeSpan retryAfter) : base("This report is still being prepared.")
+        {
+            RetryAfter = retryAfter;
+        }
+    }
+
+    public sealed class ReportConflictException : Exception
+    {
+        public ReportConflictException(string message) : base(message)
+        {
+        }
+    }
+
+    public sealed class ReportDeviceMismatchException : UnauthorizedAccessException
+    {
+        public ReportDeviceMismatchException() : base("This report belongs to a different submitting context.")
+        {
+        }
+    }
+
+    public sealed class PreparationExpiredException : IOException
+    {
+        public PreparationExpiredException(string message = "The prepared photo expired or changed.",
+            Exception? innerException = null) : base(message, innerException)
+        {
+        }
+    }
+
+    /// <summary>
+    /// The report blob is the sole acceptance and moderation coordinator. Its ETag fences every
+    /// attempt; photo blobs are immutable and are never authoritative on their own.
+    /// </summary>
+    public class ReportStore
+    {
+        public const string FinalizedUploadPrefix = "finalizedupload/";
+        public const string BlobPrefix = FinalizedUploadPrefix + "reports/";
+        public const string PhotoPrefix = FinalizedUploadPrefix + "photos/";
+        public const int MaxPhotoBytes = 8 * 1024 * 1024;
+        public const int MaxReportBytes = 4 * MaxPhotoBytes;
+        public static readonly TimeSpan PreparationTimeout = TimeSpan.FromMinutes(15);
+        private const int MaxRecordBytes = 256 * 1024;
+        private readonly BlobContainerClient container;
+        private readonly ILogger<ReportStore> logger;
+        private readonly TimeProvider clock;
+
+        public ReportStore(BlobContainerClient container, ILogger<ReportStore> logger, TimeProvider? clock = null)
+        {
+            this.container = container;
+            this.logger = logger;
+            this.clock = clock ?? TimeProvider.System;
+        }
+
+        [JsonConverter(typeof(JsonStringEnumConverter))]
+        private enum ReportState
+        {
+            Preparing,
+            Accepted,
+            Abandoned,
+            Retired
+        }
+
+        private sealed record CleanupItem(string BlobName, string? ETag);
+
+        private sealed record Document(
+            string ReportId,
+            string? DeviceId,
+            ReportState State,
+            DateTimeOffset StartedAt,
+            string? AttemptId,
+            List<SubmissionPhoto> Photos,
+            SubmissionReceipt? Receipt = null,
+            ModerationOperation? Moderation = null,
+            List<SubmissionPhoto>? ModerationPhotos = null,
+            List<string>? LegacySidecars = null,
+            List<CleanupItem>? Cleanup = null,
+            int SchemaVersion = 1,
+            string? MutationId = null)
+        {
+            [JsonIgnore]
+            public string? Version { get; init; }
+        }
+
+        public static bool IsValidReportId(string? id)
+        {
+            return id is { Length: 32 } && id.All(c => c is >= '0' and <= '9' or >= 'a' and <= 'f');
+        }
+
+        public static string LegacyReportId(string legacySubmissionId)
+        {
+            ArgumentException.ThrowIfNullOrWhiteSpace(legacySubmissionId);
+            byte[] digest = SHA256.HashData(Encoding.UTF8.GetBytes(
+                "SeattleCarsInBikeLanes:legacy-submission:v1\0" + legacySubmissionId));
+            return Convert.ToHexStringLower(digest.AsSpan(0, 16));
+        }
+
+        public virtual async Task<bool> ExistsAsync(string id, CancellationToken cancellationToken = default)
+        {
+            return await ReadAsync(id, cancellationToken) is not null;
+        }
+
+        public virtual async Task<SubmissionReport?> GetAsync(string id, string? deviceId, CancellationToken cancellationToken = default)
+        {
+            Document? document = await ReadAsync(id, cancellationToken);
+            if (document is null)
+            {
+                return null;
+            }
+            CheckDevice(document, deviceId);
+            return document.State switch
+            {
+                ReportState.Accepted or ReportState.Retired => ToReport(document),
+                ReportState.Abandoned => null,
+                _ => throw InProgress(document)
+            };
+        }
+
+        public virtual async Task<SubmissionReceipt> CommitAsync(string id, string? deviceId, ReportAttribution attribution,
+            IReadOnlyList<PreparedSubmissionPhoto> photos, CancellationToken cancellationToken = default)
+        {
+            Document? current = await ReadAsync(id, cancellationToken);
+            if (current is not null)
+            {
+                CheckDevice(current, deviceId);
+                if (IsAccepted(current))
+                {
+                    return current.Receipt!;
+                }
+                if (IsLive(current))
+                {
+                    throw InProgress(current);
+                }
+            }
+
+            ValidateAttribution(attribution);
+            ArgumentNullException.ThrowIfNull(photos);
+            photos = photos.ToArray();
+            ValidatePhotos(photos.Select(p => new SubmissionPhoto(p.Metadata, p.BlobName, p.ETag, p.Length)).ToList(),
+                id, deviceId, legacy: false);
+            foreach (PreparedSubmissionPhoto photo in photos)
+            {
+                if (!IsPhotoPath(photo.BlobName, "initialupload/"))
+                {
+                    throw new ArgumentException("Prepared photos must refer to initial-upload JPEGs.", nameof(photos));
+                }
+            }
+
+            string attemptId = Guid.NewGuid().ToString("N");
+            List<SubmissionPhoto> reserved = photos.Select((photo, index) => new SubmissionPhoto(
+                CloneMetadata(photo.Metadata, id, deviceId),
+                $"{PhotoPrefix}{id}/{attemptId}/{index}.jpeg", "", photo.Length)).ToList();
+            CheckMetadataSize(reserved);
+            Document preparing;
+            while (true)
+            {
+                if (current is not null)
+                {
+                    CheckDevice(current, deviceId);
+                    if (IsAccepted(current))
+                    {
+                        return current.Receipt!;
+                    }
+                    if (IsLive(current))
+                    {
+                        throw InProgress(current);
+                    }
+                }
+
+                preparing = new Document(id, deviceId, ReportState.Preparing, clock.GetUtcNow(), attemptId, reserved);
+                try
+                {
+                    // Reserving the complete destination set precedes even the first photo write.
+                    preparing = await WriteAsync(preparing, current?.Version, cancellationToken);
+                    break;
+                }
+                catch (RequestFailedException ex) when (IsConditionFailure(ex))
+                {
+                    current = await ReadAsync(id, cancellationToken);
+                }
+            }
+
+            try
+            {
+                List<SubmissionPhoto> completed = new List<SubmissionPhoto>();
+                for (int index = 0; index < photos.Count; index++)
+                {
+                    SubmissionPhoto stored = await CopyPhotoAsync(photos[index], reserved[index], cancellationToken);
+                    completed.Add(stored);
+                }
+
+                SubmissionReceipt receipt = new SubmissionReceipt(id, reserved[0].Metadata.SubmissionId, clock.GetUtcNow(), attribution);
+                try
+                {
+                    await WriteAsync(preparing with
+                    {
+                        State = ReportState.Accepted,
+                        Photos = completed,
+                        Receipt = receipt
+                    },
+                                                                preparing.Version, cancellationToken);
+                }
+                catch (RequestFailedException ex) when (IsConditionFailure(ex))
+                {
+                    throw new ReportInProgressException(TimeSpan.FromSeconds(1));
+                }
+                return receipt;
+            }
+            catch (Exception) when (!cancellationToken.IsCancellationRequested)
+            {
+                // An upload/accept response may be lost after it committed. Never abandon on the
+                // strength of that response alone, or validate fresh input before reconciling.
+                current = await ReadAsync(id, cancellationToken);
+                if (current is not null)
+                {
+                    CheckDevice(current, deviceId);
+                    if (IsAccepted(current))
+                    {
+                        return current.Receipt!;
+                    }
+                    if (current.State == ReportState.Preparing && current.AttemptId == attemptId)
+                    {
+                        try
+                        {
+                            await WriteAsync(current with
+                            {
+                                State = ReportState.Abandoned
+                            },
+                                                                                        current.Version, cancellationToken);
+                        }
+                        catch (RequestFailedException conflict) when (IsConditionFailure(conflict))
+                        {
+                            current = await ReadAsync(id, cancellationToken);
+                            if (current is not null && IsAccepted(current))
+                            {
+                                CheckDevice(current, deviceId);
+                                return current.Receipt!;
+                            }
+                        }
+                    }
+                }
+                throw;
+            }
+        }
+
+        public virtual async IAsyncEnumerable<SubmissionReport> GetPendingAsync(
+            [EnumeratorCancellation] CancellationToken cancellationToken = default)
+        {
+            await foreach (BlobItem blob in container.GetBlobsAsync(BlobTraits.None, BlobStates.None, BlobPrefix, cancellationToken))
+            {
+                if (!TryGetRecordId(blob.Name, out string id))
+                {
+                    continue;
+                }
+                Document? document = await ReadAsync(id, cancellationToken);
+                if (document?.State == ReportState.Accepted)
+                {
+                    yield return ToReport(document);
+                }
+            }
+        }
+
+        public virtual async Task<SubmissionReport> GetForModerationAsync(string id, CancellationToken cancellationToken = default)
+        {
+            return ToReport(await ReadModeratableAsync(id, cancellationToken));
+        }
+
+        public virtual async Task<SubmissionReport> AdoptLegacyAsync(string legacySubmissionId, IReadOnlyList<SubmissionPhoto> photos,
+            CancellationToken cancellationToken = default)
+        {
+            string id = LegacyReportId(legacySubmissionId);
+            Document? existing = await ReadAsync(id, cancellationToken);
+            if (existing is not null)
+            {
+                return ExistingLegacy(existing, legacySubmissionId);
+            }
+            ArgumentNullException.ThrowIfNull(photos);
+            ValidatePhotos(photos, id, null, legacy: true);
+            foreach (SubmissionPhoto photo in photos)
+            {
+                if (photo.Metadata.SubmissionId != legacySubmissionId ||
+                                                    !IsSafeComponent(photo.Metadata.PhotoId) ||
+                                                    photo.BlobName != $"{FinalizedUploadPrefix}{photo.Metadata.PhotoId}.jpeg")
+                {
+                    throw new ArgumentException("Legacy photo references must match their original metadata.", nameof(photos));
+                }
+                await VerifyPhotoAsync(photo.BlobName, photo.ETag, photo.Length, cancellationToken);
+            }
+
+            List<SubmissionPhoto> sanitized = photos.Select(p => p with
+            {
+                Metadata = CloneMetadata(p.Metadata, id, null)
+            }).ToList();
+            CheckMetadataSize(sanitized);
+            string? did = sanitized[0].Metadata.Attribute == true ? sanitized[0].Metadata.BlueskyUserDid : null;
+            SubmissionReceipt receipt = new SubmissionReceipt(id, legacySubmissionId, clock.GetUtcNow(), new ReportAttribution(BlueskyDid: did));
+            Document accepted = new Document(id, null, ReportState.Accepted, clock.GetUtcNow(), null, sanitized, receipt,
+                LegacySidecars: photos.Select(p => $"{FinalizedUploadPrefix}{p.Metadata.PhotoId}.json").ToList());
+            try
+            {
+                return ToReport(await WriteAsync(accepted, null, cancellationToken));
+            }
+            catch (Exception) when (!cancellationToken.IsCancellationRequested)
+            {
+                existing = await ReadAsync(id, cancellationToken);
+                if (existing is not null)
+                {
+                    return ExistingLegacy(existing, legacySubmissionId);
+                }
+                throw;
+            }
+        }
+
+        public virtual async Task<SubmissionReport> BeginModerationAsync(string id, string kind,
+            IReadOnlyList<FinalizedPhotoUploadMetadata>? overrides = null, string? expectedVersion = null,
+            CancellationToken cancellationToken = default)
+        {
+            if (kind is not ("publishing" or "deleting"))
+            {
+                throw new ArgumentException("Unknown moderation operation.", nameof(kind));
+            }
+            Document document = await ReadModeratableAsync(id, cancellationToken);
+            if (document.Moderation is not null)
+            {
+                throw new ReportConflictException("Another moderation operation owns this report; reconcile it before retrying.");
+            }
+            if (expectedVersion is not null && expectedVersion != document.Version)
+            {
+                throw new ReportConflictException("The report changed. Refresh before applying edits.");
+            }
+            List<SubmissionPhoto>? snapshot = null;
+            if (overrides is not null)
+            {
+                if (overrides.Count != document.Photos.Count)
+                {
+                    throw new ArgumentException("Moderation must include the entire canonical photo set.", nameof(overrides));
+                }
+                snapshot = new List<SubmissionPhoto>();
+                for (int index = 0; index < overrides.Count; index++)
+                {
+                    FinalizedPhotoUploadMetadata replacement = overrides[index];
+                    SubmissionPhoto original = document.Photos[index];
+                    RejectSecrets(replacement, allowTwitterLink: true);
+                    if (replacement.PhotoId != original.Metadata.PhotoId ||
+                        replacement.SubmissionId != original.Metadata.SubmissionId ||
+                        replacement.PhotoNumber != original.Metadata.PhotoNumber)
+                    {
+                        throw new ArgumentException("Moderation cannot replace, reorder, or remove photos.", nameof(overrides));
+                    }
+                    if (replacement.PhotoDateTime is null || replacement.NumberOfCars is null or <= 0 ||
+                                        !Coordinate(replacement.PhotoLatitude, 47.495082, 47.735525) ||
+                                        !Coordinate(replacement.PhotoLongitude, -122.436522, -122.235787) ||
+                                        !IsValidPublicationLink(replacement.TwitterLink) ||
+                                        replacement.ReportId is not null && replacement.ReportId != id ||
+                                        replacement.DeviceId is not null && replacement.DeviceId != document.DeviceId)
+                    {
+                        throw new ArgumentException("Invalid moderation metadata or submitting context.", nameof(overrides));
+                    }
+                    snapshot.Add(original with
+                    {
+                        Metadata = CloneMetadata(replacement, id, document.DeviceId, preserveTwitterLink: true)
+                    });
+                }
+                CheckMetadataSize(snapshot);
+            }
+
+            ModerationOperation operation = new ModerationOperation(Guid.NewGuid().ToString("N"), kind, clock.GetUtcNow());
+            try
+            {
+                return ToReport(await WriteAsync(document with
+                {
+                    Moderation = operation,
+                    ModerationPhotos = snapshot
+                },
+                                                    document.Version, cancellationToken));
+            }
+            catch (RequestFailedException ex) when (IsConditionFailure(ex))
+            {
+                throw new ReportConflictException("Another operation changed this report.");
+            }
+        }
+
+        public virtual async Task ReleaseModerationAsync(string id, string operationId, CancellationToken cancellationToken = default)
+        {
+            Document document = await ReadModeratableAsync(id, cancellationToken);
+            CheckOperation(document, operationId);
+            try
+            {
+                await WriteAsync(document with
+                {
+                    Moderation = null,
+                    ModerationPhotos = null
+                }, document.Version, cancellationToken);
+            }
+            catch (RequestFailedException ex) when (IsConditionFailure(ex))
+            {
+                throw new ReportConflictException("Another operation changed this report.");
+            }
+        }
+
+        public virtual async Task RetireAsync(string id, string operationId, CancellationToken cancellationToken = default)
+        {
+            Document document = await ReadAsync(id, cancellationToken) ?? throw new KeyNotFoundException("Report not found.");
+            CheckOperation(document, operationId);
+            if (document.State != ReportState.Retired)
+            {
+                if (document.State != ReportState.Accepted)
+                {
+                    throw new ReportConflictException("Only accepted reports can be retired.");
+                }
+                List<CleanupItem> inventory = document.Photos.Select(p => new CleanupItem(p.BlobName, p.ETag)).ToList();
+                inventory.AddRange((document.LegacySidecars ?? []).Select(name => new CleanupItem(name, null)));
+                try
+                {
+                    // Keep both the immutable receipt and a recoverable inventory before any deletion.
+                    document = await WriteAsync(document with
+                    {
+                        State = ReportState.Retired,
+                        Cleanup = inventory
+                    },
+                        document.Version, cancellationToken);
+                }
+                catch (Exception) when (!cancellationToken.IsCancellationRequested)
+                {
+                    Document? recovered = await ReadAsync(id, cancellationToken);
+                    if (recovered?.State != ReportState.Retired || recovered.Moderation?.Id != operationId)
+                    {
+                        throw;
+                    }
+                    document = recovered;
+                }
+            }
+
+            try
+            {
+                await CleanupRetiredAsync(document, cancellationToken);
+            }
+            catch (Exception ex) when (!cancellationToken.IsCancellationRequested)
+            {
+                // Retirement succeeded. Cleanup is retryable, not a reason to republish the report.
+                logger.LogWarning(ex, "Cleanup remains pending for retired report {ReportId}.", id);
+            }
+        }
+
+        public virtual async Task CleanupAsync(CancellationToken cancellationToken = default)
+        {
+            HashSet<string> unsafeReportIds = new HashSet<string>(StringComparer.Ordinal);
+            await foreach (BlobItem blob in container.GetBlobsAsync(BlobTraits.None, BlobStates.None, BlobPrefix, cancellationToken))
+            {
+                if (!TryGetRecordId(blob.Name, out string id) || unsafeReportIds.Contains(id))
+                {
+                    continue;
+                }
+                try
+                {
+                    Document? document = await ReadAsync(id, cancellationToken);
+                    if (document is null)
+                    {
+                        continue;
+                    }
+                    if (document.State == ReportState.Preparing && !IsLive(document))
+                    {
+                        try
+                        {
+                            // Expiry alone cannot authorize deleting an active worker's reserved keys.
+                            document = await WriteAsync(document with
+                            {
+                                State = ReportState.Abandoned
+                            },
+                                document.Version, cancellationToken);
+                        }
+                        catch (RequestFailedException ex) when (IsConditionFailure(ex))
+                        {
+                            continue;
+                        }
+                    }
+                    if (document.State == ReportState.Retired)
+                    {
+                        await CleanupRetiredAsync(document, cancellationToken);
+                    }
+                }
+                catch (Exception ex) when (ex is InvalidDataException or JsonException)
+                {
+                    // Reconciliation reads after a failed coordinator write can also find corruption.
+                    Quarantine(id, ex);
+                }
+            }
+
+            // Repeat this inventory scan forever: an already-fenced worker's upload can complete
+            // after an earlier sweep. Never collect on an absent coordinator or age alone.
+            await foreach (BlobItem blob in container.GetBlobsAsync(BlobTraits.None, BlobStates.None, PhotoPrefix, cancellationToken))
+            {
+                if (!blob.Name.StartsWith(PhotoPrefix, StringComparison.Ordinal))
+                {
+                    continue;
+                }
+                string[] parts = blob.Name[PhotoPrefix.Length..].Split('/');
+                if (parts.Length != 3 || !IsValidReportId(parts[0]) || !IsValidReportId(parts[1]))
+                {
+                    continue;
+                }
+                if (unsafeReportIds.Contains(parts[0]))
+                {
+                    continue;
+                }
+                Document? document;
+                try
+                {
+                    document = await ReadAsync(parts[0], cancellationToken);
+                }
+                catch (Exception ex) when (ex is InvalidDataException or JsonException)
+                {
+                    Quarantine(parts[0], ex);
+                    continue;
+                }
+                if (document is null)
+                {
+                    continue;
+                }
+                if (document.State is ReportState.Preparing or ReportState.Accepted &&
+                                (document.AttemptId == parts[1] || document.Photos.Any(p => p.BlobName == blob.Name) ||
+                                 document.ModerationPhotos?.Any(p => p.BlobName == blob.Name) == true))
+                {
+                    continue;
+                }
+                await DeleteAsync(blob.Name, blob.Properties.ETag?.ToString(), cancellationToken);
+            }
+
+            void Quarantine(string id, Exception exception)
+            {
+                unsafeReportIds.Add(id);
+                logger.LogWarning(exception,
+                    "Skipping cleanup for invalid report {ReportId}; its record and possibly referenced photos are retained.", id);
+            }
+        }
+
+        private async Task<SubmissionPhoto> CopyPhotoAsync(PreparedSubmissionPhoto source, SubmissionPhoto destination,
+            CancellationToken cancellationToken)
+        {
+            using BlobDownloadStreamingResult download = await ReadSourceAsync(source, cancellationToken);
+            if (download.Details.ContentLength != source.Length || download.Details.ETag.ToString() != source.ETag)
+            {
+                throw new PreparationExpiredException("The prepared photo changed or has an unexpected length.");
+            }
+            using ExactLengthReadStream stream = new ExactLengthReadStream(download.Content, source.Length);
+            BlobClient destinationBlob = container.GetBlobClient(destination.BlobName);
+            Response<BlobContentInfo> upload = await destinationBlob.UploadAsync(stream, new BlobUploadOptions()
+            {
+                Conditions = new BlobRequestConditions() { IfNoneMatch = ETag.All },
+                HttpHeaders = new BlobHttpHeaders() { ContentType = "image/jpeg" },
+                TransferValidation = new UploadTransferValidationOptions() { ChecksumAlgorithm = StorageChecksumAlgorithm.Auto },
+                TransferOptions = new StorageTransferOptions()
+                {
+                    InitialTransferSize = 1024 * 1024,
+                    MaximumTransferSize = 1024 * 1024,
+                    MaximumConcurrency = 1
+                }
+            }, cancellationToken);
+            await stream.VerifyCompleteAsync(cancellationToken);
+            string etag = upload.Value.ETag.ToString();
+            await VerifyPhotoAsync(destination.BlobName, etag, source.Length, cancellationToken);
+            return destination with
+            {
+                ETag = etag
+            };
+        }
+
+        private async Task<BlobDownloadStreamingResult> ReadSourceAsync(PreparedSubmissionPhoto source,
+            CancellationToken cancellationToken)
+        {
+            try
+            {
+                return (await container.GetBlobClient(source.BlobName).DownloadStreamingAsync(
+                                                    new BlobDownloadOptions() { Conditions = new BlobRequestConditions() { IfMatch = new ETag(source.ETag) } },
+                                                    cancellationToken)).Value;
+            }
+            catch (RequestFailedException ex) when (IsExpiredSource(ex))
+            {
+                throw new PreparationExpiredException(innerException: ex);
+            }
+        }
+
+        private async Task VerifyPhotoAsync(string name, string etag, long length, CancellationToken cancellationToken)
+        {
+            BlobProperties properties = (await container.GetBlobClient(name).GetPropertiesAsync(
+                                        new BlobRequestConditions() { IfMatch = new ETag(etag) }, cancellationToken)).Value;
+            if (properties.ContentLength != length || properties.ETag.ToString() != etag)
+            {
+                throw new InvalidDataException("The stored photo changed or has an unexpected length.");
+            }
+        }
+
+        private async Task<Document?> ReadAsync(string id, CancellationToken cancellationToken)
+        {
+            if (!IsValidReportId(id))
+            {
+                throw new ArgumentException("Report IDs must contain 32 lowercase hexadecimal characters.", nameof(id));
+            }
+            BlobClient blob = container.GetBlobClient($"{BlobPrefix}{id}.json");
+            for (int attempt = 0; ; attempt++)
+            {
+                try
+                {
+                    BlobProperties properties = (await blob.GetPropertiesAsync(cancellationToken: cancellationToken)).Value;
+                    if (properties.ContentLength is <= 0 or > MaxRecordBytes)
+                    {
+                        throw new InvalidDataException("The report record is empty or too large.");
+                    }
+                    if (string.IsNullOrWhiteSpace(properties.ETag.ToString()) || properties.ETag == ETag.All)
+                    {
+                        throw new IOException("Storage returned no usable version for the report record.");
+                    }
+                    using BlobDownloadStreamingResult result = (await blob.DownloadStreamingAsync(new BlobDownloadOptions()
+                    {
+                        Conditions = new BlobRequestConditions() { IfMatch = properties.ETag }
+                    }, cancellationToken)).Value;
+                    if (result.Details.ETag != properties.ETag)
+                    {
+                        throw new RequestFailedException(412, "The report changed while being read.", "ConditionNotMet", null);
+                    }
+                    if (result.Details.ContentLength != properties.ContentLength)
+                    {
+                        throw new InvalidDataException("The report stream has an unexpected length.");
+                    }
+                    // Neither a misleading length header nor an unbounded stream may grow this buffer.
+                    byte[] content = new byte[(int)properties.ContentLength + 1];
+                    int count = 0;
+                    while (count < content.Length)
+                    {
+                        int read = await result.Content.ReadAsync(content.AsMemory(count), cancellationToken);
+                        if (read == 0)
+                        {
+                            break;
+                        }
+                        count += read;
+                    }
+                    if (count != properties.ContentLength)
+                    {
+                        throw new InvalidDataException("The report stream does not match its checked length.");
+                    }
+                    Document document = JsonSerializer.Deserialize<Document>(content.AsSpan(0, count))
+                                        ?? throw new InvalidDataException("The report record is empty.");
+                    ValidateStoredDocument(document, id);
+                    return document with
+                    {
+                        Version = result.Details.ETag.ToString()
+                    };
+                }
+                catch (RequestFailedException ex) when (ex.Status == 404 && ex.ErrorCode is null or "BlobNotFound")
+                {
+                    return null;
+                }
+                catch (RequestFailedException ex) when (attempt < 2 && ex.Status == 412 &&
+                    ex.ErrorCode is null or "ConditionNotMet")
+                {
+                    // Retry a changed coordinator from its new properties, never as absence or corruption.
+                }
+            }
+        }
+
+        private static void ValidateStoredDocument(Document document, string id)
+        {
+            if (document.SchemaVersion != 1 || document.ReportId != id ||
+                                        !Enum.IsDefined(document.State) || document.Photos is null ||
+                                        !IsSafeStoredTime(document.StartedAt) ||
+                                        document.AttemptId is not null && !IsValidReportId(document.AttemptId) ||
+                                        document.MutationId is not null && !IsValidReportId(document.MutationId))
+            {
+                throw new InvalidDataException("Invalid report record.");
+            }
+            bool accepted = IsAccepted(document);
+            bool legacy = document.AttemptId is null;
+            if (!accepted)
+            {
+                if (legacy || document.Receipt is not null || document.Moderation is not null ||
+                                                    document.ModerationPhotos is not null || document.LegacySidecars is not null || document.Cleanup is not null)
+                {
+                    throw new InvalidDataException("Invalid preparation record.");
+                }
+            }
+            else
+            {
+                SubmissionReceipt? receipt = document.Receipt;
+                if (receipt is null || receipt.ReportId != id || !IsSafeComponent(receipt.SubmissionId) ||
+                    receipt.SubmittedAt == default || receipt.Attribution is null ||
+                    legacy && (document.DeviceId is not null || LegacyReportId(receipt.SubmissionId) != id))
+                {
+                    throw new InvalidDataException("Invalid report receipt or legacy context.");
+                }
+                try
+                {
+                    ValidateAttribution(receipt.Attribution);
+                }
+                catch (ArgumentException ex)
+                {
+                    throw new InvalidDataException("Invalid stored report attribution.", ex);
+                }
+            }
+
+            if (document.Moderation is { } moderation &&
+                (!accepted || !IsValidReportId(moderation.Id) ||
+                 moderation.Kind is not ("publishing" or "deleting") || !IsSafeStoredTime(moderation.StartedAt)) ||
+                document.ModerationPhotos is not null && document.Moderation is null)
+            {
+                throw new InvalidDataException("Invalid moderation ownership.");
+            }
+            if (document.State == ReportState.Retired)
+            {
+                if (document.Moderation is null || document.Cleanup is null)
+                {
+                    throw new InvalidDataException("Retired reports require ownership and a cleanup inventory.");
+                }
+                if (document.Photos.Count == 0)
+                {
+                    if (document.Cleanup.Count != 0 || document.ModerationPhotos is not null || document.LegacySidecars is not null)
+                    {
+                        throw new InvalidDataException("Invalid compacted retirement record.");
+                    }
+                    return;
+                }
+            }
+            else if (document.Cleanup is not null)
+            {
+                throw new InvalidDataException("Only retired reports may authorize inventory cleanup.");
+            }
+
+            ValidateStoredPhotos(document, document.Photos, legacy, moderation: false);
+            if (document.ModerationPhotos is { } snapshot)
+            {
+                ValidateStoredPhotos(document, snapshot, legacy, moderation: true);
+                if (snapshot.Count != document.Photos.Count)
+                {
+                    throw new InvalidDataException("Invalid moderation photo inventory.");
+                }
+                for (int index = 0; index < snapshot.Count; index++)
+                {
+                    SubmissionPhoto original = document.Photos[index];
+                    SubmissionPhoto replacement = snapshot[index];
+                    if (replacement.BlobName != original.BlobName || replacement.ETag != original.ETag ||
+                        replacement.Length != original.Length || replacement.Metadata.PhotoId != original.Metadata.PhotoId ||
+                        replacement.Metadata.SubmissionId != original.Metadata.SubmissionId ||
+                        replacement.Metadata.PhotoNumber != original.Metadata.PhotoNumber)
+                    {
+                        throw new InvalidDataException("Moderation cannot change stored photo references.");
+                    }
+                }
+            }
+
+            HashSet<string> sidecars = document.Photos.Select(p => $"{FinalizedUploadPrefix}{p.Metadata.PhotoId}.json")
+                .ToHashSet(StringComparer.Ordinal);
+            if (legacy)
+            {
+                if (document.LegacySidecars is null || document.LegacySidecars.Count != sidecars.Count ||
+                                                    !sidecars.SetEquals(document.LegacySidecars))
+                {
+                    throw new InvalidDataException("Invalid legacy sidecar inventory.");
+                }
+            }
+            else if (document.LegacySidecars is not null)
+            {
+                throw new InvalidDataException("Non-legacy reports cannot reference legacy sidecars.");
+            }
+
+            if (document.State == ReportState.Retired)
+            {
+                HashSet<CleanupItem> inventory = document.Photos.Select(p => new CleanupItem(p.BlobName, p.ETag)).ToHashSet();
+                if (legacy)
+                {
+                    inventory.UnionWith(sidecars.Select(name => new CleanupItem(name, null)));
+                }
+                if (document.Cleanup!.Count != inventory.Count || !inventory.SetEquals(document.Cleanup))
+                {
+                    throw new InvalidDataException("Cleanup must match the retained photo and sidecar inventory.");
+                }
+            }
+        }
+
+        private static void ValidateStoredPhotos(Document document, IReadOnlyList<SubmissionPhoto> photos, bool legacy,
+            bool moderation)
+        {
+            if (photos.Any(photo => photo is null || photo.Metadata is null))
+            {
+                throw new InvalidDataException("Missing stored photo or metadata.");
+            }
+            try
+            {
+                // A preparing/abandoned reservation has destination keys but no committed photo ETags yet.
+                IReadOnlyList<SubmissionPhoto> checkedPhotos = IsAccepted(document) ? photos :
+                    photos.Select(photo => photo.ETag == "" ? photo with { ETag = "reserved" } : photo).ToArray();
+                ValidatePhotos(checkedPhotos, document.ReportId, document.DeviceId, legacy || moderation);
+                foreach (SubmissionPhoto photo in photos)
+                {
+                    RejectSecrets(photo.Metadata, allowTwitterLink: moderation);
+                }
+            }
+            catch (ArgumentException ex)
+            {
+                throw new InvalidDataException("Invalid stored photo set.", ex);
+            }
+
+            for (int index = 0; index < photos.Count; index++)
+            {
+                SubmissionPhoto photo = photos[index];
+                FinalizedPhotoUploadMetadata metadata = photo.Metadata;
+                string expectedPath = legacy ? $"{FinalizedUploadPrefix}{metadata.PhotoId}.jpeg" :
+                    $"{PhotoPrefix}{document.ReportId}/{document.AttemptId}/{index}.jpeg";
+                if (photo.BlobName != expectedPath || metadata.ReportId != document.ReportId ||
+                    metadata.DeviceId != document.DeviceId ||
+                    document.Receipt is { } receipt && metadata.SubmissionId != receipt.SubmissionId)
+                {
+                    throw new InvalidDataException("Invalid stored photo reference or submitting context.");
+                }
+                if (moderation && (metadata.PhotoDateTime is null || metadata.NumberOfCars is null or <= 0 ||
+                                !Coordinate(metadata.PhotoLatitude, 47.495082, 47.735525) ||
+                                !Coordinate(metadata.PhotoLongitude, -122.436522, -122.235787) ||
+                                !IsValidPublicationLink(metadata.TwitterLink)))
+                {
+                    throw new InvalidDataException("Invalid stored moderation metadata.");
+                }
+            }
+        }
+
+        private static bool IsSafeStoredTime(DateTimeOffset time)
+        {
+            return time != default &&
+                                    time.Ticks <= DateTime.MaxValue.Ticks - PreparationTimeout.Ticks &&
+                                    time.UtcTicks <= DateTime.MaxValue.Ticks - PreparationTimeout.Ticks;
+        }
+
+        private async Task<Document> WriteAsync(Document document, string? expectedVersion, CancellationToken cancellationToken)
+        {
+            document = document with
+            {
+                MutationId = Guid.NewGuid().ToString("N"),
+                Version = null
+            };
+            BinaryData content = BinaryData.FromObjectAsJson(document);
+            if (content.ToMemory().Length > MaxRecordBytes)
+            {
+                throw new ArgumentException("Report metadata is too large.");
+            }
+            try
+            {
+                Response<BlobContentInfo> response = await container.GetBlobClient($"{BlobPrefix}{document.ReportId}.json")
+                                                    .UploadAsync(content, new BlobUploadOptions()
+                                                    {
+                                                        Conditions = expectedVersion is null
+                                                            ? new BlobRequestConditions() { IfNoneMatch = ETag.All }
+                                                            : new BlobRequestConditions() { IfMatch = new ETag(expectedVersion) },
+                                                        HttpHeaders = new BlobHttpHeaders() { ContentType = "application/json" }
+                                                    }, cancellationToken);
+                return document with
+                {
+                    Version = response.Value.ETag.ToString()
+                };
+            }
+            catch (Exception) when (!cancellationToken.IsCancellationRequested)
+            {
+                Document? recovered = await ReadAsync(document.ReportId, cancellationToken);
+                if (recovered?.MutationId == document.MutationId)
+                {
+                    return recovered;
+                }
+                throw;
+            }
+        }
+
+        private async Task<Document> ReadModeratableAsync(string id, CancellationToken cancellationToken)
+        {
+            Document document = await ReadAsync(id, cancellationToken) ?? throw new KeyNotFoundException("Report not found.");
+            if (document.State == ReportState.Preparing)
+            {
+                throw InProgress(document);
+            }
+            if (document.State != ReportState.Accepted)
+            {
+                throw new ReportConflictException("This report is not pending moderation.");
+            }
+            return document;
+        }
+
+        private async Task CleanupRetiredAsync(Document document, CancellationToken cancellationToken)
+        {
+            if (document.Cleanup is null || document.Cleanup.Count == 0)
+            {
+                return;
+            }
+            foreach (CleanupItem item in document.Cleanup)
+            {
+                await DeleteAsync(item.BlobName, item.ETag, cancellationToken);
+            }
+            try
+            {
+                await WriteAsync(document with
+                {
+                    Photos = [],
+                    ModerationPhotos = null,
+                    LegacySidecars = null,
+                    Cleanup = []
+                }, document.Version, cancellationToken);
+            }
+            catch (RequestFailedException ex) when (IsConditionFailure(ex))
+            {
+                // Concurrent cleanup can compact the same tombstone. No state can restore it.
+            }
+        }
+
+        private async Task DeleteAsync(string name, string? etag, CancellationToken cancellationToken)
+        {
+            await container.GetBlobClient(name).DeleteIfExistsAsync(DeleteSnapshotsOption.IncludeSnapshots,
+                                        etag is null ? null : new BlobRequestConditions() { IfMatch = new ETag(etag) }, cancellationToken);
+        }
+
+        private bool IsLive(Document document)
+        {
+            return document.State == ReportState.Preparing && document.StartedAt + PreparationTimeout > clock.GetUtcNow();
+        }
+
+        private ReportInProgressException InProgress(Document document)
+        {
+            return new ReportInProgressException(TimeSpan.FromSeconds(Math.Max(1, Math.Ceiling(
+                                        (document.StartedAt + PreparationTimeout - clock.GetUtcNow()).TotalSeconds))));
+        }
+
+        private static bool IsAccepted(Document document)
+        {
+            return document.State is ReportState.Accepted or ReportState.Retired;
+        }
+
+        private static bool IsConditionFailure(RequestFailedException ex)
+        {
+            return ex.Status == 412 && ex.ErrorCode is null or "ConditionNotMet" ||
+                                    ex.Status == 409 && ex.ErrorCode is null or "BlobAlreadyExists";
+        }
+
+        private static bool IsExpiredSource(RequestFailedException ex)
+        {
+            return ex.Status == 404 && ex.ErrorCode is null or "BlobNotFound" ||
+                                    ex.Status == 412 && ex.ErrorCode is null or "ConditionNotMet";
+        }
+
+        private static SubmissionReport ToReport(Document document)
+        {
+            return new SubmissionReport(document.Receipt!, document.DeviceId, document.ModerationPhotos ?? document.Photos,
+                                        document.State == ReportState.Retired, document.Moderation)
+            {
+                Version = document.Version
+            };
+        }
+
+        private static void CheckDevice(Document document, string? deviceId)
+        {
+            if (!string.Equals(document.DeviceId, deviceId, StringComparison.Ordinal))
+            {
+                throw new ReportDeviceMismatchException();
+            }
+        }
+
+        private static void CheckOperation(Document document, string operationId)
+        {
+            if (document.Moderation is null || document.Moderation.Id != operationId)
+            {
+                throw new ReportConflictException("This operation does not own the report.");
+            }
+        }
+
+        private static SubmissionReport ExistingLegacy(Document document, string legacySubmissionId)
+        {
+            CheckDevice(document, null);
+            if (!IsAccepted(document) || document.Receipt?.SubmissionId != legacySubmissionId)
+            {
+                throw new ReportConflictException("The legacy report ID is already reserved.");
+            }
+            return ToReport(document);
+        }
+
+        private static bool TryGetRecordId(string name, out string id)
+        {
+            id = name.StartsWith(BlobPrefix, StringComparison.Ordinal) && name.EndsWith(".json", StringComparison.Ordinal)
+                                        ? name[BlobPrefix.Length..^5] : "";
+            return IsValidReportId(id);
+        }
+
+        private static bool IsSafeComponent(string value)
+        {
+            return !string.IsNullOrWhiteSpace(value) && value.Length <= 128 &&
+                                    value is not ("." or "..") && value.All(c => char.IsAsciiLetterOrDigit(c) || c is '-' or '_' or '.');
+        }
+
+        private static bool IsPhotoPath(string name, string prefix)
+        {
+            return !string.IsNullOrEmpty(name) && name.StartsWith(prefix, StringComparison.Ordinal) && name.Length <= 512 &&
+                                    name[prefix.Length..].Split('/').All(part => part.Length > 0 && part is not ("." or "..")) &&
+                                    !name.Contains('\\') && !name.Contains('?') && !name.Contains('#') &&
+                                    (name.EndsWith(".jpeg", StringComparison.Ordinal) || name.EndsWith(".jpg", StringComparison.Ordinal));
+        }
+
+        private static void ValidateAttribution(ReportAttribution attribution)
+        {
+            ArgumentNullException.ThrowIfNull(attribution);
+            if (attribution.BlueskyDid is { } did &&
+                (!did.StartsWith("did:", StringComparison.Ordinal) || did.Length > 512 || did.Any(char.IsWhiteSpace)))
+            {
+                throw new ArgumentException("Invalid Bluesky attribution.", nameof(attribution));
+            }
+            if ((attribution.MastodonServer is null) != (attribution.MastodonAccountId is null))
+            {
+                throw new ArgumentException("Mastodon attribution requires a server and account ID.", nameof(attribution));
+            }
+            if (attribution.MastodonServer is { } server &&
+                        (!Uri.TryCreate(server, UriKind.Absolute, out Uri? uri) || uri.Scheme != "https" ||
+                         uri.UserInfo.Length != 0 || uri.AbsolutePath != "/" || uri.Query.Length != 0 || uri.Fragment.Length != 0 ||
+                         string.IsNullOrWhiteSpace(attribution.MastodonAccountId) || attribution.MastodonAccountId.Length > 128))
+            {
+                throw new ArgumentException("Invalid Mastodon attribution.", nameof(attribution));
+            }
+        }
+
+        private static void ValidatePhotos(IReadOnlyList<SubmissionPhoto> photos, string id, string? deviceId, bool legacy)
+        {
+            if (photos.Count is < 1 or > 4)
+            {
+                throw new ArgumentException("A report must contain one to four photos.", nameof(photos));
+            }
+            HashSet<string> ids = new HashSet<string>(StringComparer.Ordinal);
+            HashSet<string> paths = new HashSet<string>(StringComparer.Ordinal);
+            long total = 0;
+            for (int index = 0; index < photos.Count; index++)
+            {
+                SubmissionPhoto photo = photos[index];
+                FinalizedPhotoUploadMetadata metadata = photo.Metadata ?? throw new ArgumentException("Missing photo metadata.");
+                if (!IsSafeComponent(metadata.PhotoId) || !IsSafeComponent(metadata.SubmissionId) ||
+                    !ids.Add(metadata.PhotoId) || !paths.Add(photo.BlobName) ||
+                    string.IsNullOrWhiteSpace(photo.ETag) || photo.ETag == "*" ||
+                    photo.Length is <= 0 or > MaxPhotoBytes ||
+                    (total += photo.Length) > MaxReportBytes ||
+                    metadata.SubmissionId != photos[0].Metadata.SubmissionId ||
+                    metadata.PhotoNumber < 0 || (index > 0 && metadata.PhotoNumber <= photos[index - 1].Metadata.PhotoNumber))
+                {
+                    throw new ArgumentException("Invalid photo set, versions, order, or sizes.", nameof(photos));
+                }
+                if (legacy)
+                {
+                    continue;
+                }
+                RejectSecrets(metadata);
+                if (metadata.PhotoNumber != index ||
+                    metadata.ReportId is not null && metadata.ReportId != id ||
+                    metadata.DeviceId is not null && metadata.DeviceId != deviceId ||
+                    metadata.PhotoDateTime is null || metadata.NumberOfCars is null or <= 0 ||
+                    !Coordinate(metadata.PhotoLatitude, 47.495082, 47.735525) ||
+                    !Coordinate(metadata.PhotoLongitude, -122.436522, -122.235787) ||
+                    metadata.NumberOfCars != photos[0].Metadata.NumberOfCars ||
+                    metadata.Attribute != photos[0].Metadata.Attribute ||
+                    metadata.BlueskyUserDid != photos[0].Metadata.BlueskyUserDid ||
+                    metadata.MastodonFullUsername != photos[0].Metadata.MastodonFullUsername)
+                {
+                    throw new ArgumentException("Invalid report metadata or submitting context.", nameof(photos));
+                }
+            }
+        }
+
+        private static bool Coordinate(string? value, double minimum, double maximum)
+        {
+            return double.TryParse(value, NumberStyles.Float, CultureInfo.InvariantCulture, out double number) &&
+                                    double.IsFinite(number) && number >= minimum && number <= maximum;
+        }
+
+        private static bool IsValidPublicationLink(string? value)
+        {
+            return string.IsNullOrEmpty(value) ||
+                                    Uri.TryCreate(value, UriKind.Absolute, out Uri? uri) && uri.Scheme is "http" or "https" &&
+                                    uri.Host.Length > 0 && uri.UserInfo.Length == 0;
+        }
+
+        private static void CheckMetadataSize(List<SubmissionPhoto> photos)
+        {
+            // Reserve room for an independent moderation snapshot and retirement inventory, so
+            // accepting a near-limit report cannot make its later lifecycle transitions impossible.
+            if (BinaryData.FromObjectAsJson(photos).ToMemory().Length > MaxRecordBytes / 3)
+            {
+                throw new ArgumentException("Report metadata is too large.");
+            }
+        }
+
+        private static void RejectSecrets(FinalizedPhotoUploadMetadata metadata, bool allowTwitterLink = false)
+        {
+            if (!string.IsNullOrEmpty(metadata.TwitterAccessToken) || !string.IsNullOrEmpty(metadata.MastodonAccessToken) ||
+                                        !string.IsNullOrEmpty(metadata.ThreadsAccessToken) || !string.IsNullOrEmpty(metadata.BlueskyAccessJwt) ||
+                                        !string.IsNullOrEmpty(metadata.BlueskyAdminDid) ||
+                                        !allowTwitterLink && !string.IsNullOrEmpty(metadata.TwitterLink))
+            {
+                throw new ArgumentException("Credentials and administrator-only fields cannot be stored in a report.");
+            }
+        }
+
+        private static FinalizedPhotoUploadMetadata CloneMetadata(FinalizedPhotoUploadMetadata metadata, string id, string? deviceId,
+            bool preserveTwitterLink = false)
+        {
+            FinalizedPhotoUploadMetadata clone = JsonSerializer.Deserialize<FinalizedPhotoUploadMetadata>(
+                                        JsonSerializer.Serialize(metadata))!;
+            clone.TwitterAccessToken = null;
+            clone.MastodonAccessToken = null;
+            clone.ThreadsAccessToken = null;
+            clone.BlueskyAccessJwt = null;
+            clone.BlueskyAdminDid = null;
+            if (!preserveTwitterLink)
+            {
+                clone.TwitterLink = null;
+            }
+            clone.ReportId = id;
+            clone.DeviceId = deviceId;
+            return clone;
+        }
+
+        private sealed class ExactLengthReadStream : Stream
+        {
+            private readonly Stream inner;
+            private readonly long expectedLength;
+            private long count;
+
+            public ExactLengthReadStream(Stream inner, long expectedLength)
+            {
+                this.inner = inner;
+                this.expectedLength = expectedLength;
+            }
+
+            public override bool CanRead => true;
+            public override bool CanSeek => false;
+            public override bool CanWrite => false;
+            public override long Length => throw new NotSupportedException();
+            public override long Position
+            {
+                get
+                {
+                    return count;
+                }
+                set
+                {
+                    throw new NotSupportedException();
+                }
+            }
+
+            public override int Read(byte[] buffer, int offset, int count)
+            {
+                return Read(buffer.AsSpan(offset, count));
+            }
+
+            public override int Read(Span<byte> buffer)
+            {
+                try
+                {
+                    return buffer.IsEmpty ? 0 : Check(inner.Read(buffer[..(int)Math.Min(buffer.Length, expectedLength - count + 1)]));
+                }
+                catch (RequestFailedException ex) when (IsExpiredSource(ex))
+                {
+                    throw new PreparationExpiredException(innerException: ex);
+                }
+            }
+
+            public override async ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
+            {
+                try
+                {
+                    return buffer.IsEmpty ? 0 :
+                                                                Check(await inner.ReadAsync(buffer[..(int)Math.Min(buffer.Length, expectedLength - count + 1)], cancellationToken));
+                }
+                catch (RequestFailedException ex) when (IsExpiredSource(ex))
+                {
+                    throw new PreparationExpiredException(innerException: ex);
+                }
+            }
+
+            public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+            {
+                return ReadAsync(buffer.AsMemory(offset, count), cancellationToken).AsTask();
+            }
+
+            private int Check(int read)
+            {
+                count += read;
+                if (count > expectedLength || read == 0 && count != expectedLength)
+                {
+                    throw new PreparationExpiredException("Photo stream does not match its checked length.");
+                }
+                return read;
+            }
+
+            public async Task VerifyCompleteAsync(CancellationToken cancellationToken)
+            {
+                if (count != expectedLength || await ReadAsync(new byte[1], cancellationToken) != 0)
+                {
+                    throw new InvalidDataException("Photo stream does not match its checked length.");
+                }
+            }
+
+            public override void Flush()
+            {
+                throw new NotSupportedException();
+            }
+
+            public override long Seek(long offset, SeekOrigin origin)
+            {
+                throw new NotSupportedException();
+            }
+
+            public override void SetLength(long value)
+            {
+                throw new NotSupportedException();
+            }
+
+            public override void Write(byte[] buffer, int offset, int count)
+            {
+                throw new NotSupportedException();
+            }
+        }
+    }
+}

--- a/SeattleCarsInBikeLanes/ReportCleanupService.cs
+++ b/SeattleCarsInBikeLanes/ReportCleanupService.cs
@@ -1,0 +1,33 @@
+using Azure;
+using SeattleCarsInBikeLanes.Providers;
+
+namespace SeattleCarsInBikeLanes
+{
+    public sealed class ReportCleanupService : BackgroundService
+    {
+        private readonly ReportStore reports;
+        private readonly ILogger<ReportCleanupService> logger;
+
+        public ReportCleanupService(ReportStore reports, ILogger<ReportCleanupService> logger)
+        {
+            this.reports = reports;
+            this.logger = logger;
+        }
+
+        protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+        {
+            using PeriodicTimer timer = new PeriodicTimer(TimeSpan.FromMinutes(10));
+            do
+            {
+                try
+                {
+                    await reports.CleanupAsync(stoppingToken);
+                }
+                catch (Exception ex) when (ex is RequestFailedException or IOException or InvalidDataException or System.Text.Json.JsonException)
+                {
+                    logger.LogError(ex, "Report cleanup did not finish; durable cleanup state is retained for retry.");
+                }
+            } while (await timer.WaitForNextTickAsync(stoppingToken));
+        }
+    }
+}

--- a/SeattleCarsInBikeLanes/SeattleCarsInBikeLanes.csproj
+++ b/SeattleCarsInBikeLanes/SeattleCarsInBikeLanes.csproj
@@ -30,6 +30,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\SeattleCarsInBikeLanes.Core\SeattleCarsInBikeLanes.Core.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/SeattleCarsInBikeLanes/Storage/Models/AbstractPhotoUploadMetadata.cs
+++ b/SeattleCarsInBikeLanes/Storage/Models/AbstractPhotoUploadMetadata.cs
@@ -1,4 +1,6 @@
-﻿namespace SeattleCarsInBikeLanes.Storage.Models
+﻿using SeattleCarsInBikeLanes.Core.Contracts;
+
+namespace SeattleCarsInBikeLanes.Storage.Models
 {
     public abstract class AbstractPhotoUploadMetadata
     {
@@ -65,11 +67,5 @@
             PhotoLongitude = photoLongitude;
             Tags = tags;
         }
-    }
-
-    public class ImageTag
-    {
-        public string Name { get; set; } = default!;
-        public float Confidence { get; set; } = default!;
     }
 }

--- a/SeattleCarsInBikeLanes/Storage/Models/FinalizedPhotoUploadMetadata.cs
+++ b/SeattleCarsInBikeLanes/Storage/Models/FinalizedPhotoUploadMetadata.cs
@@ -1,4 +1,6 @@
-﻿namespace SeattleCarsInBikeLanes.Storage.Models
+﻿using SeattleCarsInBikeLanes.Core.Contracts;
+
+namespace SeattleCarsInBikeLanes.Storage.Models
 {
     public class FinalizedPhotoUploadMetadata : AbstractPhotoUploadMetadata
     {
@@ -20,9 +22,55 @@
         public string? ThreadsAccessToken { get; set; }
         public bool UserSpecifiedDateTime { get; set; }
         public bool UserSpecifiedLocation { get; set; }
+
+        /// <summary>
+        /// Which device submitted the report, when it came from the mobile app.
+        /// </summary>
+        /// <remarks>
+        /// Set by the server from the request header, never from the request body, so it cannot be
+        /// forged to blame another device. It identifies an install, not a person.
+        /// </remarks>
+        public string? DeviceId { get; set; }
+
+        /// <summary>
+        /// The stable report identifier used to suppress duplicate finalization.
+        /// </summary>
+        public string? ReportId { get; set; }
+
         public string? TwitterLink { get; set; }
         public string? BlueskyAdminDid { get; set; }
         public string? BlueskyAccessJwt { get; set; }
+
+        public static FinalizedPhotoUploadMetadata FromContract(FinalizedPhotoUpload upload)
+        {
+            return new FinalizedPhotoUploadMetadata()
+            {
+                PhotoId = upload.PhotoId,
+                SubmissionId = upload.SubmissionId,
+                PhotoNumber = upload.PhotoNumber,
+                PhotoDateTime = upload.PhotoDateTime,
+                PhotoLatitude = upload.PhotoLatitude,
+                PhotoLongitude = upload.PhotoLongitude,
+                PhotoCrossStreet = upload.PhotoCrossStreet,
+                Tags = upload.Tags,
+                NumberOfCars = upload.NumberOfCars,
+                UserSpecifiedDateTime = upload.UserSpecifiedDateTime,
+                UserSpecifiedLocation = upload.UserSpecifiedLocation,
+                Attribute = upload.Attribute,
+                TwitterSubmittedBy = upload.TwitterSubmittedBy,
+                MastodonSubmittedBy = upload.MastodonSubmittedBy,
+                BlueskySubmittedBy = upload.BlueskySubmittedBy,
+                ThreadsSubmittedBy = upload.ThreadsSubmittedBy,
+                TwitterUsername = upload.TwitterUsername,
+                TwitterAccessToken = upload.TwitterAccessToken,
+                MastodonEndpoint = upload.MastodonEndpoint,
+                MastodonUsername = upload.MastodonUsername,
+                MastodonFullUsername = upload.MastodonFullUsername,
+                MastodonAccessToken = upload.MastodonAccessToken,
+                ThreadsUsername = upload.ThreadsUsername,
+                ThreadsAccessToken = upload.ThreadsAccessToken
+            };
+        }
 
         // Here because of bug when trying to deserialize values types to nullable value type properties
         // See https://github.com/dotnet/runtime/issues/44428

--- a/SeattleCarsInBikeLanes/Storage/Models/InitialPhotoUploadMetadata.cs
+++ b/SeattleCarsInBikeLanes/Storage/Models/InitialPhotoUploadMetadata.cs
@@ -1,7 +1,32 @@
-﻿namespace SeattleCarsInBikeLanes.Storage.Models
+﻿using SeattleCarsInBikeLanes.Core.Contracts;
+
+namespace SeattleCarsInBikeLanes.Storage.Models
 {
     public class InitialPhotoUploadMetadata : AbstractPhotoUploadMetadata
     {
+        public string? ReportId { get; set; }
+        public string? DeviceId { get; set; }
+
+        public InitialPhotoUploadMetadata()
+        {
+        }
+
+        public InitialPhotoUpload ToContract(string uri)
+        {
+            return new InitialPhotoUpload()
+            {
+                Uri = uri,
+                PhotoId = PhotoId,
+                SubmissionId = SubmissionId,
+                PhotoNumber = PhotoNumber,
+                PhotoDateTime = PhotoDateTime,
+                PhotoLatitude = PhotoLatitude,
+                PhotoLongitude = PhotoLongitude,
+                PhotoCrossStreet = PhotoCrossStreet,
+                Tags = Tags
+            };
+        }
+
         public InitialPhotoUploadMetadata(string photoId,
             string submissionId,
             int photoNumber,

--- a/SeattleCarsInBikeLanes/wwwroot/admin.html
+++ b/SeattleCarsInBikeLanes/wwwroot/admin.html
@@ -82,14 +82,67 @@
       <button class="btn btn-danger" id="deletePostButton">Delete</button>
     </div>
   </div>
-  <div class="row">
-    <div id="pendingItems"></div>
+  <section class="my-4" aria-labelledby="blockedDevicesHeading">
+    <h2 id="blockedDevicesHeading" class="h4">Blocked devices</h2>
+    <p>Blocks prevent future submissions. Accepted reports are unchanged. Reasons are visible only to administrators.</p>
+    <button type="button" class="btn btn-secondary" id="refreshBlockedDevicesButton">Refresh blocked devices</button>
+    <p id="blockedDevicesStatus" class="mt-2" role="status" aria-live="polite">Loading blocked devices...</p>
+    <div id="blockedDevicesError" class="alert alert-danger" role="alert" hidden></div>
+    <ul id="blockedDevicesList" class="list-group"></ul>
+  </section>
+  <div class="modal fade" id="deviceBlockModal" tabindex="-1" aria-labelledby="deviceBlockModalTitle"
+    aria-describedby="deviceBlockModalDescription" aria-hidden="true">
+    <div class="modal-dialog modal-dialog-scrollable">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h2 class="modal-title fs-5" id="deviceBlockModalTitle">Block device</h2>
+        </div>
+        <div class="modal-body">
+          <p class="text-break">Device: <strong id="deviceBlockModalTarget"></strong></p>
+          <p id="deviceBlockModalDescription"></p>
+          <div id="deviceBlockReasonGroup">
+            <label for="deviceBlockReason" class="form-label">Reason for blocking (required)</label>
+            <textarea id="deviceBlockReason" class="form-control" rows="4" required maxlength="1000"
+              aria-describedby="deviceBlockReasonHelp deviceBlockModalError"></textarea>
+            <p id="deviceBlockReasonHelp" class="form-text">1-1,000 characters after trimming. Visible only to administrators.</p>
+          </div>
+          <div id="deviceBlockSavedReasonGroup" hidden>
+            <h3 class="h6">Saved reason</h3>
+            <p id="deviceBlockSavedReason" class="text-break" style="white-space: pre-wrap;"></p>
+          </div>
+          <div id="deviceBlockModalError" class="alert alert-danger" role="alert" hidden></div>
+          <button type="button" class="btn btn-secondary" id="deviceBlockModalRefresh" hidden>Refresh status</button>
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-secondary" id="deviceBlockModalCancel">Cancel</button>
+          <button type="button" class="btn btn-danger" id="deviceBlockModalConfirm">Confirm block</button>
+        </div>
+      </div>
+    </div>
   </div>
+  <div class="row">
+    <div id="pendingItems" role="status" aria-live="polite"></div>
+    <div><button type="button" class="btn btn-secondary" id="refreshPendingButton">Refresh pending reports</button></div>
+  </div>
+  <details class="my-3">
+    <summary>Retrying a failed upload</summary>
+    <p>A failed upload stays in this panel with its photos. Check Bluesky, Mastodon and Threads
+      and delete any posts that succeeded. Check the logs, fix the cause (such as an expired
+      Threads access token), then click Upload again on the same report.</p>
+    <p>Publishing is never retried automatically. While a request is still running, its buttons
+      are disabled to prevent duplicate clicks. A failed request releases the report for retry
+      and keeps your form edits. Database and feed entries are updated under the same report ID
+      if an earlier attempt reached those steps.</p>
+    <p>Missing or corrupt saved photos require repair of the original JPEG/JSON pairs.
+      The panel cannot recover bytes that were already lost. If a corrupt sidecar cannot be associated
+      with a report, legacy moderation is blocked until it is repaired so that no photos are omitted.</p>
+  </details>
   <div id="cardsDiv"></div>
   <script src="https://cdn.jsdelivr.net/npm/luxon@3.0.4/build/global/luxon.min.js"></script>
   <script src="js/element-helpers.js"></script>
-  <script src="js/admin-helpers.js"></script>
-  <script src="js/admin.js"></script>
+  <script src="js/admin-helpers.js?v=device-blocks-1"></script>
+  <script src="js/admin-device-blocks.js?v=device-blocks-1"></script>
+  <script src="js/admin.js?v=device-blocks-1"></script>
 </body>
 
 </html>

--- a/SeattleCarsInBikeLanes/wwwroot/index.html
+++ b/SeattleCarsInBikeLanes/wwwroot/index.html
@@ -379,10 +379,14 @@
     <script src="js/azure-maps-layer-legend.min.js"></script>
     <script src="js/azure-maps-spider-clusters.min.js"></script>
     <script src="js/element-helpers.js"></script>
-    <script src="js/helpers.js"></script>
+    <!-- The v= query parameter changes the script URL so browsers fetch updated code instead of
+         reusing a cached version that sends the old upload format. We update this label manually
+         when a deployment needs fresh scripts. -->
+    <script src="js/helpers.js?v=shared-reports-1"></script>
+    <script src="js/upload-report.js?v=shared-reports-1"></script>
     <script src="js/bluesky-auth.js"></script>
     <script src="js/bikelanes.js"></script>
-    <script src="js/index.js"></script>
+    <script src="js/index.js?v=shared-reports-1"></script>
     <script src="js/mobile-auth.js"></script>
     <script type="module" src="js/csvexport.js"></script>
 </body>

--- a/SeattleCarsInBikeLanes/wwwroot/js/admin-device-blocks.js
+++ b/SeattleCarsInBikeLanes/wwwroot/js/admin-device-blocks.js
@@ -1,0 +1,233 @@
+class AdminDeviceBlocks {
+    constructor() {
+        this.records = new Map();
+        this.status = 'unknown';
+        this.refreshVersion = 0;
+        this.busy = false;
+        this.action = null;
+        this.list = document.getElementById('blockedDevicesList');
+        this.listStatus = document.getElementById('blockedDevicesStatus');
+        this.listError = document.getElementById('blockedDevicesError');
+        this.refreshButton = document.getElementById('refreshBlockedDevicesButton');
+        this.modalElement = document.getElementById('deviceBlockModal');
+        this.modal = new bootstrap.Modal(this.modalElement);
+        this.reason = document.getElementById('deviceBlockReason');
+        this.savedReason = document.getElementById('deviceBlockSavedReason');
+        this.modalError = document.getElementById('deviceBlockModalError');
+        this.confirmButton = document.getElementById('deviceBlockModalConfirm');
+        this.cancelButton = document.getElementById('deviceBlockModalCancel');
+        this.modalRefresh = document.getElementById('deviceBlockModalRefresh');
+
+        this.refreshButton.addEventListener('click', () => this.refresh());
+        this.confirmButton.addEventListener('click', () => this.confirm());
+        this.cancelButton.addEventListener('click', () => this.modal.hide());
+        this.modalRefresh.addEventListener('click', () => this.recover());
+        this.reason.addEventListener('input', () => this.reason.removeAttribute('aria-invalid'));
+        this.modalElement.addEventListener('shown.bs.modal', () => {
+            (this.action?.blocking ? this.reason : this.cancelButton).focus();
+        });
+        this.modalElement.addEventListener('hide.bs.modal', event => {
+            if (this.busy) event.preventDefault();
+        });
+        this.modalElement.addEventListener('hidden.bs.modal', () => {
+            const opener = this.action?.opener;
+            this.action = null;
+            this.reason.value = '';
+            (opener?.isConnected && !opener.disabled ? opener : this.refreshButton).focus();
+        });
+    }
+
+    createControl(deviceId) {
+        const control = document.createElement('span');
+        control.append(`Device: ${deviceId}`);
+        if (typeof deviceId !== 'string' || !deviceId.trim()) return control;
+        control.dataset.deviceBlockControl = deviceId.trim();
+        const status = document.createElement('span');
+        status.className = 'ms-2';
+        status.setAttribute('role', 'status');
+        const button = document.createElement('button');
+        button.type = 'button';
+        button.className = 'btn btn-outline-danger btn-sm ms-2';
+        button.textContent = 'Block device';
+        button.addEventListener('click', () => this.open(control.dataset.deviceBlockControl, true, button));
+        control.append(status, button);
+        this.updateControl(control);
+        return control;
+    }
+
+    updateControl(control) {
+        const deviceId = control.dataset.deviceBlockControl;
+        const blocked = this.records.has(deviceId);
+        control.querySelector('span').textContent = this.status === 'known' ?
+            (blocked ? 'Blocked' : 'Not blocked') :
+            (this.status === 'loading' ? 'Checking block status...' : 'Block status unknown');
+        control.querySelector('button').disabled = this.busy || this.status !== 'known' || blocked ||
+            !/^[A-Za-z0-9_-]{1,128}$/.test(deviceId);
+    }
+
+    render() {
+        document.querySelectorAll('[data-device-block-control]').forEach(control => this.updateControl(control));
+        const rows = document.createDocumentFragment();
+        for (const [deviceId, reason] of this.records) {
+            const row = document.createElement('li');
+            row.className = 'list-group-item';
+            const id = document.createElement('strong');
+            id.className = 'text-break';
+            id.textContent = deviceId;
+            const text = document.createElement('p');
+            text.className = 'text-break mb-2';
+            text.style.whiteSpace = 'pre-wrap';
+            text.textContent = reason;
+            const button = document.createElement('button');
+            button.type = 'button';
+            button.className = 'btn btn-outline-danger btn-sm';
+            button.textContent = 'Unblock';
+            button.setAttribute('aria-label', `Unblock device ${deviceId}`);
+            button.disabled = this.busy || this.status !== 'known';
+            button.addEventListener('click', () => this.open(deviceId, false, button));
+            row.append(id, text, button);
+            rows.append(row);
+        }
+        this.list.replaceChildren(rows);
+        this.listStatus.textContent = this.status === 'known' ?
+            (this.records.size ? `${this.records.size} blocked device(s).` : 'No blocked devices.') :
+            this.status === 'loading' ? 'Loading blocked devices...' :
+                'Block status is unknown. Refresh blocked devices to try again. Any entries below are last known values.';
+        this.list.setAttribute('aria-busy', String(this.status === 'loading'));
+        this.refreshButton.disabled = this.busy || this.status === 'loading';
+    }
+
+    async refresh(reconciling = false) {
+        if (this.busy && !reconciling) return false;
+        const version = ++this.refreshVersion;
+        this.status = 'loading';
+        this.listError.hidden = true;
+        this.render();
+        try {
+            const records = await getBlockedDevices();
+            if (version !== this.refreshVersion) return false;
+            if (!Array.isArray(records) || records.some(record =>
+                !record || typeof record.deviceId !== 'string' || !/^[A-Za-z0-9_-]{1,128}$/.test(record.deviceId) ||
+                typeof record.reason !== 'string' || !record.reason.trim() || record.reason.trim().length > 1000) ||
+                new Set(records.map(record => record.deviceId)).size !== records.length) {
+                throw new Error('The site returned an incomplete or unreadable blocklist. Refresh blocked devices before retrying.');
+            }
+            this.records = new Map(records.map(record => [record.deviceId, record.reason]));
+            this.status = 'known';
+            return true;
+        } catch (error) {
+            if (version !== this.refreshVersion) return false;
+            this.status = 'unknown';
+            this.listError.textContent = `Could not load blocked devices. ${error.message} Report moderation is still available.`;
+            this.listError.hidden = false;
+            return false;
+        } finally {
+            if (version === this.refreshVersion) {
+                this.render();
+                this.updateModal();
+            }
+        }
+    }
+
+    open(deviceId, blocking, opener) {
+        if (this.busy || this.action || this.status !== 'known' ||
+            !/^[A-Za-z0-9_-]{1,128}$/.test(deviceId) || this.records.has(deviceId) === blocking) return;
+        this.action = { deviceId, blocking, opener, requiresRefresh: false, error: '', failureMessage: '' };
+        document.getElementById('deviceBlockModalTitle').textContent = blocking ? 'Block device' : 'Unblock device';
+        document.getElementById('deviceBlockModalTarget').textContent = deviceId;
+        document.getElementById('deviceBlockModalDescription').textContent = blocking ?
+            'Block future submissions from this device? Accepted reports will not be changed.' :
+            'Allow future submissions from this device? Unblocking removes its saved reason. Accepted reports will not be changed.';
+        document.getElementById('deviceBlockReasonGroup').hidden = !blocking;
+        document.getElementById('deviceBlockSavedReasonGroup').hidden = blocking;
+        this.reason.required = blocking;
+        this.reason.value = '';
+        this.reason.removeAttribute('aria-invalid');
+        this.savedReason.textContent = this.records.get(deviceId) || '';
+        this.updateModal();
+        this.modal.show();
+    }
+
+    updateModal() {
+        if (!this.action) return;
+        const { deviceId, blocking, error, requiresRefresh } = this.action;
+        const reached = this.status === 'known' && this.records.has(deviceId) === blocking;
+        this.confirmButton.textContent = blocking ? 'Confirm block' : 'Confirm unblock';
+        this.confirmButton.disabled = this.busy || requiresRefresh || this.status !== 'known' || reached;
+        this.cancelButton.disabled = this.busy;
+        this.reason.readOnly = this.busy;
+        this.modalRefresh.hidden = !requiresRefresh;
+        this.modalRefresh.disabled = this.busy;
+        this.modalError.textContent = error;
+        this.modalError.hidden = !error;
+        this.modalElement.setAttribute('aria-busy', String(this.busy));
+        if (this.busy) changeButtonToLoadingButton(this.confirmButton, 'Checking / saving...');
+    }
+
+    async confirm() {
+        const action = this.action;
+        if (!action || this.busy || action.requiresRefresh || this.status !== 'known' ||
+            this.records.has(action.deviceId) === action.blocking) return;
+        const reason = this.reason.value.trim();
+        if (action.blocking && (!reason || reason.length > 1000)) {
+            action.error = 'Enter a reason of 1-1,000 characters after trimming.';
+            this.reason.setAttribute('aria-invalid', 'true');
+            this.updateModal();
+            this.reason.focus();
+            return;
+        }
+        this.busy = true;
+        // A pre-write list response must never undo an acknowledged write.
+        ++this.refreshVersion;
+        action.error = '';
+        this.render();
+        this.updateModal();
+        let succeeded = false;
+        try {
+            if (action.blocking) await blockDevice(action.deviceId, reason);
+            else await unblockDevice(action.deviceId);
+            if (action.blocking) this.records.set(action.deviceId, reason);
+            else this.records.delete(action.deviceId);
+            succeeded = true;
+        } catch (error) {
+            action.failureMessage = error.message;
+            action.error = `${action.failureMessage} The ${action.blocking ? 'block' : 'unblock'} request was not confirmed.`;
+            if (error.refreshRequired) {
+                action.requiresRefresh = true;
+                await this.reconcile();
+            }
+        } finally {
+            this.busy = false;
+            this.render();
+            this.updateModal();
+            if (succeeded) this.modal.hide();
+        }
+    }
+
+    async reconcile() {
+        const action = this.action;
+        const refreshed = await this.refresh(true);
+        action.requiresRefresh = !refreshed;
+        if (!refreshed) {
+            action.error = `${action.failureMessage} The request was not confirmed, and block status could not be checked. Refresh status before retrying.`;
+        } else {
+            const blocked = this.records.has(action.deviceId);
+            action.error = `${action.failureMessage} The request was not confirmed. The refreshed list shows this device as ${blocked ? 'blocked' : 'not blocked'}. ` +
+                (blocked === action.blocking ? 'Close this dialog to review the current list.' : 'You can retry the request.');
+            if (!action.blocking) this.savedReason.textContent = this.records.get(action.deviceId) || '';
+        }
+    }
+
+    async recover() {
+        if (this.busy || !this.action?.requiresRefresh) return;
+        this.busy = true;
+        this.updateModal();
+        try {
+            await this.reconcile();
+        } finally {
+            this.busy = false;
+            this.render();
+            this.updateModal();
+        }
+    }
+}

--- a/SeattleCarsInBikeLanes/wwwroot/js/admin-helpers.js
+++ b/SeattleCarsInBikeLanes/wwwroot/js/admin-helpers.js
@@ -1,143 +1,118 @@
+async function adminRequest(path, options = {}, recovery = {}) {
+    let response;
+    let text;
+    try {
+        response = await fetch(`api/AdminPage/${path}`, { cache: 'no-store', ...options });
+        text = await response.text();
+    } catch (cause) {
+        if (!(cause instanceof TypeError) && cause?.name !== 'AbortError') throw cause;
+        const error = new Error(recovery.network || 'The server could not be reached. Refresh pending reports to check whether the operation completed before retrying.');
+        error.cause = cause;
+        error.refreshRequired = true;
+        throw error;
+    }
+    let body;
+    try {
+        body = text ? JSON.parse(text) : null;
+    } catch (cause) {
+        if (!(cause instanceof SyntaxError)) throw cause;
+        if (response.headers.get('content-type')?.includes('json')) {
+            const error = new Error(recovery.unreadable || 'The site returned an unreadable response. Refresh pending reports before retrying.');
+            error.cause = cause;
+            error.refreshRequired = true;
+            throw error;
+        }
+        body = text;
+    }
+    if (!response.ok) {
+        const message = typeof body === 'string' ? body :
+            body?.message || body?.detail || (body?.errors && Object.values(body.errors).flat().join(' ')) || body?.title;
+        const error = new Error(message || `Request failed (${response.status}). ${recovery.failed || 'Refresh before retrying.'}`);
+        error.status = response.status;
+        error.retryAllowed = body?.retryAllowed === true && typeof body.reportVersion === 'string' && body.reportVersion.length > 0;
+        error.reportVersion = error.retryAllowed ? body.reportVersion : null;
+        error.refreshRequired = !error.retryAllowed &&
+            (response.status === 409 || response.status === 404 || response.status >= 500);
+        throw error;
+    }
+    if (recovery.expectedStatus && response.status !== recovery.expectedStatus) {
+        const error = new Error(recovery.unreadable);
+        error.refreshRequired = true;
+        throw error;
+    }
+    return body;
+}
+
+function adminJsonRequest(path, method, body, recovery = {}) {
+    return adminRequest(path, {
+        method,
+        body: JSON.stringify(body),
+        headers: { 'Content-Type': 'application/json' }
+    }, recovery);
+}
+
+const deviceBlockRecovery = {
+    network: 'The server could not be reached. Refresh blocked devices to check the current status before retrying.',
+    unreadable: 'The site returned an unexpected response. Refresh blocked devices to check the current status before retrying.',
+    failed: 'Refresh blocked devices before retrying.'
+};
+
+function getBlockedDevices() {
+    return adminRequest('BlockedDevices', {}, { ...deviceBlockRecovery, expectedStatus: 200 });
+}
+
+function blockDevice(deviceId, reason) {
+    return adminJsonRequest('BlockedDevices', 'POST', { deviceId, reason },
+        { ...deviceBlockRecovery, expectedStatus: 204 });
+}
+
+function unblockDevice(deviceId) {
+    return adminJsonRequest('BlockedDevices', 'DELETE', { deviceId },
+        { ...deviceBlockRecovery, expectedStatus: 204 });
+}
+
 function getBlueskySession() {
-    return fetch('api/AdminPage/GetBlueskySession')
-    .then(response => {
-        if (!response.ok) {
-            return response.text();
-        }
-
-        return response.json();
-    })
-    .then(response => {
-        if (typeof response === 'string') {
-            throw new Error(response);
-        }
-
-        return response;
-    });
+    return adminRequest('GetBlueskySession');
 }
 
 function getPendingPhotos() {
-    return fetch('api/AdminPage/PendingPhotos')
-    .then(response => {
-        if (!response.ok) {
-            return response.text();
-        }
-
-        return response.json();
-    })
-    .then(response => {
-        if (typeof response === 'string') {
-            throw new Error(response);
-        }
-
-        return response;
-    });
+    return adminRequest('PendingPhotos');
 }
 
-function uploadTweet(metadata) {
-    return fetch('api/AdminPage/UploadTweet', {
-        method: 'POST',
-        body: JSON.stringify(metadata),
-        headers: {
-            'Content-Type': 'application/json'
-        }
-    })
-    .then(response => {
-        if (!response.ok) {
-            return response.text();
-        }
-
-        return null;
-    })
-    .then(response => {
-        if (typeof response === 'string') {
-            throw new Error(response);
-        }
-    });
+function uploadTweet(report) {
+    return adminJsonRequest('UploadTweet', 'POST', report);
 }
 
 function postTweet(link, body, images, tweetLink, quoteTweetLink, blueskyDid, blueskyAccessJwt) {
-    return fetch('api/AdminPage/PostTweet', {
-        method: 'POST',
-        body: JSON.stringify({
-            postUrl: link,
-            tweetBody: body,
-            tweetImages: images,
-            tweetLink: tweetLink,
-            quoteTweetLink: quoteTweetLink,
-            blueskyDid: blueskyDid,
-            blueskyAccessJwt: blueskyAccessJwt
-        }),
-        headers: {
-            'Content-Type': 'application/json'
-        }
-    })
-    .then(response => {
-        if (!response.ok) {
-            return response.text();
-        }
-
-        return null;
-    })
-    .then(response => {
-        if (typeof response === 'string') {
-            throw new Error(response);
-        }
+    return adminJsonRequest('PostTweet', 'POST', {
+        postUrl: link,
+        tweetBody: body,
+        tweetImages: images,
+        tweetLink,
+        quoteTweetLink,
+        blueskyDid,
+        blueskyAccessJwt
     });
 }
 
-function deletePendingPhoto(metadata) {
-    return fetch('api/AdminPage/DeletePendingPhoto', {
-        method: 'DELETE',
-        body: JSON.stringify(metadata),
-        headers: {
-            'Content-Type': 'application/json'
-        }
-    });
+function deletePendingPhoto(report) {
+    return adminJsonRequest('DeletePendingPhoto', 'DELETE', report);
 }
 
 function deletePost(identifier) {
-    return fetch('api/AdminPage/DeletePost', {
-        method: 'DELETE',
-        body: JSON.stringify({ postIdentifier: identifier }),
-        headers: {
-            'Content-Type': 'application/json'
-        }
-    });
+    return adminJsonRequest('DeletePost', 'DELETE', { postIdentifier: identifier });
 }
 
 function postMonthlyStats(link) {
-    return fetch('api/AdminPage/PostMonthlyStats', {
-        method: 'POST',
-        body: JSON.stringify({ postIdentifier: link }),
-        headers: {
-            'Content-Type': 'application/json'
-        }
-    })
-    .then(response => {
-        if (!response.ok) {
-            return response.text();
-        }
-
-        return null;
-    })
-    .then(response => {
-        if (typeof response === 'string') {
-            throw new Error(response);
-        }
-    });
+    return adminJsonRequest('PostMonthlyStats', 'POST', { postIdentifier: link });
 }
 
 function displayError(text) {
-    const oldAlertDiv = document.getElementById('alertDiv');
-    if (oldAlertDiv) {
-        oldAlertDiv.remove();
-    }
-
+    document.getElementById('alertDiv')?.remove();
     const alertDiv = document.createElement('div');
     alertDiv.className = 'alert alert-danger';
     alertDiv.setAttribute('role', 'alert');
-    alertDiv.setAttribute('id', 'alertDiv');
+    alertDiv.id = 'alertDiv';
     alertDiv.append(text);
-    document.getElementsByTagName('body')[0].append(alertDiv);
+    document.body.prepend(alertDiv);
 }

--- a/SeattleCarsInBikeLanes/wwwroot/js/admin.js
+++ b/SeattleCarsInBikeLanes/wwwroot/js/admin.js
@@ -1,6 +1,7 @@
-const isDesktop = window.screen.availWidth >= 576;
 let blueskyAdminDid = null;
 let blueskyAccessJwt = null;
+let pendingRefresh = 0;
+const adminDeviceBlocks = new AdminDeviceBlocks();
 
 function createElementWithClass(tagName, className) {
     const element = document.createElement(tagName);
@@ -23,7 +24,8 @@ function createTextInputRow(label, name, value, userSpecified) {
     if (userSpecified) {
         input.style = 'color: red;';
     }
-    input.value = value;
+    input.value = value ?? '';
+    input.setAttribute('aria-label', label);
     inputDiv.appendChild(input);
     row.appendChild(inputDiv);
     return row;
@@ -47,9 +49,14 @@ function createPictureCarousel(key, metadatas) {
             carouselItem.classList.add('active');
         }
         const img = createElementWithClass('img', 'd-block');
-        img.style = 'max-width: 25rem;';
-        img.src = metadata.uri;
-        carouselItem.appendChild(img);
+        img.style = 'max-width: 100%;';
+        img.alt = `Report photo ${index + 1}`;
+        if (metadata.uri) {
+            img.src = metadata.uri;
+            carouselItem.appendChild(img);
+        } else {
+            carouselItem.append('Preview unavailable. See the report warning below.');
+        }
         innerDiv.appendChild(carouselItem);
     });
     div.appendChild(innerDiv);
@@ -88,21 +95,40 @@ function createDesktopCard(key, metadatas) {
     const dateTime = luxon.DateTime.fromISO(metadata.photoDateTime);
 
     const card = createElementWithClass('div', 'card');
-    card.id = metadata.photoId;
+    card.id = key;
     card.style = 'max-width: 25rem;';
 
     let picture;
     if (metadatas.length === 1) {
         picture = document.createElement('img');
-        picture.src = metadata.uri;
+        picture.alt = 'Report photo';
+        if (metadata.uri) {
+            picture.src = metadata.uri;
+        } else {
+            picture = document.createElement('p');
+            picture.append('Preview unavailable. See the report warning below.');
+        }
     } else {
         picture = createPictureCarousel(key, metadatas);
     }
     
     const cardBody = createElementWithClass('div', 'card-body');
+    const status = createElementWithClass('p', 'text-break');
+    status.append(`Report: ${metadata.reportId} · ${metadata.moderationStatus}`);
+    if (metadata.deviceId) status.append(' · ', adminDeviceBlocks.createControl(metadata.deviceId));
+    if (metadata.moderationOperationId) {
+        status.append(` · Operation: ${metadata.moderationOperationId} · Started: ${metadata.moderationStartedAt}`);
+    }
+    cardBody.appendChild(status);
+    for (const warning of new Set(metadatas.map(photo => photo.warning).filter(Boolean))) {
+        const warningElement = createElementWithClass('p', 'alert alert-warning');
+        warningElement.setAttribute('role', 'status');
+        warningElement.append(warning);
+        cardBody.appendChild(warningElement);
+    }
 
     const form = document.createElement('form');
-    form.id = `${metadata.photoId}_form`;
+    form.id = `${key}_form`;
 
     const numberOfCarsRow = createElementWithClass('div', 'row');
     const numberOfCarsLabelDiv = createElementWithClass('div', 'col-auto');
@@ -116,6 +142,8 @@ function createDesktopCard(key, metadatas) {
     numberOfCarsInput.setAttribute('type', 'number');
     numberOfCarsInput.setAttribute('name', 'numberOfCars');
     numberOfCarsInput.setAttribute('min', '1');
+    numberOfCarsInput.setAttribute('aria-label', 'Number of cars');
+    numberOfCarsInput.required = true;
     numberOfCarsInput.value = metadata.numberOfCars;
     numberOfCarsInputDiv.appendChild(numberOfCarsInput);
     numberOfCarsRow.appendChild(numberOfCarsInputDiv);
@@ -134,7 +162,9 @@ function createDesktopCard(key, metadatas) {
     if (metadata.userSpecifiedDateTime) {
         dateInput.style = 'color: red;';
     }
-    dateInput.value = dateTime.toISODate();
+    dateInput.value = dateTime.toISODate() ?? '';
+    dateInput.setAttribute('aria-label', 'Date');
+    dateInput.required = true;
     dateInputDiv.appendChild(dateInput);
     dateRow.appendChild(dateInputDiv);
 
@@ -152,7 +182,9 @@ function createDesktopCard(key, metadatas) {
     if (metadata.userSpecifiedDateTime) {
         timeInput.style = 'color: red;';
     }
-    timeInput.value = dateTime.toLocaleString(luxon.DateTime.TIME_24_SIMPLE);
+    timeInput.value = dateTime.isValid ? dateTime.toFormat('HH:mm') : '';
+    timeInput.setAttribute('aria-label', 'Time');
+    timeInput.required = true;
     timeInputDiv.appendChild(timeInput);
     timeRow.appendChild(timeInputDiv);
 
@@ -161,136 +193,114 @@ function createDesktopCard(key, metadatas) {
     const twitterAttributionRow = createTextInputRow('Twitter Attribution:', 'twitterSubmittedBy', metadata.twitterSubmittedBy);
     const mastodonAttributionRow = createTextInputRow('Mastodon Attribution:', 'mastodonSubmittedBy', metadata.mastodonSubmittedBy);
     const blueskyAttributionRow = createTextInputRow('Bluesky Attribution:', 'blueskySubmittedBy', metadata.blueskySubmittedBy);
-    const twitterLinkRow = createTextInputRow('Twitter Link:', 'twitterLink', '');
+    const threadsAttributionRow = createTextInputRow('Threads Attribution:', 'threadsSubmittedBy', metadata.threadsSubmittedBy);
+    const twitterLinkRow = createTextInputRow('Twitter Link:', 'twitterLink', metadata.twitterLink);
+
+    function readEdits() {
+        const fields = new FormData(form);
+        const [latitude, longitude, extra] = fields.get('gps').split(',').map(value => value.trim());
+        const date = luxon.DateTime.fromISO(`${fields.get('date')}T${fields.get('time')}`);
+        const numberOfCars = Number(fields.get('numberOfCars'));
+        if (!latitude || !longitude || extra !== undefined || !Number.isFinite(Number(latitude)) ||
+            !Number.isFinite(Number(longitude)) || !date.isValid || !Number.isInteger(numberOfCars) || numberOfCars < 1) {
+            throw new Error('Enter a positive car count, valid date/time, and GPS as latitude, longitude.');
+        }
+        return {
+            numberOfCars,
+            photoDateTime: date.toISO({ includeOffset: false }),
+            photoCrossStreet: fields.get('location').trim(),
+            photoLatitude: latitude,
+            photoLongitude: longitude,
+            twitterSubmittedBy: fields.get('twitterSubmittedBy').trim() || 'Submission',
+            mastodonSubmittedBy: fields.get('mastodonSubmittedBy').trim() || 'Submission',
+            blueskySubmittedBy: fields.get('blueskySubmittedBy').trim() || 'Submission',
+            threadsSubmittedBy: fields.get('threadsSubmittedBy').trim() || 'Submission',
+            twitterLink: fields.get('twitterLink').trim()
+        };
+    }
 
     const copyButton = createElementWithClass('button', 'btn btn-light me-4');
     copyButton.innerHTML = '<i class="bi bi-clipboard"></i>';
-    copyButton.addEventListener('click', function() {
-        const carString = metadata.numberOfCars === 1 ? 'car' : 'cars';
-        let submissionString = 'Submission';
-        if (metadata.mastodonSubmittedBy && metadata.mastodonSubmittedBy !== 'Submission') {
-            const splitMastodonSubmittedBy = metadata.mastodonSubmittedBy.split(' ');
-            const splitUsername = splitMastodonSubmittedBy[2].split('@');
-            submissionString = `Submitted by https://${splitUsername[2]}/@${splitUsername[1]}`;
+    copyButton.type = 'button';
+    copyButton.setAttribute('aria-label', 'Copy report text');
+    copyButton.addEventListener('click', async function() {
+        try {
+            const edits = readEdits();
+            const date = luxon.DateTime.fromISO(edits.photoDateTime);
+            const carString = edits.numberOfCars === 1 ? 'car' : 'cars';
+            let attribution = edits.mastodonSubmittedBy !== 'Submission' ? edits.mastodonSubmittedBy : edits.blueskySubmittedBy;
+            const mastodonMention = attribution.match(/^Submitted by @([^@\s]+)@([^@\s]+)$/);
+            if (mastodonMention) attribution = `Submitted by https://${mastodonMention[2]}/@${mastodonMention[1]}`;
+            else if (metadata.blueskyHandle && attribution === `Submitted by @${metadata.blueskyHandle}`) {
+                attribution = `Submitted by https://bsky.app/profile/${metadata.blueskyHandle}`;
+            }
+            await navigator.clipboard.writeText(
+                `${edits.numberOfCars} ${carString}\nDate: ${date.toFormat('M/d/yyyy')}\nTime: ${date.toFormat('h:mm a')}\n` +
+                `Location: ${edits.photoCrossStreet}\nGPS: ${edits.photoLatitude}, ${edits.photoLongitude}\n${attribution}`);
+        } catch (error) {
+            displayError(`Could not copy report text. ${error.message}`);
         }
-        if (submissionString === 'Submission' && metadata.blueskySubmittedBy && metadata.blueskySubmittedBy !== 'Submission') {
-            const splitBlueskySubmittedBy = metadata.blueskySubmittedBy.split(' ');
-            const splitHandle = splitBlueskySubmittedBy[2].split('@');
-            submissionString = `Submitted by https://bsky.app/profile/${splitHandle[1]}`;
-        }
-        const copyString =
-            `${metadata.numberOfCars} ${carString}\n` +
-            `Date: ${dateTime.toFormat('M/d/yyyy')}\n` +
-            `Time: ${dateTime.toFormat('h:mm a')}\n` +
-            `Location: ${metadata.photoCrossStreet}\n` +
-            `GPS: ${metadata.photoLatitude}, ${metadata.photoLongitude}\n` +
-            `${submissionString}`;
-        navigator.clipboard.writeText(copyString);
     });
     const uploadButton = createSubmitButton('btn-success', 'Upload');
     uploadButton.className = 'btn btn-success me-4';
     const deleteButton = createSubmitButton('btn-danger', 'Delete');
+    deleteButton.formNoValidate = true;
     const buttonDiv = createElementWithClass('div', 'text-center');
     buttonDiv.append(copyButton, uploadButton, deleteButton);
 
-    form.append(numberOfCarsRow, dateRow, timeRow, locationRow, gpsRow, twitterAttributionRow, mastodonAttributionRow, blueskyAttributionRow, twitterLinkRow, buttonDiv);
+    form.append(numberOfCarsRow, dateRow, timeRow, locationRow, gpsRow, twitterAttributionRow, mastodonAttributionRow, blueskyAttributionRow, threadsAttributionRow, twitterLinkRow, buttonDiv);
 
-    form.addEventListener('submit', (event) => {
+    const canModerate = metadatas.every(photo => photo.canModerate);
+    uploadButton.disabled = !canModerate;
+    deleteButton.disabled = !canModerate;
+    if (!canModerate) {
+        form.querySelectorAll('input').forEach(input => input.readOnly = true);
+    }
+    let inFlight = false;
+    form.addEventListener('submit', async (event) => {
         event.preventDefault();
-        const data = new FormData(event.target);
         const submitButton = event.submitter;
-
-        if (submitButton.innerText === 'Upload') {
-            changeButtonToLoadingButton(submitButton, 'Uploading...');
-            for (const [name, value] of data) {
-                if (name === 'numberOfCars') {
-                    const parsedNumberOfCars = parseInt(value);
-                    if (!isNaN(parsedNumberOfCars) && parsedNumberOfCars !== metadata.numberOfCars) {
-                        metadata.numberOfCars = parsedNumberOfCars;
-                    }
-                }
-
-                if (name === 'location') {
-                    if (value.trim() !== metadata.photoCrossStreet) {
-                        metadata.photoCrossStreet = value.trim();
-                    }
-                }
-
-                if (name === 'gps') {
-                    const [latitude, longitude] = value.split(',');
-                    if (latitude.trim() !== metadata.photoLatitude) {
-                        metadata.photoLatitude = latitude.trim();
-                    }
-                    if (longitude.trim() !== metadata.photoLongitude) {
-                        metadata.photoLongitude = longitude.trim();
-                    }
-                }
-
-                if (name === 'twitterSubmittedBy') {
-                    if (value.trim() !== metadata.twitterSubmittedBy) {
-                        metadata.twitterSubmittedBy = value.trim();
-                    }
-                }
-
-                if (name === 'mastodonSubmittedBy') {
-                    if (value.trim() !== metadata.mastodonSubmittedBy) {
-                        metadata.mastodonSubmittedBy = value.trim();
-                    }
-                }
-
-                if (name === 'blueskySubmittedBy') {
-                    if (value.trim() !== metadata.blueskySubmittedBy) {
-                        metadata.blueskySubmittedBy = value.trim();
-                    }
-                }
-
-                if (name === 'twitterLink') {
-                    metadata.twitterLink = value.trim();
+        if (!canModerate || inFlight || ![uploadButton, deleteButton].includes(submitButton)) return;
+        const publishing = submitButton === uploadButton;
+        let refreshRequired = false;
+        try {
+            const request = {
+                reportId: metadata.reportId,
+                reportVersion: metadata.reportVersion,
+                legacySubmissionId: metadata.legacySubmissionId,
+                photoIds: metadatas.map(photo => photo.photoId),
+                ...(publishing ? { edits: readEdits(), blueskyAdminDid, blueskyAccessJwt } : {})
+            };
+            inFlight = true;
+            uploadButton.disabled = true;
+            deleteButton.disabled = true;
+            changeButtonToLoadingButton(submitButton, publishing ? 'Uploading...' : 'Deleting...');
+            if (publishing) await uploadTweet(request);
+            else await deletePendingPhoto(request);
+            refreshRequired = true;
+            await displayPendingPhotos();
+        } catch (error) {
+            displayError(error.message);
+            if (error.retryAllowed) {
+                // Keep the edited form and advance its version after the server releases the
+                // failed attempt. A retry of an adopted report no longer uses the flat-data path.
+                for (const photo of metadatas) {
+                    photo.reportVersion = error.reportVersion;
+                    photo.legacySubmissionId = null;
                 }
             }
-
-            if (!metadata.twitterSubmittedBy) {
-                metadata.twitterSubmittedBy = 'Submission';
+            const staleCard = error.retryAllowed && !card.isConnected;
+            refreshRequired = refreshRequired || error.refreshRequired || staleCard;
+            if (error.refreshRequired || staleCard) {
+                try { await displayPendingPhotos(); }
+                catch (refreshError) { displayError(`${error.message} Refresh also failed: ${refreshError.message}`); }
             }
-            
-            if (!metadata.mastodonSubmittedBy) {
-                metadata.mastodonSubmittedBy = 'Submission';
-            }
-
-            if (!metadata.blueskySubmittedBy) {
-                metadata.blueskySubmittedBy = 'Submission';
-            }
-
-            if (!metadata.threadsSubmittedBy) {
-                metadata.threadsSubmittedBy = 'Submission';
-            }
-
-            if (blueskyAdminDid) {
-                metadata.blueskyAdminDid = blueskyAdminDid;
-            }
-
-            if (blueskyAccessJwt) {
-                metadata.blueskyAccessJwt = blueskyAccessJwt;
-            }
-
-            uploadTweet(metadatas)
-            .then(() => {
-                document.getElementById(metadata.photoId).remove();
-                return displayPendingPhotos();
-            })
-            .catch(error => {
-                changeLoadingButtonToRegularButton(submitButton, 'Upload');
-            });
-        } else if (submitButton.innerText === 'Delete') {
-            changeButtonToLoadingButton(submitButton, 'Deleting...');
-            deletePendingPhoto(metadatas)
-            .then(() => {
-                document.getElementById(metadata.photoId).remove();
-                return displayPendingPhotos();
-            })
-            .catch(error => {
-                changeLoadingButtonToRegularButton(submitButton, 'Delete');
-            });
+        } finally {
+            changeLoadingButtonToRegularButton(submitButton, publishing ? 'Upload' : 'Delete');
+            // If reconciliation failed, do not re-enable a stale card.
+            uploadButton.disabled = refreshRequired || !canModerate;
+            deleteButton.disabled = refreshRequired || !canModerate;
+            inFlight = false;
         }
     });
 
@@ -365,13 +375,15 @@ document.getElementById('deletePostButton').addEventListener('click', function(e
 });
 
 function displayPendingPhotos() {
+    const refresh = ++pendingRefresh;
     const cardsDiv = document.getElementById('cardsDiv');
-    if (cardsDiv.childElementCount === 0) {
-        return getPendingPhotos()
+    return getPendingPhotos()
         .then(response => {
-            document.getElementById('pendingItems').innerText = `Pending photos: ${Object.keys(response).length}`;
+            if (refresh !== pendingRefresh) return;
+            const cards = document.createDocumentFragment();
+            document.getElementById('pendingItems').innerText = `Pending reports: ${Object.keys(response).length}`;
             if (Object.keys(response).length === 0) {
-                cardsDiv.append('No pending reported items.');
+                cards.append('No pending reported items.');
             } else {
                 const sortedKeys = Object.keys(response).sort((a, b) => {
                     const aDate = luxon.DateTime.fromISO(response[a][0].photoDateTime);
@@ -380,28 +392,21 @@ function displayPendingPhotos() {
                 });
                 for (const key of sortedKeys) {
                     const card = createDesktopCard(key, response[key]);
-                    cardsDiv.append(card);
+                    cards.append(card);
                 }
             }
-        })
-        .catch(error => {
-            const cardsDiv = document.getElementById('cardsDiv');
-            const alertDiv = document.createElement('div');
-            alertDiv.className = 'alert alert-danger';
-            alertDiv.setAttribute('role', 'alert');
-            alertDiv.append(error.message);
-            cardsDiv.append(alertDiv);
+            cardsDiv.replaceChildren(cards);
         });
-    } else {
-        document.getElementById('pendingItems').innerText = `Pending photos: ${document.getElementsByClassName('card').length}`;
-        return Promise.resolve();
-    }
 }
 
+document.getElementById('refreshPendingButton').addEventListener('click', () => {
+    displayPendingPhotos().catch(error => displayError(error.message));
+});
+adminDeviceBlocks.refresh();
+displayPendingPhotos().catch(error => displayError(error.message));
 getBlueskySession()
 .then(response => {
     blueskyAdminDid = response.did;
     blueskyAccessJwt = response.accessJwt;
-    displayPendingPhotos();
-});
-
+})
+.catch(error => displayError(`Could not load the Bluesky admin session. ${error.message}`));

--- a/SeattleCarsInBikeLanes/wwwroot/js/helpers.js
+++ b/SeattleCarsInBikeLanes/wwwroot/js/helpers.js
@@ -43,44 +43,75 @@ function searchReportedItems(searchParams) {
     });
 }
 
-function uploadImage(files) {
+class UploadRequestError extends Error {
+    constructor(message, status, code) {
+        super(message);
+        this.status = status;
+        this.code = code;
+    }
+}
+
+async function readUploadResponse(response) {
+    const text = await response.text();
+    const body = text && response.headers.get('content-type')?.includes('json')
+        ? JSON.parse(text) : text;
+    if (!response.ok) {
+        const message = typeof body === 'string' ? body :
+            body?.message || body?.detail || body?.title;
+        throw new UploadRequestError(message || `The site could not complete the upload (${response.status}).`,
+            response.status, body?.code);
+    }
+    return body;
+}
+
+function validateUploadReceipt(receipt, reportId) {
+    if (!receipt || receipt.reportId !== reportId ||
+        typeof receipt.submissionId !== 'string' || !receipt.submissionId ||
+        !receipt.submittedAt || !Number.isFinite(Date.parse(receipt.submittedAt)) ||
+        !receipt.attribution || typeof receipt.attribution !== 'object' ||
+        Array.isArray(receipt.attribution)) {
+        throw new Error('The site did not return a valid confirmation. Retry to check whether your report was received.');
+    }
+    return receipt;
+}
+
+async function uploadImage(files, reportId) {
     const data = new FormData();
     for (const file of files) {
         data.append('files', file);
     }
-    return fetch(`api/Upload/Initial`, {
+    const response = await fetch('api/Upload/Initial', {
         method: 'POST',
+        headers: { 'X-Report-Id': reportId },
         body: data
-    })
-    .then(response => {
-        if (!response.ok) {
-            return response.text();
-        }
-
-        return response.json();
-    })
-    .then(response => {
-        if (typeof response === 'string') {
-            throw new Error(response);
-        }
-
-        return response;
     });
+    const photos = await readUploadResponse(response);
+    if (!Array.isArray(photos) || photos.length !== files.length ||
+        photos.some((photo, index) => !photo.photoId || !photo.submissionId ||
+            photo.photoNumber !== index || photo.submissionId !== photos[0].submissionId)) {
+        throw new Error('The site did not return the complete photo set. Please retry.');
+    }
+    return photos;
 }
 
-function finalizeUploadImage(metadata) {
-    return fetch('api/Upload/Finalize', {
+async function finalizeUploadImage(metadata, reportId, attribution) {
+    const response = await fetch('api/Upload/Finalize', {
         method: 'POST',
-        body: JSON.stringify(metadata),
+        body: JSON.stringify({ photos: metadata, attribution }),
         headers: {
-            'Content-Type': 'application/json'
-        }
-    })
-    .then(response => {
-        if (!response.ok) {
-            throw new Error(`Error when finalizing image upload. ${response}`);
+            'Content-Type': 'application/json',
+            'X-Report-Id': reportId
         }
     });
+    return validateUploadReceipt(await readUploadResponse(response), reportId);
+}
+
+async function getUploadReceipt(reportId) {
+    const response = await fetch(`api/Upload/Reports/${encodeURIComponent(reportId)}`, { cache: 'no-store' });
+    if (response.status === 404) {
+        return null;
+    }
+    return validateUploadReceipt(await readUploadResponse(response), reportId);
 }
 
 function createReportedItemFeatureCollection(reportedItems) {

--- a/SeattleCarsInBikeLanes/wwwroot/js/index.js
+++ b/SeattleCarsInBikeLanes/wwwroot/js/index.js
@@ -25,6 +25,7 @@ let trailsLayer = null;
 const darkMode = window.matchMedia('(prefers-color-scheme: dark)').matches;
 let loggedInMastodonFullUsername = null;
 let loggedInMastodonUsername = null;
+let loggedInMastodonAccountId = null;
 
 function toggleFilterLegendControl() {
     toggleLegendControl(filterLegendControl);
@@ -103,6 +104,7 @@ function clearMastodonAuth(notifyNative = true) {
     localStorage.removeItem('mastodonAccessToken');
     loggedInMastodonFullUsername = null;
     loggedInMastodonUsername = null;
+    loggedInMastodonAccountId = null;
     setMastodonButtonAsLoggedOut();
     document.getElementById('mastodonLogoutButton').className = 'dropdown-item disabled';
     if (notifyNative) {
@@ -120,6 +122,7 @@ function checkMastodonAuth() {
         .then(response => {
             loggedInMastodonFullUsername = response.fullUsername;
             loggedInMastodonUsername = response.username;
+            loggedInMastodonAccountId = response.accountId;
         });
     } else {
         document.getElementById('mastodonLogoutButton').className = 'dropdown-item disabled';
@@ -389,8 +392,13 @@ function initFilterLegendHtml() {
 function initUpload1LegendHtml() {
     document.getElementById('photoFileInput').value = '';
     const form = document.getElementById('uploadForm1');
+    let processing = false;
+    let report = null;
     const upload1Event = function(event) {
         event.preventDefault();
+        if (processing) {
+            return;
+        }
         const button = event.submitter;
         changeButtonToLoadingButton(button, 'Processing...');
         document.getElementById('uploadForm1AlertDiv').innerHTML = '';
@@ -406,7 +414,13 @@ function initUpload1LegendHtml() {
             for (const file of files) {
                 onlyFiles.push(file[1]);
             }
-            uploadImage(onlyFiles)
+            if (!report || onlyFiles.some((file, index) => file.name !== report.files[index]?.name ||
+                file.size !== report.files[index]?.size || file.lastModified !== report.files[index]?.lastModified) ||
+                onlyFiles.length !== report.files.length) {
+                report = new ReportUpload(onlyFiles);
+            }
+            processing = true;
+            report.prepare()
             .then(response => {
                 form.removeEventListener('submit', upload1Event);
                 form.setAttribute('hidden', '');
@@ -417,7 +431,7 @@ function initUpload1LegendHtml() {
                 uploadLegendControl.setOptions({
                     legends: [{
                         type: 'html',
-                        html: initUpload2LegendHtml(response)
+                        html: initUpload2LegendHtml(response, report)
                     }]
                 });
             })
@@ -426,7 +440,8 @@ function initUpload1LegendHtml() {
                     .appendChild(createAlertBanner(error.message));
                 
                 changeLoadingButtonToRegularButton(button, 'Process');
-            });
+            })
+            .finally(() => { processing = false; });
         }
     };
     form.addEventListener('submit', upload1Event);
@@ -434,7 +449,7 @@ function initUpload1LegendHtml() {
     return form;
 }
 
-function initUpload2LegendHtml(metadatas) {
+function initUpload2LegendHtml(metadatas, report) {
     if (metadatas.length === 1) {
         document.getElementById('uploadCarousel').setAttribute('hidden', '');
         document.getElementById('photo').src = metadatas[0].uri;
@@ -550,10 +565,35 @@ function initUpload2LegendHtml(metadatas) {
     }
 
     const form = document.getElementById('uploadForm2');
+    let submitting = false;
+    const originalDisabled = new Map();
+    const lockFields = (locked) => {
+        for (const input of form.querySelectorAll('input')) {
+            if (locked) {
+                if (!originalDisabled.has(input)) {
+                    originalDisabled.set(input, input.disabled);
+                }
+                input.disabled = true;
+            } else if (originalDisabled.has(input)) {
+                input.disabled = originalDisabled.get(input);
+                originalDisabled.delete(input);
+            }
+        }
+    };
     const upload2Event = function(event) {
         event.preventDefault();
+        if (submitting) {
+            return;
+        }
         const button = event.submitter;
+        // Disabled form inputs are excluded by FormData, so temporarily restore them
+        // when checking an uncertain submission. ReportUpload retains its frozen body.
+        lockFields(false);
         changeButtonToLoadingButton(button, 'Uploading...');
+        for (const photo of metadatas) {
+            photo.attribute = false;
+            photo.mastodonAccessToken = null;
+        }
         const data = new FormData(event.target);
         for (const [name, value] of data) {
             if (name === 'photoNumberOfCars') {
@@ -650,8 +690,41 @@ function initUpload2LegendHtml(metadatas) {
             }
         }
 
-        finalizeUploadImage(metadatas)
+        const attribution = {};
+        if (!report.uncertain && document.getElementById('attributeCheckbox').checked) {
+            if (window.blueskyUserDid) {
+                attribution.blueskyDid = window.blueskyUserDid;
+            }
+            if (localStorage.getItem('mastodonAccessToken')) {
+                if (!loggedInMastodonAccountId) {
+                    showUploadForm2Error('Your Mastodon account is still being verified. Please wait and retry.');
+                    changeLoadingButtonToRegularButton(button, 'Upload');
+                    lockFields(report.uncertain);
+                    return;
+                }
+                try {
+                    attribution.mastodonServer = new URL(localStorage.getItem('mastodonEndpoint')).origin;
+                } catch (error) {
+                    if (!(error instanceof TypeError)) {
+                        throw error;
+                    }
+                    showUploadForm2Error('Your saved Mastodon server is invalid. Sign in again, or turn off attribution.');
+                    changeLoadingButtonToRegularButton(button, 'Upload');
+                    return;
+                }
+                attribution.mastodonAccountId = loggedInMastodonAccountId;
+            }
+            if (Object.keys(attribution).length === 0 && !report.uncertain) {
+                showUploadForm2Error('Sign in again, or turn off attribution to submit anonymously.');
+                changeLoadingButtonToRegularButton(button, 'Upload');
+                return;
+            }
+        }
+        submitting = true;
+        lockFields(true);
+        report.submit(metadatas, attribution)
         .then(() => {
+            lockFields(false);
             userMustSelectLocation = false;
             selectedPosition = null;
             document.getElementById('photoNumberOfCarsInput').value = '';
@@ -698,9 +771,15 @@ function initUpload2LegendHtml(metadatas) {
             });
         })
         .catch(error => {
-            showUploadForm2Error(error.message);
+            const recovery = report.uncertain
+                ? ' Your submission is unconfirmed. Retry to check its status; do not start another report.'
+                : error.code === 'credential_rejected'
+                    ? ' Sign in again, or turn off attribution and retry.' : '';
+            showUploadForm2Error(error.message + recovery);
+            lockFields(report.uncertain);
             changeLoadingButtonToRegularButton(button, 'Upload');
-        });
+        })
+        .finally(() => { submitting = false; });
     };
     form.addEventListener('submit', upload2Event);
     form.removeAttribute('hidden');

--- a/SeattleCarsInBikeLanes/wwwroot/js/upload-report.js
+++ b/SeattleCarsInBikeLanes/wwwroot/js/upload-report.js
@@ -1,0 +1,84 @@
+// State belongs to the open upload page; closing it does not create an offline queue.
+class ReportUpload {
+    constructor(files) {
+        this.id = crypto.randomUUID().replaceAll('-', '');
+        this.files = files;
+        this.prepared = null;
+        this.request = null;
+        this.receipt = null;
+        this.pending = null;
+        this.uncertain = false;
+    }
+
+    async prepare() {
+        this.prepared = await uploadImage(this.files, this.id);
+        return this.prepared;
+    }
+
+    submit(photos, attribution) {
+        if (this.pending) {
+            return this.pending;
+        }
+        this.pending = this.send(photos, attribution).finally(() => { this.pending = null; });
+        return this.pending;
+    }
+
+    async send(photos, attribution) {
+        if (this.receipt) {
+            return this.receipt;
+        }
+        try {
+            if (this.uncertain) {
+                const accepted = await getUploadReceipt(this.id);
+                if (accepted) {
+                    return this.accept(accepted);
+                }
+            }
+
+            // Freeze the submitted values while the outcome is uncertain. A retry cannot
+            // silently pick up a different account or edits made after the original request.
+            if (!this.request) {
+                this.request = structuredClone({ photos, attribution });
+            }
+            this.usePreparedReferences();
+            this.uncertain = true;
+            try {
+                return this.accept(await finalizeUploadImage(this.request.photos, this.id, this.request.attribution));
+            } catch (error) {
+                if (!(error instanceof UploadRequestError) || error.code !== 'preparation_expired') {
+                    throw error;
+                }
+                // Expiry can require new photo IDs, but never a new logical report ID.
+                await this.prepare();
+                this.usePreparedReferences();
+                return this.accept(await finalizeUploadImage(this.request.photos, this.id, this.request.attribution));
+            }
+        } catch (error) {
+            if (error instanceof UploadRequestError && error.status >= 400 && error.status < 500 &&
+                error.status !== 408 && error.status !== 429 && error.code !== 'report_in_progress') {
+                this.uncertain = false;
+                this.request = null;
+            }
+            throw error;
+        }
+    }
+
+    usePreparedReferences() {
+        if (!this.prepared || this.prepared.length !== this.request.photos.length) {
+            throw new Error('The prepared photos do not match this report. Please start the upload again.');
+        }
+        this.request.photos.forEach((photo, index) => {
+            photo.photoId = this.prepared[index].photoId;
+            photo.submissionId = this.prepared[index].submissionId;
+            photo.photoNumber = this.prepared[index].photoNumber;
+        });
+    }
+
+    accept(receipt) {
+        this.receipt = receipt;
+        this.uncertain = false;
+        this.request = null;
+        this.files = [];
+        return receipt;
+    }
+}


### PR DESCRIPTION
## Summary

Extract the deployable backend, website, and Admin Panel changes from the mobile work into a standalone `main`-based PR. Both clients use `POST /api/Upload/Initial` and `POST /api/Upload/Finalize`, with shared contracts and receipt lookup rather than a separate mobile submission endpoint.

- Commit complete reports with stable IDs and durable receipts, retaining separate JPEGs under `finalizedupload/`. Keep existing flat JPEG/JSON submissions available for moderation.
- Preserve EXIF/XMP metadata, outside-Seattle map links, and the website's two-stage upload flow; reconcile uncertain submissions without creating duplicates.
- Preserve concurrent Mastodon, Bluesky, and Threads publication after Imgur, using independent read-only streams. Database/feed writes still happen afterward.
- Keep failed publications pending for our existing manual workflow: remove successful social posts, fix the cause, and click Upload again. Database and feed writes are repeatable.
- Add Cosmos-backed device blocking, required reasons, and authenticated Admin Panel block/unblock controls. Submission checks fail open on storage outages; administrative failures remain visible.
- Include supporting credential-verification endpoints, scoped regression coverage, deployment documentation, repository-style C#, and the .NET 10 debugger launch path.

## Validation

- Server suite: 576 tests passed.
- Shared Core suite: 4 tests passed.
- Updated JavaScript passes syntax checks.
- Website smoke testing reported working by the owner.
- Mobile end-to-end blocking checks remain pending until we switch back to the mobile branch.

## Deployment and follow-up

Before relying on device blocking, provision the `blocked-devices` container in the existing `seattle` Cosmos database with partition key `/id`, TTL disabled, and the appropriate data-plane permissions. Full setup and failure behavior are documented in `CONTRIBUTING.md`.

PR runs build/test but do not deploy. After merge and backend deployment, integrate `main` into the existing mobile branch, update its shared upload contract usage, and exercise mobile uploads and blocking. The mobile app implementation is not included in this PR.

Related: #15.