### PR TITLE
Use compact Android tabs in landscape

### DIFF
--- a/SeattleCarsInBikeLanes.Mobile/MauiProgram.cs
+++ b/SeattleCarsInBikeLanes.Mobile/MauiProgram.cs
@@ -47,6 +47,11 @@ public static class MauiProgram
 				fonts.AddFont("FluentSystemIcons-Regular.ttf", "FluentIcons");
 			});
 
+#if ANDROID
+		builder.ConfigureMauiHandlers(handlers =>
+			handlers.AddHandler<AppShell, Platforms.Android.CompactShellRenderer>());
+#endif
+
 		RegisterServices(builder.Services);
 		RegisterViewModels(builder.Services);
 		RegisterPages(builder.Services);

--- a/SeattleCarsInBikeLanes.Mobile/Platforms/Android/CompactShellRenderer.cs
+++ b/SeattleCarsInBikeLanes.Mobile/Platforms/Android/CompactShellRenderer.cs
@@ -1,0 +1,91 @@
+using Google.Android.Material.BottomNavigation;
+using Microsoft.Maui.Controls.Handlers.Compatibility;
+using Microsoft.Maui.Controls.Platform.Compatibility;
+
+namespace SeattleCarsInBikeLanes.Mobile.Platforms.Android;
+
+internal sealed class CompactShellRenderer : ShellRenderer
+{
+	protected override IShellBottomNavViewAppearanceTracker CreateBottomNavViewAppearanceTracker(
+		ShellItem shellItem) => new CompactBottomNavAppearanceTracker(this, shellItem);
+
+	private sealed class CompactBottomNavAppearanceTracker : ShellBottomNavViewAppearanceTracker
+	{
+		private BottomNavigationView? bottomView;
+
+		public CompactBottomNavAppearanceTracker(IShellContext context, ShellItem shellItem)
+			: base(context, shellItem)
+		{
+		}
+
+		public override void SetAppearance(BottomNavigationView bottomView, IShellAppearanceElement appearance)
+		{
+			base.SetAppearance(bottomView, appearance);
+			TrackView(bottomView);
+		}
+
+		public override void ResetAppearance(BottomNavigationView bottomView)
+		{
+			base.ResetAppearance(bottomView);
+			TrackView(bottomView);
+		}
+
+		private void TrackView(BottomNavigationView view)
+		{
+			if (bottomView != view)
+			{
+				if (bottomView is not null)
+				{
+					bottomView.LayoutChange -= OnLayoutChange;
+				}
+
+				bottomView = view;
+				bottomView.LayoutChange += OnLayoutChange;
+			}
+
+			UpdateLayout();
+		}
+
+		private void OnLayoutChange(object? sender, global::Android.Views.View.LayoutChangeEventArgs e)
+		{
+			if (e.Right - e.Left != e.OldRight - e.OldLeft)
+			{
+				UpdateLayout();
+			}
+		}
+
+		private void UpdateLayout()
+		{
+			if (bottomView?.Resources is not { } resources)
+			{
+				return;
+			}
+
+			// Shell's native container rotates without reliably raising Shell.SizeChanged.
+			bool landscape = bottomView.RootView is { } root && root.Width > root.Height;
+			int Dimension(int portrait, int compact) =>
+				resources.GetDimensionPixelSize(landscape ? compact : portrait);
+
+			// Leave view padding alone: Material owns the gesture/navigation-bar and cutout insets.
+			bottomView.SetMinimumHeight(Dimension(
+				Resource.Dimension.shell_tab_bar_height, Resource.Dimension.compact_shell_tab_bar_height));
+			bottomView.ItemPaddingTop = Dimension(
+				Resource.Dimension.shell_tab_bar_padding_top, Resource.Dimension.compact_shell_tab_bar_padding);
+			bottomView.ItemPaddingBottom = Dimension(
+				Resource.Dimension.shell_tab_bar_padding_bottom, Resource.Dimension.compact_shell_tab_bar_padding);
+			bottomView.ItemActiveIndicatorHeight = Dimension(
+				Resource.Dimension.shell_tab_bar_indicator_height, Resource.Dimension.compact_shell_tab_bar_indicator_height);
+		}
+
+		protected override void Dispose(bool disposing)
+		{
+			if (disposing && bottomView is not null)
+			{
+				bottomView.LayoutChange -= OnLayoutChange;
+				bottomView = null;
+			}
+
+			base.Dispose(disposing);
+		}
+	}
+}

