### PR TITLE
Fix iOS reports stuck saving photo status

### DIFF
--- a/.github/workflows/mobile.yml
+++ b/.github/workflows/mobile.yml
@@ -8,6 +8,7 @@ on:
       - "SeattleCarsInBikeLanes.Mobile.Core/**"
       - "SeattleCarsInBikeLanes.Mobile.Core.Tests/**"
       - "SeattleCarsInBikeLanes.Core/**"
+      - "scripts/ios-photo-status-smoke/**"
   push:
     branches:
       - main
@@ -17,6 +18,7 @@ on:
       - "SeattleCarsInBikeLanes.Mobile.Core/**"
       - "SeattleCarsInBikeLanes.Mobile.Core.Tests/**"
       - "SeattleCarsInBikeLanes.Core/**"
+      - "scripts/ios-photo-status-smoke/**"
   workflow_dispatch:
 
 jobs:
@@ -61,6 +63,19 @@ jobs:
           --no-restore
           -p:GOOGLE_MAPS_API_KEY="$GOOGLE_MAPS_API_KEY"
           -p:JpegXmpWritePluginMDEProject="${{ github.workspace }}/dependencies/JpegXmpWritePluginMDE/JpegXmpWritePluginMDE/JpegXmpWritePluginMDE.csproj"
+
+      - name: Run native photo orientation regressions
+        run: |
+          dotnet build scripts/ios-photo-status-smoke/PhotoStatusSmoke.csproj \
+            -c Debug -p:OutputPath="$RUNNER_TEMP/photo-status-smoke/" \
+            -p:JpegXmpWritePluginMDEProject="${{ github.workspace }}/dependencies/JpegXmpWritePluginMDE/JpegXmpWritePluginMDE/JpegXmpWritePluginMDE.csproj"
+          simulator=$(xcrun simctl list devices available --json | jq -r \
+            '[.devices[][] | select(.isAvailable and (.name | startswith("iPhone")))][0].udid')
+          xcrun simctl boot "$simulator"
+          xcrun simctl bootstatus "$simulator" -b
+          xcrun simctl install "$simulator" "$RUNNER_TEMP/photo-status-smoke/PhotoStatusSmoke.app"
+          xcrun simctl launch --console "$simulator" com.golf1052.PhotoStatusSmoke 2>&1 | tee "$RUNNER_TEMP/photo-status-smoke.log"
+          grep -q 'PHOTO_STATUS_SMOKE_PASS:' "$RUNNER_TEMP/photo-status-smoke.log"
 
       - name: Build iOS simulator
         run: >