--- a/SeattleCarsInBikeLanes.Mobile/Platforms/Android/Resources/values/dimens.xml
+++ b/SeattleCarsInBikeLanes.Mobile/Platforms/Android/Resources/values/dimens.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <dimen name="shell_tab_bar_height">@dimen/m3_bottom_nav_min_height</dimen>
+    <dimen name="shell_tab_bar_padding_top">@dimen/m3_bottom_nav_item_padding_top</dimen>
+    <dimen name="shell_tab_bar_padding_bottom">@dimen/m3_bottom_nav_item_padding_bottom</dimen>
+    <dimen name="shell_tab_bar_indicator_height">@dimen/m3_bottom_nav_item_active_indicator_height</dimen>
+    <dimen name="compact_shell_tab_bar_height">56dp</dimen>
+    <dimen name="compact_shell_tab_bar_padding">4dp</dimen>
+    <dimen name="compact_shell_tab_bar_indicator_height">24dp</dimen>
+</resources>

--- a/SeattleCarsInBikeLanes.Mobile/README.md
+++ b/SeattleCarsInBikeLanes.Mobile/README.md
@@ -235,8 +235,20 @@ in the app icon and splash screen uses exact `#6495ED`, while the splash backgro
 follows the light/dark colors above.
 The camera HUD also keeps fixed high-contrast colors over the live preview. These
 Android theme resources are not loaded on iOS, which continues to use the shared
-MAUI styles. .NET MAUI 10 Shell tabs use the Material 3 token palette, but native
-Material 3 Shell navigation requires .NET MAUI 11.
+MAUI styles.
+
+Android Shell tabs retain the Material 3 80dp height in portrait and use a compact
+56dp height in landscape, excluding the system navigation/gesture inset. The
+landscape layout keeps the 24dp icons and text labels, with smaller item padding
+and selection indicators. `CompactShellRenderer` updates these dimensions when
+the native tab bar resizes, using the window's aspect ratio; Android does not
+recreate the activity on rotation. Material continues to manage bottom and side
+system insets.
+
+iOS keeps MAUI's native `UITabBarController` layout. UIKit adapts the tab bar to
+the device's size classes, including compact-height landscape layouts, and manages
+the home-indicator safe area. Its precise height and icon/label arrangement depend
+on the iOS version and device; the Android dimensions are not applied to iOS.
 
 ### Deploy to an Android device
 
@@ -257,6 +269,13 @@ dotnet build SeattleCarsInBikeLanes.Mobile.csproj \
 ### Android smoke test
 
 Run this matrix on a physical Android 10+ device before merging mobile changes:
+
+After deploying a Debug build to an unlocked phone, run
+`bash scripts/android-tab-bar-smoke.sh` from the repository root. It checks both
+landscape directions and repeated portrait restoration without switching tabs,
+including the system navigation inset, and restores the phone's rotation setting.
+Set `ANDROID_SERIAL` when more than one device is connected. Also check that all
+three tabs remain readable and tappable in landscape with large system text.
 
 | Area | Expected result |
 | --- | --- |