--- a/SeattleCarsInBikeLanes.Mobile/Platforms/iOS/PhotoEditingRenderer.cs
+++ b/SeattleCarsInBikeLanes.Mobile/Platforms/iOS/PhotoEditingRenderer.cs
@@ -1,0 +1,66 @@
+using CoreGraphics;
+using CoreImage;
+using Foundation;
+using ImageIO;
+using SeattleCarsInBikeLanes.Mobile.Services;
+using UniformTypeIdentifiers;
+using ImageProperties = ImageIO.CGImageProperties;
+
+namespace SeattleCarsInBikeLanes.Platforms.iOS;
+
+internal static class PhotoEditingRenderer
+{
+    public static byte[] RenderUpright(byte[] original, CGImagePropertyOrientation orientation)
+    {
+        ArgumentNullException.ThrowIfNull(original);
+        if (orientation is < CGImagePropertyOrientation.Up or > CGImagePropertyOrientation.Left)
+            throw new IOException("The photo has an unsupported orientation.");
+        if (orientation == CGImagePropertyOrientation.Up &&
+            original.Length >= 2 && original[0] == 0xff && original[1] == 0xd8)
+            return original;
+
+        using NSData data = NSData.FromArray(original);
+        using CGImageSource source = CGImageSource.FromData(data)
+            ?? throw new IOException("The photo could not be opened for rendering.");
+        using CGImage pixels = source.CreateImage(0, new CGImageOptions())
+            ?? throw new IOException("The photo pixels could not be decoded.");
+        using CIImage image = CIImage.FromCGImage(pixels);
+        using CIImage upright = image.CreateByApplyingOrientation(orientation);
+        using CIContext context = CIContext.FromOptions(null);
+        using CGImage rendered = context.CreateCGImage(upright, upright.Extent)
+            ?? throw new IOException("The photo could not be rendered upright.");
+
+        using NSDictionary properties = source.CopyProperties(new CGImageOptions(), 0)
+            ?? throw new IOException("The photo metadata could not be read.");
+        using NSMutableDictionary outputProperties = new NSMutableDictionary(properties);
+        outputProperties[ImageProperties.Orientation] = NSNumber.FromInt32(1);
+        outputProperties[ImageProperties.PixelWidth] = NSNumber.FromNInt(rendered.Width);
+        outputProperties[ImageProperties.PixelHeight] = NSNumber.FromNInt(rendered.Height);
+        SetProperties(ImageProperties.TIFFDictionary,
+            (ImageProperties.TIFFOrientation, 1));
+        SetProperties(ImageProperties.ExifDictionary,
+            (ImageProperties.ExifPixelXDimension, rendered.Width),
+            (ImageProperties.ExifPixelYDimension, rendered.Height));
+
+        using NSMutableData result = new NSMutableData();
+        using CGImageDestination destination = CGImageDestination.Create(result, UTTypes.Jpeg.Identifier, 1)
+            ?? throw new IOException("The upright JPEG could not be created.");
+        destination.AddImage(rendered,
+            new CGImageDestinationOptions(outputProperties) { LossyCompressionQuality = 1 });
+        if (!destination.Close())
+            throw new IOException("The upright JPEG could not be saved.");
+        // ImageIO doesn't reliably round-trip custom XMP. Restore it with the JPEG
+        // writer, normalizing its orientation/dimensions to match the baked pixels.
+        return JpegXmpEditor.CopyUprightXmp(original, result.ToArray(),
+            (int)rendered.Width, (int)rendered.Height);
+
+        void SetProperties(NSString dictionaryKey, params (NSString Key, nint Value)[] values)
+        {
+            using NSMutableDictionary dictionary = properties[dictionaryKey] is NSDictionary existing
+                ? new NSMutableDictionary(existing) : new NSMutableDictionary();
+            foreach ((NSString key, nint value) in values)
+                dictionary[key] = NSNumber.FromNInt(value);
+            outputProperties[dictionaryKey] = dictionary;
+        }
+    }
+}

--- a/SeattleCarsInBikeLanes.Mobile/Platforms/iOS/PhotoLibraryService.cs
+++ b/SeattleCarsInBikeLanes.Mobile/Platforms/iOS/PhotoLibraryService.cs
@@ -436,7 +436,9 @@ public sealed class PhotoLibraryService : IPhotoLibraryService
         try
         {
             byte[] original = File.ReadAllBytes(input.FullSizeImageUrl.Path!);
-            byte[] updated = JpegXmpEditor.SetUploadState(original, state);
+            byte[] upright = PhotoEditingRenderer.RenderUpright(original,
+                (CGImagePropertyOrientation)input.FullSizeImageOrientation);
+            byte[] updated = JpegXmpEditor.SetUploadState(upright, state);
 
             using PHContentEditingOutput output = new PHContentEditingOutput(input)
             {

--- a/SeattleCarsInBikeLanes.Mobile/README.md
+++ b/SeattleCarsInBikeLanes.Mobile/README.md
@@ -331,7 +331,32 @@ already have received the report: cancelling is local only, does not remove anyt
 from the site, and reporting those photos again could create a duplicate.
 
 iOS stamps the rendered current photo rather than reconstructing earlier adjustment
-recipes, and reads the edited resource back. Android keeps the MediaStore asset ID
+recipes, and reads the edited resource back. PhotoKit requires edited JPEGs to have
+upright pixels, not just an EXIF rotation tag. Rotated or mirrored photos are rendered
+at full resolution before stamping; EXIF/GPS and custom XMP are retained with
+orientation and dimensions updated. Already-upright JPEGs are not recompressed.
+Without this normalization, PhotoKit rejects the edit with error 3302 and the
+accepted report remains at **Sent; saving photo status**. After updating, **Retry**
+on an affected report finishes locally using its saved receipt, without resubmitting.
+
+The native regression smoke app exercises all eight EXIF orientations, pixel
+placement, dimensions, EXIF/GPS, custom XMP, exact receipt timestamps, and repeated
+rendering. It uses synthetic images, needs no Photos permission, and never contacts
+the server. With an iOS simulator booted, run from the repository root:
+
+```bash
+output="$HOME/Library/Caches/SeattleCarsInBikeLanes/photo-status-smoke/"
+dotnet build scripts/ios-photo-status-smoke/PhotoStatusSmoke.csproj \
+  -c Debug -p:OutputPath="$output"
+xcrun simctl install booted "$output/PhotoStatusSmoke.app"
+xcrun simctl launch --console booted com.golf1052.PhotoStatusSmoke
+```
+
+Success prints `PHOTO_STATUS_SMOKE_PASS`; `simctl launch` does not propagate the
+app's exit status, so automation must check that marker. The project uses the same
+JPEG writer checkout as the app; override `JpegXmpWritePluginMDEProject` if needed.
+
+Android keeps the MediaStore asset ID
 unchanged: before truncating, it saves and flushes the contents of original/staged
 JPEGs and a journal in the app's no-backup directory, then publishes the journal.
 Process-interrupted edits are recovered before app access when those files remain

--- a/SeattleCarsInBikeLanes.Mobile/Services/JpegXmpEditor.cs
+++ b/SeattleCarsInBikeLanes.Mobile/Services/JpegXmpEditor.cs
@@ -25,12 +25,37 @@ public static class JpegXmpEditor
     {
         ArgumentNullException.ThrowIfNull(jpeg);
 
-        byte[]? existingPacket = JpegSegmentScanner.FindXmpPacket(new MemoryStream(jpeg, writable: false));
-        IXmpMeta meta = (existingPacket is null ? null : CarsInBikeLanesXmp.TryParse(existingPacket))
-            ?? XmpMetaFactory.Create();
-
+        IXmpMeta meta = ReadMetadata(jpeg);
         CarsInBikeLanesXmp.Write(meta, state);
+        return WriteMetadata(jpeg, meta);
+    }
 
+    /// <summary>
+    /// Restores custom XMP after rendering, updating tags that describe the old pixel layout.
+    /// </summary>
+    public static byte[] CopyUprightXmp(byte[] original, byte[] rendered, int width, int height)
+    {
+        ArgumentNullException.ThrowIfNull(original);
+        ArgumentNullException.ThrowIfNull(rendered);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(width);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(height);
+        IXmpMeta meta = ReadMetadata(original);
+        meta.SetPropertyInteger("http://ns.adobe.com/tiff/1.0/", "Orientation", 1);
+        meta.SetPropertyInteger("http://ns.adobe.com/tiff/1.0/", "ImageWidth", width);
+        meta.SetPropertyInteger("http://ns.adobe.com/tiff/1.0/", "ImageLength", height);
+        meta.SetPropertyInteger("http://ns.adobe.com/exif/1.0/", "PixelXDimension", width);
+        meta.SetPropertyInteger("http://ns.adobe.com/exif/1.0/", "PixelYDimension", height);
+        return WriteMetadata(rendered, meta);
+    }
+
+    private static IXmpMeta ReadMetadata(byte[] jpeg)
+    {
+        byte[]? packet = JpegSegmentScanner.FindXmpPacket(new MemoryStream(jpeg, writable: false));
+        return (packet is null ? null : CarsInBikeLanesXmp.TryParse(packet)) ?? XmpMetaFactory.Create();
+    }
+
+    private static byte[] WriteMetadata(byte[] jpeg, IXmpMeta meta)
+    {
         // The writer truncates and rewrites the stream it is given, so it needs one that can grow.
         // A MemoryStream constructed over an existing array cannot.
         using MemoryStream stream = new MemoryStream();

--- a/scripts/ios-photo-status-smoke/Info.plist
+++ b/scripts/ios-photo-status-smoke/Info.plist
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>UIDeviceFamily</key><array><integer>1</integer></array>
+  <key>UISupportedInterfaceOrientations</key><array><string>UIInterfaceOrientationPortrait</string></array>
+  <key>UILaunchScreen</key><dict/>
+</dict>
+</plist>

--- a/scripts/ios-photo-status-smoke/PhotoStatusSmoke.csproj
+++ b/scripts/ios-photo-status-smoke/PhotoStatusSmoke.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0-ios</TargetFramework>
+    <RuntimeIdentifier>iossimulator-arm64</RuntimeIdentifier>
+    <OutputType>Exe</OutputType>
+    <SupportedOSPlatformVersion>16.0</SupportedOSPlatformVersion>
+    <ApplicationId>com.golf1052.PhotoStatusSmoke</ApplicationId>
+    <ApplicationTitle>Photo status smoke test</ApplicationTitle>
+    <ApplicationVersion>1</ApplicationVersion>
+    <ApplicationDisplayVersion>1.0</ApplicationDisplayVersion>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <JpegXmpWritePluginMDEProject Condition="'$(JpegXmpWritePluginMDEProject)' == ''">$(HOME)/Documents/GitHub/JpegXmpWritePluginMDE/JpegXmpWritePluginMDE/JpegXmpWritePluginMDE.csproj</JpegXmpWritePluginMDEProject>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="../../SeattleCarsInBikeLanes.Mobile.Core/SeattleCarsInBikeLanes.Mobile.Core.csproj" />
+    <Compile Include="../../SeattleCarsInBikeLanes.Mobile/Platforms/iOS/PhotoEditingRenderer.cs" Link="PhotoEditingRenderer.cs" />
+    <Compile Include="../../SeattleCarsInBikeLanes.Mobile/Services/JpegXmpEditor.cs" Link="JpegXmpEditor.cs" />
+    <ProjectReference Include="$(JpegXmpWritePluginMDEProject)" />
+    <PackageReference Include="MetadataExtractor" Version="2.9.3" />
+  </ItemGroup>
+</Project>

--- a/scripts/ios-photo-status-smoke/Program.cs
+++ b/scripts/ios-photo-status-smoke/Program.cs
@@ -1,0 +1,144 @@
+using System.Runtime.InteropServices;
+using CoreGraphics;
+using Foundation;
+using ImageIO;
+using SeattleCarsInBikeLanes.Mobile.Core.Metadata;
+using SeattleCarsInBikeLanes.Mobile.Core.Models;
+using SeattleCarsInBikeLanes.Platforms.iOS;
+using UIKit;
+using XmpCore;
+using XmpCore.Options;
+using ImageProperties = ImageIO.CGImageProperties;
+
+UIApplication.Main(args, null, typeof(SmokeApp));
+
+[Register("SmokeApp")]
+public sealed class SmokeApp : UIApplicationDelegate
+{
+    public override bool FinishedLaunching(UIApplication application, NSDictionary? options)
+    {
+        BeginInvokeOnMainThread(() =>
+        {
+            try
+            {
+                Run();
+                Console.WriteLine("PHOTO_STATUS_SMOKE_PASS: all eight EXIF orientations, pixels, metadata and repeat rendering");
+                Environment.Exit(0);
+            }
+            catch (Exception error)
+            {
+                Console.WriteLine($"PHOTO_STATUS_SMOKE_FAIL: {error}");
+                Environment.Exit(1);
+            }
+        });
+        return true;
+    }
+
+    private static void Run()
+    {
+        int[][] corners =
+        [
+            [0, 1, 2, 3], [1, 0, 3, 2], [3, 2, 1, 0], [2, 3, 0, 1],
+            [0, 2, 1, 3], [2, 0, 3, 1], [3, 1, 2, 0], [1, 3, 0, 2]
+        ];
+        XmpUploadState state = new(true, DateTimeOffset.Parse("2026-09-09T00:16:48.9376486+00:00"), "smoke-receipt");
+        GeoPosition location = new(47.6, -122.3);
+        using UIGraphicsImageRenderer renderer = new(new CGSize(80, 60),
+            new UIGraphicsImageRendererFormat { Scale = 1 });
+        using UIImage image = renderer.CreateImage(context =>
+        {
+            UIColor[] colors = [UIColor.Red, UIColor.Green, UIColor.Blue, UIColor.Yellow];
+            for (int i = 0; i < colors.Length; i++)
+            {
+                colors[i].SetFill();
+                context.FillRect(new CGRect(i % 2 * 40, i / 2 * 30, 40, 30));
+            }
+        });
+
+        for (int value = 1; value <= 8; value++)
+        {
+            CGImagePropertyOrientation orientation = (CGImagePropertyOrientation)value;
+            using NSMutableData encoded = new();
+            using (CGImageDestination destination = CGImageDestination.Create(encoded, "public.jpeg", 1)!)
+            {
+                using NSDictionary properties = NSDictionary.FromObjectAndKey(
+                    NSNumber.FromInt32(value), ImageProperties.Orientation);
+                destination.AddImage(image.CGImage!, properties);
+                Require(destination.Close(), "Encode fixture");
+            }
+            using MemoryStream sourceBytes = new(encoded.ToArray());
+            using MemoryStream captureBytes = new();
+            PhotoExif.WriteCaptureMetadata(sourceBytes, captureBytes, state.UploadedAt!.Value, location);
+            IXmpMeta xmp = CarsInBikeLanesXmp.Create(state);
+            xmp.SetProperty("http://ns.adobe.com/tiff/1.0/", "Orientation", value.ToString());
+            xmp.SetProperty("http://purl.org/dc/elements/1.1/", "source", "preserve-custom-xmp");
+            byte[] original = AddXmp(captureBytes.ToArray(), xmp);
+            PhotoExifData before = PhotoExif.Read(new MemoryStream(original));
+            byte[] rendered = PhotoEditingRenderer.RenderUpright(original, orientation);
+            if (value == 1) Require(ReferenceEquals(original, rendered), "Upright JPEG must not be recompressed");
+            using NSData data = NSData.FromArray(rendered);
+            using CGImageSource source = CGImageSource.FromData(data)!;
+            using CGImage pixels = source.CreateImage(0, new CGImageOptions())!;
+            var propertiesAfter = source.GetProperties(0, null)!;
+            Require((int?)propertiesAfter.Orientation is null or 1, $"Orientation {value}: metadata must be up");
+            Require(pixels.Width == (value < 5 ? 80 : 60) && pixels.Height == (value < 5 ? 60 : 80),
+                $"Orientation {value}: full-resolution dimensions");
+            Require(ReadCorners(pixels).SequenceEqual(corners[value - 1]), $"Orientation {value}: upright pixels");
+            XmpUploadState renderedState = JpegSegmentScanner.ReadUploadState(new MemoryStream(rendered));
+            Require(renderedState == state,
+                $"Orientation {value}: exact receipt ID and timestamp; got {renderedState}");
+            IXmpMeta afterXmp = CarsInBikeLanesXmp.TryParse(
+                JpegSegmentScanner.FindXmpPacket(new MemoryStream(rendered))!)!;
+            Require(afterXmp.GetPropertyString("http://purl.org/dc/elements/1.1/", "source") == "preserve-custom-xmp",
+                $"Orientation {value}: custom XMP");
+            Require(afterXmp.GetPropertyInteger("http://ns.adobe.com/tiff/1.0/", "Orientation") == 1,
+                $"Orientation {value}: XMP orientation");
+            PhotoExifData after = PhotoExif.Read(new MemoryStream(rendered));
+            Require(after.TakenAt == before.TakenAt, $"Orientation {value}: capture date");
+            Require(after.Location is { } actual && before.Location is { } expected &&
+                Math.Abs(actual.Latitude - expected.Latitude) < 0.000001 &&
+                Math.Abs(actual.Longitude - expected.Longitude) < 0.000001, $"Orientation {value}: GPS");
+            Require(ReferenceEquals(rendered, PhotoEditingRenderer.RenderUpright(rendered, CGImagePropertyOrientation.Up)),
+                $"Orientation {value}: retry must not rotate or recompress again");
+            Console.WriteLine($"PHOTO_STATUS_SMOKE orientation {value}: PASS");
+        }
+    }
+
+    private static int[] ReadCorners(CGImage image)
+    {
+        int width = (int)image.Width, height = (int)image.Height;
+        using CGColorSpace colorSpace = CGColorSpace.CreateDeviceRGB();
+        using CGBitmapContext bitmap = new(IntPtr.Zero, width, height, 8, width * 4, colorSpace,
+            CGBitmapFlags.ByteOrder32Big | CGBitmapFlags.PremultipliedLast);
+        bitmap.DrawImage(new CGRect(0, 0, width, height), image);
+        byte[] bytes = new byte[width * height * 4];
+        Marshal.Copy(bitmap.Data, bytes, 0, bytes.Length);
+        return new[] { (width / 4, height / 4), (width * 3 / 4, height / 4),
+            (width / 4, height * 3 / 4), (width * 3 / 4, height * 3 / 4) }
+            .Select(point =>
+            {
+                int i = (point.Item2 * width + point.Item1) * 4;
+                return bytes[i] > 180 && bytes[i + 1] > 180 ? 3 :
+                    bytes[i] > 180 ? 0 : bytes[i + 1] > 180 ? 1 : 2;
+            }).ToArray();
+    }
+
+    private static byte[] AddXmp(byte[] jpeg, IXmpMeta metadata)
+    {
+        byte[] packet = XmpMetaFactory.SerializeToBuffer(metadata, new SerializeOptions());
+        byte[] signature = System.Text.Encoding.ASCII.GetBytes(JpegSegmentScanner.XmpSignature);
+        using MemoryStream result = new();
+        result.Write(jpeg, 0, 2);
+        int length = packet.Length + signature.Length + 2;
+        result.Write([0xff, 0xe1, (byte)(length >> 8), (byte)length]);
+        result.Write(signature);
+        result.Write(packet);
+        result.Write(jpeg, 2, jpeg.Length - 2);
+        return result.ToArray();
+    }
+
+    private static void Require(bool condition, string message)
+    {
+        if (!condition) throw new InvalidOperationException(message);
+    }
+}


### PR DESCRIPTION
## Root cause

Captured JPEGs can store rotation/mirroring in EXIF instead of their pixel layout. `WriteUploadStateCoreAsync` copied those pixels directly into `PHContentEditingOutput.RenderedContentUrl`. [PhotoKit requires edited content to bake in its orientation](https://developer.apple.com/documentation/photos/phcontenteditingoutput/renderedcontenturl), so it rejects these edits with `PHPhotosErrorDomain` **3302**.

The upload itself has already succeeded: the iPhone queue contained two reports with saved server receipts, but local acknowledgement exhausted its retries. Using a local copy of an affected JPEG reproduced the rejection in an iOS simulator; the same PhotoKit write and read-back succeed with this fix.

## Changes

- Render rotated/mirrored editing input upright at full resolution before writing upload status; leave already-upright JPEGs byte-for-byte unchanged before stamping.
- Preserve EXIF capture date/GPS and custom XMP, while updating orientation and pixel dimensions. Use the existing JPEG XMP writer rather than relying on ImageIO to round-trip custom XMP.
- Keep queue receipts, retry behavior, asset IDs, and the server API unchanged. After installing the fix, **Retry** on an already-accepted report completes only its local acknowledgement; it does not submit a duplicate.
- Add a synthetic native iOS smoke app covering all eight EXIF orientations, pixel placement, dimensions, metadata, exact receipt timestamps, and repeat rendering. Run it in Debug in mobile CI and document local use.

## Validation

- Full iOS simulator and Android app **Debug** builds succeed. Android required isolated build artifacts because the existing `obj/Debug` tree had an `R.txt` file lock.
- Native PhotoKit round-trip with the affected JPEG: fails before the fix (3302), succeeds and reads the expected acknowledgement after the fix.
- All eight native synthetic orientation cases pass.
- 61 existing targeted queue, catalog, XMP, EXIF, and metadata-preservation tests pass.
- Connected Pixel 8a shows its existing report in **Already reported**, with no pending report; no fabricated production reports were sent.

The installed phone apps and their report/photo data have not been replaced or reset. The affected photo was used only in local diagnostic artifacts, not committed to the repository. Android's MediaStore implementation is unchanged; the upright-rendering requirement is specific to PhotoKit.