--- a/scripts/android-tab-bar-smoke.sh
+++ b/scripts/android-tab-bar-smoke.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+adb_path="${ADB:-$HOME/Library/Android/sdk/platform-tools/adb}"
+if [[ ! -x "$adb_path" ]]; then
+    adb_path="$(command -v adb || true)"
+fi
+if [[ -z "$adb_path" ]]; then
+    echo "adb was not found. Set ADB to its full path or add it to PATH." >&2
+    exit 1
+fi
+
+package="com.golf1052.SeattleCarsInBikeLanes.Mobile"
+original_mode="$("$adb_path" shell cmd window user-rotation)"
+original_rotation="$("$adb_path" shell settings get system user_rotation)"
+density="$("$adb_path" shell wm density | tail -1 | awk '{print $NF}')"
+if [[ ! "$density" =~ ^[0-9]+$ ]]; then
+    echo "Could not read the device display density." >&2
+    exit 1
+fi
+
+restore_rotation() {
+    "$adb_path" shell cmd window user-rotation lock "$original_rotation"
+    if [[ "$original_mode" == "free" ]]; then
+        "$adb_path" shell cmd window user-rotation free
+    fi
+}
+trap restore_rotation EXIT
+
+component="$("$adb_path" shell cmd package resolve-activity --brief "$package" | tail -1)"
+"$adb_path" shell am start -W -n "$component" >/dev/null
+
+menu_pattern='BottomNavigationMenuView\{[^}]* ([0-9]+),([0-9]+)-([0-9]+),([0-9]+)'
+bar_pattern='BottomNavigationView\{[^}]* ([0-9]+),([0-9]+)-([0-9]+),([0-9]+)'
+inset_pattern='type=navigationBars frame=\[([0-9]+),([0-9]+)\]\[([0-9]+),([0-9]+)\]'
+
+# Do not switch tabs between rotations: resizing must work without an appearance refresh.
+for rotation in 0 1 3 0 1 0; do
+    expected_dp=56
+    if [[ "$rotation" == 0 ]]; then
+        expected_dp=80
+    fi
+    expected_px=$(( (expected_dp * density + 80) / 160 ))
+    "$adb_path" shell cmd window user-rotation lock "$rotation"
+
+    actual_px=-1
+    for attempt in {1..15}; do
+        sleep 1
+        hierarchy="$("$adb_path" shell dumpsys activity "$package")"
+        if [[ "$hierarchy" =~ $menu_pattern ]]; then
+            actual_px=$(( BASH_REMATCH[4] - BASH_REMATCH[2] ))
+            if [[ "$actual_px" == "$expected_px" ]]; then
+                break
+            fi
+        fi
+    done
+
+    if [[ "$actual_px" != "$expected_px" ]]; then
+        echo "Rotation $rotation: expected ${expected_px}px (${expected_dp}dp), got ${actual_px}px." >&2
+        exit 1
+    fi
+    if [[ ! "$hierarchy" =~ $bar_pattern ]]; then
+        echo "Could not find the native bottom navigation bar." >&2
+        exit 1
+    fi
+    bar_height=$(( BASH_REMATCH[4] - BASH_REMATCH[2] ))
+
+    insets="$("$adb_path" shell dumpsys window displays)"
+    if [[ ! "$insets" =~ $inset_pattern ]]; then
+        echo "Could not find the system navigation inset." >&2
+        exit 1
+    fi
+    inset_height=$(( BASH_REMATCH[4] - BASH_REMATCH[2] ))
+    inset_width=$(( BASH_REMATCH[3] - BASH_REMATCH[1] ))
+    if (( inset_height > inset_width )); then
+        # Three-button navigation can move to a side in landscape.
+        inset_height=0
+    fi
+    if (( bar_height != actual_px + inset_height )); then
+        echo "Rotation $rotation: bar height ${bar_height}px does not preserve the ${inset_height}px system inset." >&2
+        exit 1
+    fi
+    echo "Rotation $rotation: ${expected_dp}dp tabs + ${inset_height}px system inset."
+done


### PR DESCRIPTION
## Summary
- Reduce Android Shell tabs from 80dp to 56dp in landscape while keeping portrait unchanged.
- Preserve tab icons, labels, selection indicators, and native system-navigation/cutout insets.
- Update sizing from native layout changes so rotation works without switching tabs or recreating the activity.
- Keep iOS's native adaptive `UITabBarController` behavior and document platform differences.
- Add an ADB smoke script covering both landscape directions, repeated portrait restoration, and system-inset preservation.

## Validation
- Android and iOS simulator builds succeeded.
- Deployed to the connected Pixel 8a: landscape tab content measured 147px (56dp), portrait 210px (80dp), with the existing 63px gesture inset preserved.
- Rotation smoke script passed all six transitions without switching tabs.
- Exercised all three tabs in landscape and checked readability with enlarged system text.
- Confirmed UIKit's compact landscape layout on an iPhone 17 Pro simulator running iOS 26.5.

Based directly on `main`; excludes the separate photo-access-warning change and unrelated local `.gitignore` edits.